### PR TITLE
fix: harden io path validation and error handling

### DIFF
--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -30,6 +31,16 @@ class AnonymizerInput(BaseModel):
     data_summary: str | None = Field(
         default=None, description="Short description of the data. Improves LLM detection accuracy."
     )
+
+    @field_validator("source")
+    @classmethod
+    def validate_source_path(cls, value: str) -> str:
+        source = Path(value)
+        if not source.exists():
+            raise ValueError(f"Input path does not exist: {source}")
+        if not source.is_file():
+            raise ValueError(f"Input path is not a file: {source}")
+        return value
 
 
 class Detect(BaseModel):

--- a/src/anonymizer/engine/io/constants.py
+++ b/src/anonymizer/engine/io/constants.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+SUPPORTED_IO_FORMATS: tuple[str, ...] = (".csv", ".parquet")

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -9,7 +9,8 @@ import pandas as pd
 
 from anonymizer.config.anonymizer_config import AnonymizerInput
 from anonymizer.engine.constants import COL_TEXT
-from anonymizer.interface.errors import InvalidInputError
+from anonymizer.engine.io.constants import SUPPORTED_IO_FORMATS
+from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
 
 
 def read_input(input_data: AnonymizerInput) -> pd.DataFrame:
@@ -35,16 +36,13 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
 
 def _load_dataframe(input_data: AnonymizerInput) -> pd.DataFrame:
     source = Path(str(input_data.source))
-    if not source.exists():
-        raise InvalidInputError(f"Input path does not exist: {source}")
-    if not source.is_file():
-        raise InvalidInputError(f"Input path is not a file: {source}")
     suffix = source.suffix.lower()
+    if suffix not in SUPPORTED_IO_FORMATS:
+        supported_formats = " or ".join(SUPPORTED_IO_FORMATS)
+        raise InvalidInputError(f"Unsupported input format: {suffix}. Use {supported_formats}.")
     try:
         if suffix == ".csv":
             return pd.read_csv(source)
-        if suffix == ".parquet":
-            return pd.read_parquet(source)
+        return pd.read_parquet(source)
     except (OSError, pd.errors.ParserError, ValueError) as error:
-        raise InvalidInputError(f"Failed to read input data from path: {source}") from error
-    raise InvalidInputError(f"Unsupported input format: {suffix}. Use .csv or .parquet.")
+        raise AnonymizerIOError(f"Failed to read input data from path: {source}") from error

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -35,9 +35,16 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
 
 def _load_dataframe(input_data: AnonymizerInput) -> pd.DataFrame:
     source = Path(str(input_data.source))
+    if not source.exists():
+        raise InvalidInputError(f"Input path does not exist: {source}")
+    if not source.is_file():
+        raise InvalidInputError(f"Input path is not a file: {source}")
     suffix = source.suffix.lower()
-    if suffix == ".csv":
-        return pd.read_csv(source)
-    if suffix == ".parquet":
-        return pd.read_parquet(source)
+    try:
+        if suffix == ".csv":
+            return pd.read_csv(source)
+        if suffix == ".parquet":
+            return pd.read_parquet(source)
+    except (OSError, pd.errors.ParserError, ValueError) as error:
+        raise InvalidInputError(f"Failed to read input data from path: {source}") from error
     raise InvalidInputError(f"Unsupported input format: {suffix}. Use .csv or .parquet.")

--- a/src/anonymizer/engine/io/writer.py
+++ b/src/anonymizer/engine/io/writer.py
@@ -7,14 +7,15 @@ from pathlib import Path
 
 import pandas as pd
 
-from anonymizer.interface.errors import InvalidInputError
+from anonymizer.engine.io.constants import SUPPORTED_IO_FORMATS
+from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
 
 
 def write_output(dataframe: pd.DataFrame, output_path: str | Path) -> Path:
     """Write dataframe to csv/parquet based on output suffix."""
     path = Path(output_path)
     suffix = path.suffix.lower()
