### PR TITLE
chore: assign anonymizer-reviewers to docs/ in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 
 src/ @NVIDIA-NeMo/anonymizer-reviewers
 tests/ @NVIDIA-NeMo/anonymizer-reviewers
+docs/ @NVIDIA-NeMo/anonymizer-reviewers
 
 # Critical files require maintainers
 pyproject.toml @NVIDIA-NeMo/anonymizer-maintainers


### PR DESCRIPTION
Add CODEOWNERS coverage for docs/ to require anonymizer reviewers on documentation changes.