### PR TITLE
fix: resolve replaced highlight drift

### DIFF
--- a/docs/notebook_source/01_replace.py
+++ b/docs/notebook_source/01_replace.py
@@ -28,9 +28,10 @@ import tempfile
 from pathlib import Path
 
 try:
-    NOTEBOOK_DIR = Path(__file__).resolve().parent
+    NOTEBOOK_SOURCE_DIR = Path(__file__).resolve().parent
 except NameError:
-    NOTEBOOK_DIR = Path.cwd()
+    # Running as .ipynb — cwd is docs/notebooks/, data lives in docs/notebook_source/
+    NOTEBOOK_SOURCE_DIR = Path.cwd().parent / "notebook_source"
 
 from anonymizer import Annotate, Anonymizer, AnonymizerConfig, AnonymizerInput, Hash, Redact, Substitute
 
@@ -93,7 +94,7 @@ anonymizer = Anonymizer(model_configs=MODEL_CONFIGS_YAML, model_providers=provid
 
 # %%
 input_data = AnonymizerInput(
-    source=str(NOTEBOOK_DIR / "data" / "synth_bios_sample10.csv"),
+    source=str(NOTEBOOK_SOURCE_DIR / "data" / "synth_bios_sample10.csv"),
     text_column="bio",
     data_summary="Biographical profiles",
 )

--- a/docs/notebook_source/02_detection_debug.py
+++ b/docs/notebook_source/02_detection_debug.py
@@ -28,9 +28,10 @@ from collections import Counter
 from pathlib import Path
 
 try:
-    NOTEBOOK_DIR = Path(__file__).resolve().parent
+    NOTEBOOK_SOURCE_DIR = Path(__file__).resolve().parent
 except NameError:
-    NOTEBOOK_DIR = Path.cwd()
+    # Running as .ipynb — cwd is docs/notebooks/, data lives in docs/notebook_source/
+    NOTEBOOK_SOURCE_DIR = Path.cwd().parent / "notebook_source"
 
 import pandas as pd
 
@@ -94,7 +95,7 @@ anonymizer = Anonymizer(model_configs=MODEL_CONFIGS_YAML, model_providers=provid
 config = AnonymizerConfig(replace=Redact())
 
 input_data = AnonymizerInput(
-    source=str(NOTEBOOK_DIR / "data" / "synth_bios_sample10.csv"),
+    source=str(NOTEBOOK_SOURCE_DIR / "data" / "synth_bios_sample10.csv"),
     text_column="bio",
     data_summary="Biographical profiles",
 )

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import html
 import json
 import re
+from dataclasses import dataclass
 from typing import Any
 
 import pandas as pd
@@ -41,6 +42,14 @@ LABEL_BORDER_COLORS: list[str] = [
     "#a855f7",
     "#ef4444",
 ]
+
+
+@dataclass(frozen=True)
+class _SyntheticLookupMaps:
+    by_value_label: dict[tuple[str, str], str]
+    by_value: dict[str, str]
+    by_value_label_ci: dict[tuple[str, str], str]
+    by_value_ci: dict[str, str]
 
 
 def _color_for_label(label: str) -> tuple[str, str]:
@@ -140,6 +149,12 @@ def _build_replaced_entities(
         by_value[orig] = synth
         by_value_label_ci[(orig.lower(), label)] = synth
         by_value_ci[orig.lower()] = synth
+    lookups = _SyntheticLookupMaps(
+        by_value_label=by_value_label,
+        by_value=by_value,
+        by_value_label_ci=by_value_label_ci,
+        by_value_ci=by_value_ci,
+    )
 
     sorted_entities = sorted(
         original_entities,
@@ -159,7 +174,7 @@ def _build_replaced_entities(
         if start < original_cursor or end <= start or end > len(original_text):
             continue
 
-        synthetic = _resolve_synthetic(value, label, by_value_label, by_value, by_value_label_ci, by_value_ci)
+        synthetic = _resolve_synthetic(value, label, lookups)
         original_span = original_text[start:end]
 
         pos = replaced_text.find(synthetic, search_from) if synthetic else -1
@@ -189,22 +204,19 @@ def _build_replaced_entities(
 def _resolve_synthetic(
     value: str,
     label: str,
-    by_value_label: dict[tuple[str, str], str],
-    by_value: dict[str, str],
-    by_value_label_ci: dict[tuple[str, str], str],
-    by_value_ci: dict[str, str],
+    lookups: _SyntheticLookupMaps,
 ) -> str:
     """Look up synthetic value with exact-match first, then case-insensitive fallback."""
-    result = by_value_label.get((value, label))
+    result = lookups.by_value_label.get((value, label))
     if result is not None:
         return result
-    result = by_value.get(value)
+    result = lookups.by_value.get(value)
     if result is not None:
         return result
-    result = by_value_label_ci.get((value.lower(), label))
+    result = lookups.by_value_label_ci.get((value.lower(), label))
     if result is not None:
         return result
-    result = by_value_ci.get(value.lower())
+    result = lookups.by_value_ci.get(value.lower())
     if result is not None:
         return result
     return value

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -122,15 +122,24 @@ def _build_replaced_entities(
     original_text: str,
     replaced_text: str,
 ) -> list[dict[str, Any]]:
-    """Compute entity positions in the replaced text by replaying the replacement splicing."""
+    """Compute entity positions in the replaced text by locating synthetic values directly.
+
+    Instead of replaying cursor arithmetic (which drifts when entity values
+    differ in case from the replacement map keys), we resolve each entity's
+    synthetic value and find it in the replaced text by scanning forward.
+    """
     by_value_label: dict[tuple[str, str], str] = {}
     by_value: dict[str, str] = {}
+    by_value_label_ci: dict[tuple[str, str], str] = {}
+    by_value_ci: dict[str, str] = {}
     for entry in replacement_map:
         orig = entry.get("original", "")
         label = entry.get("label", "")
         synth = entry.get("synthetic", "")
         by_value_label[(orig, label)] = synth
         by_value[orig] = synth
+        by_value_label_ci[(orig.lower(), label)] = synth
+        by_value_ci[orig.lower()] = synth
 
     sorted_entities = sorted(
         original_entities,
@@ -139,7 +148,7 @@ def _build_replaced_entities(
 
     replaced_entities: list[dict[str, Any]] = []
     original_cursor = 0
-    replaced_cursor = 0
+    search_from = 0
 
     for entity in sorted_entities:
         start = int(entity.get("start_position", 0))
@@ -150,23 +159,55 @@ def _build_replaced_entities(
         if start < original_cursor or end <= start or end > len(original_text):
             continue
 
-        gap = start - original_cursor
-        replaced_cursor += gap
+        synthetic = _resolve_synthetic(value, label, by_value_label, by_value, by_value_label_ci, by_value_ci)
+        original_span = original_text[start:end]
 
-        synthetic = by_value_label.get((value, label), by_value.get(value, value))
+        pos = replaced_text.find(synthetic, search_from) if synthetic else -1
+        if pos < 0 and synthetic != original_span:
+            pos = replaced_text.find(original_span, search_from)
+            if pos >= 0:
+                synthetic = original_span
+
+        if pos < 0:
+            original_cursor = end
+            continue
+
         replaced_entities.append(
             {
-                "value": synthetic,
+                "value": replaced_text[pos : pos + len(synthetic)],
                 "label": label,
-                "start_position": replaced_cursor,
-                "end_position": replaced_cursor + len(synthetic),
+                "start_position": pos,
+                "end_position": pos + len(synthetic),
             }
         )
-
-        replaced_cursor += len(synthetic)
+        search_from = pos + len(synthetic)
         original_cursor = end
 
     return replaced_entities
+
+
+def _resolve_synthetic(
+    value: str,
+    label: str,
+    by_value_label: dict[tuple[str, str], str],
+    by_value: dict[str, str],
+    by_value_label_ci: dict[tuple[str, str], str],
+    by_value_ci: dict[str, str],
+) -> str:
+    """Look up synthetic value with exact-match first, then case-insensitive fallback."""
+    result = by_value_label.get((value, label))
+    if result is not None:
+        return result
+    result = by_value.get(value)
+    if result is not None:
+        return result
+    result = by_value_label_ci.get((value.lower(), label))
+    if result is not None:
+        return result
+    result = by_value_ci.get(value.lower())
+    if result is not None:
+        return result
+    return value
 
 
 def _build_original_entities_from_map(

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -312,6 +312,60 @@ def test_display_record_explicit_index_does_not_advance_cycle() -> None:
     assert preview._display_cycle_index == 0
 
 
+def test_build_replaced_entities_no_drift_with_case_mismatch() -> None:
+    """Regression for #15: case-insensitive expanded entities must resolve correctly.
+
+    expand_entity_occurrences stores value=text[start:end] which may differ in case
+    from the replacement map key (e.g. "the Lantern" vs "The Lantern"). The old
+    cursor-replay approach missed the map entry and used a wrong-length fallback,
+    causing cumulative drift on all subsequent entities.
+    """
+    original_text = "Mara works at The Lantern in Austin. the Lantern is her home. Luis visits."
+    original_entities = [
+        {"value": "Mara", "label": "first_name", "start_position": 0, "end_position": 4},
+        {"value": "The Lantern", "label": "company_name", "start_position": 14, "end_position": 25},
+        {"value": "Austin", "label": "city", "start_position": 29, "end_position": 35},
+        {"value": "the Lantern", "label": "company_name", "start_position": 37, "end_position": 48},
+        {"value": "Luis", "label": "first_name", "start_position": 65, "end_position": 69},
+    ]
+    replacement_map = [
+        {"original": "Mara", "label": "first_name", "synthetic": "Leila"},
+        {"original": "The Lantern", "label": "company_name", "synthetic": "The Ember"},
+        {"original": "Austin", "label": "city", "synthetic": "Boulder"},
+        {"original": "Luis", "label": "first_name", "synthetic": "Diego"},
+    ]
+    replaced_text = "Leila works at The Ember in Boulder. The Ember is her home. Diego visits."
+
+    result = _build_replaced_entities(original_entities, replacement_map, original_text, replaced_text)
+    assert len(result) == 5
+    for entity in result:
+        actual = replaced_text[entity["start_position"] : entity["end_position"]]
+        assert actual == entity["value"], (
+            f"expected {entity['value']!r} at [{entity['start_position']}:{entity['end_position']}], got {actual!r}"
+        )
+
+
+def test_build_replaced_entities_no_drift_when_entity_absent_from_map() -> None:
+    """When an entity is not in the map, its original text span stays; no drift on later entities."""
+    original_text = "Contact Sofia and Diego at Acme"
+    original_entities = [
+        {"value": "Sofia", "label": "first_name", "start_position": 8, "end_position": 13},
+        {"value": "Diego", "label": "first_name", "start_position": 18, "end_position": 23},
+        {"value": "Acme", "label": "organization", "start_position": 27, "end_position": 31},
+    ]
+    replacement_map = [
+        {"original": "Diego", "label": "first_name", "synthetic": "Carlos"},
+        {"original": "Acme", "label": "organization", "synthetic": "NovaCorp"},
+    ]
+    replaced_text = "Contact Sofia and Carlos at NovaCorp"
+
+    result = _build_replaced_entities(original_entities, replacement_map, original_text, replaced_text)
+    assert len(result) == 3
+    for entity in result:
+        actual = replaced_text[entity["start_position"] : entity["end_position"]]
+        assert actual == entity["value"]
+
+
 def test_display_record_out_of_bounds_raises() -> None:
     preview = _make_preview(rows=1)
     with pytest.raises(IndexError, match="out of bounds"):


### PR DESCRIPTION
## Summary

- Fix replaced-text highlight drift in `display_record()` by resolving replacement spans via forward search in replaced text instead of replaying cursor arithmetic.
- Add case-insensitive replacement-map lookup/fallback so propagated entities (for example, "the Lantern" vs "The Lantern") map correctly without label offset corruption.
- Add regression tests for drift scenarios: case mismatch and entities absent from replacement map.
- Fix notebook source path handling in `docs/notebook_source/01_replace.py` and `docs/notebook_source/02_detection_debug.py` so .ipynb execution resolves data from `docs/notebook_source/data`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verify preview rendering in replace notebook

<img width="1133" height="769" alt="image" src="https://github.com/user-attachments/assets/d1ee5a98-9b6c-4a92-a71e-2a18efbedde9" />

## Related Issues
Closes #15