-    if suffix not in {".csv", ".parquet"}:
+    if suffix not in SUPPORTED_IO_FORMATS:
         raise InvalidInputError(f"Unsupported output format for path: {path}")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -24,4 +25,4 @@ def write_output(dataframe: pd.DataFrame, output_path: str | Path) -> Path:
         dataframe.to_parquet(path, index=False)
         return path
     except (OSError, ValueError) as error:
-        raise InvalidInputError(f"Failed to write output data to path: {path}") from error
+        raise AnonymizerIOError(f"Failed to write output data to path: {path}") from error

--- a/src/anonymizer/engine/io/writer.py
+++ b/src/anonymizer/engine/io/writer.py
@@ -14,10 +14,14 @@ def write_output(dataframe: pd.DataFrame, output_path: str | Path) -> Path:
     """Write dataframe to csv/parquet based on output suffix."""
     path = Path(output_path)
     suffix = path.suffix.lower()
-    if suffix == ".csv":
-        dataframe.to_csv(path, index=False)
-        return path
-    if suffix == ".parquet":
+    if suffix not in {".csv", ".parquet"}:
+        raise InvalidInputError(f"Unsupported output format for path: {path}")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if suffix == ".csv":
+            dataframe.to_csv(path, index=False)
+            return path
         dataframe.to_parquet(path, index=False)
         return path
-    raise InvalidInputError(f"Unsupported output format for path: {path}")
+    except (OSError, ValueError) as error:
+        raise InvalidInputError(f"Failed to write output data to path: {path}") from error

--- a/src/anonymizer/interface/errors.py
+++ b/src/anonymizer/interface/errors.py
@@ -10,3 +10,7 @@ class AnonymizerError(Exception):
 
 class InvalidInputError(AnonymizerError):
     """Raised when input data or configuration is invalid."""
+
+
+class AnonymizerIOError(AnonymizerError):
+    """Raised when file IO operations fail."""

--- a/tests/config/test_anonymizer_config.py
+++ b/tests/config/test_anonymizer_config.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Rewrite
@@ -25,9 +27,11 @@ def test_rewrite_defaults_privacy_goal() -> None:
     assert config.rewrite.privacy_goal is not None
 
 
-def test_data_summary_on_input() -> None:
+def test_data_summary_on_input(tmp_path: Path) -> None:
+    source_path = tmp_path / "data.csv"
+    source_path.write_text("text\nsample\n")
     inp = AnonymizerInput(
-        source="data.csv",
+        source=str(source_path),
         data_summary="Medical clinic visit notes from outpatient encounters.",
     )
     assert inp.data_summary is not None

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -93,3 +93,50 @@ def test_read_input_preserves_text_attr_when_column_exists(tmp_path: Path) -> No
     inp = AnonymizerInput(source=str(file_path))
     result = read_input(inp)
     assert result.attrs["original_text_column"] == "text"
+
+
+def test_read_input_missing_path_raises(tmp_path: Path) -> None:
+    missing_file = tmp_path / "missing" / "data.csv"
+    inp = AnonymizerInput(source=str(missing_file))
+    with pytest.raises(InvalidInputError, match="does not exist"):
+        read_input(inp)
+
+
+def test_write_output_creates_parent_directories(stub_dataframe: pd.DataFrame, tmp_path: Path) -> None:
+    out_path = tmp_path / "nested" / "deep" / "out.csv"
+    write_output(stub_dataframe, out_path)
+    assert out_path.exists()
+
+
+def test_read_input_directory_path_raises(tmp_path: Path) -> None:
+    directory_path = tmp_path / "data.csv"
+    directory_path.mkdir()
+    inp = AnonymizerInput(source=str(directory_path))
+    with pytest.raises(InvalidInputError, match="is not a file"):
+        read_input(inp)
+
+
+def test_read_input_pandas_failure_raises_invalid_input_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_path = tmp_path / "data.csv"
+    file_path.write_text("text\nhello\n")
+
+    def _raise_read_error(*args: object, **kwargs: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(pd, "read_csv", _raise_read_error)
+    inp = AnonymizerInput(source=str(file_path))
+    with pytest.raises(InvalidInputError, match="Failed to read input data"):
+        read_input(inp)
+
+
+def test_write_output_unwritable_path_raises_invalid_input_error(
+    stub_dataframe: pd.DataFrame, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out_path = tmp_path / "nested" / "out.csv"
+
+    def _raise_write_error(*args: object, **kwargs: object) -> None:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(pd.DataFrame, "to_csv", _raise_write_error)
+    with pytest.raises(InvalidInputError, match="Failed to write output data"):
+        write_output(stub_dataframe, out_path)

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -7,12 +7,13 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from anonymizer.config.anonymizer_config import AnonymizerInput
 from anonymizer.engine.constants import COL_TEXT
 from anonymizer.engine.io.reader import read_input
 from anonymizer.engine.io.writer import write_output
-from anonymizer.interface.errors import InvalidInputError
+from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
 
 
 def test_write_output_csv_roundtrips(stub_dataframe: pd.DataFrame, tmp_path: Path) -> None:
@@ -95,11 +96,10 @@ def test_read_input_preserves_text_attr_when_column_exists(tmp_path: Path) -> No
     assert result.attrs["original_text_column"] == "text"
 
 
-def test_read_input_missing_path_raises(tmp_path: Path) -> None:
+def test_anonymizer_input_missing_path_raises_validation_error(tmp_path: Path) -> None:
     missing_file = tmp_path / "missing" / "data.csv"
-    inp = AnonymizerInput(source=str(missing_file))
-    with pytest.raises(InvalidInputError, match="does not exist"):
-        read_input(inp)
+    with pytest.raises(ValidationError, match="Input path does not exist"):
+        AnonymizerInput(source=str(missing_file))
 
 
 def test_write_output_creates_parent_directories(stub_dataframe: pd.DataFrame, tmp_path: Path) -> None:
@@ -108,15 +108,14 @@ def test_write_output_creates_parent_directories(stub_dataframe: pd.DataFrame, t
     assert out_path.exists()
 
 
-def test_read_input_directory_path_raises(tmp_path: Path) -> None:
+def test_anonymizer_input_directory_path_raises_validation_error(tmp_path: Path) -> None:
     directory_path = tmp_path / "data.csv"
     directory_path.mkdir()
-    inp = AnonymizerInput(source=str(directory_path))
-    with pytest.raises(InvalidInputError, match="is not a file"):
-        read_input(inp)
+    with pytest.raises(ValidationError, match="Input path is not a file"):
+        AnonymizerInput(source=str(directory_path))
 
 
-def test_read_input_pandas_failure_raises_invalid_input_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_input_pandas_failure_raises_anonymizer_io_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     file_path = tmp_path / "data.csv"
     file_path.write_text("text\nhello\n")
 
@@ -125,11 +124,11 @@ def test_read_input_pandas_failure_raises_invalid_input_error(tmp_path: Path, mo
 
     monkeypatch.setattr(pd, "read_csv", _raise_read_error)
     inp = AnonymizerInput(source=str(file_path))
-    with pytest.raises(InvalidInputError, match="Failed to read input data"):
+    with pytest.raises(AnonymizerIOError, match="Failed to read input data"):
         read_input(inp)
 
 
-def test_write_output_unwritable_path_raises_invalid_input_error(
+def test_write_output_unwritable_path_raises_anonymizer_io_error(
     stub_dataframe: pd.DataFrame, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     out_path = tmp_path / "nested" / "out.csv"
@@ -138,5 +137,5 @@ def test_write_output_unwritable_path_raises_invalid_input_error(
         raise PermissionError("permission denied")
 
     monkeypatch.setattr(pd.DataFrame, "to_csv", _raise_write_error)
-    with pytest.raises(InvalidInputError, match="Failed to write output data"):
+    with pytest.raises(AnonymizerIOError, match="Failed to write output data"):
         write_output(stub_dataframe, out_path)


### PR DESCRIPTION
## Summary
- Add input path validation in `read_input` flow: fail fast when path does not exist or is not a file.
- Normalize read/write filesystem and pandas failures into clear `InvalidInputError` messages with path context.
- Ensure output parent directories are created before writing, and add regression tests for these edge cases.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes
  - Verified new failure modes return `InvalidInputError` instead of raw OS/pandas errors

## Related Issues
Closes #12 