### PR TITLE
fix: surface JSON parse failures for observability

### DIFF
--- a/src/anonymizer/engine/detection/postprocess.py
+++ b/src/anonymizer/engine/detection/postprocess.py
@@ -361,8 +361,12 @@ def _safe_json_loads(value: dict | str) -> dict:
     try:
         parsed = json.loads(value)
         return parsed if isinstance(parsed, dict) else {}
-    except json.JSONDecodeError:
-        logger.warning("Failed to parse JSON in postprocessing pipeline: %.120r", value)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Failed to parse JSON in postprocessing pipeline (error=%s, length=%d)",
+            exc.msg,
+            len(value),
+        )
         return {}
 
 

--- a/src/anonymizer/engine/detection/postprocess.py
+++ b/src/anonymizer/engine/detection/postprocess.py
@@ -4,10 +4,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha1
+
+logger = logging.getLogger(__name__)
 
 VALIDATION_CONTEXT_WINDOW = 32
 
@@ -359,6 +362,7 @@ def _safe_json_loads(value: dict | str) -> dict:
         parsed = json.loads(value)
         return parsed if isinstance(parsed, dict) else {}
     except json.JSONDecodeError:
+        logger.warning("Failed to parse JSON in postprocessing pipeline: %.120r", value)
         return {}
 
 

--- a/tests/engine/test_detection_postprocess.py
+++ b/tests/engine/test_detection_postprocess.py
@@ -636,13 +636,11 @@ def test_expand_case_insensitive_matching() -> None:
     assert len(expanded) == 2
 
 
-def test_safe_json_loads_logs_warning_on_invalid_json(caplog: pytest.LogCaptureFixture) -> None:
-    from anonymizer.engine.detection.postprocess import _safe_json_loads
-
+def test_parse_raw_entities_logs_warning_on_malformed_json(caplog: pytest.LogCaptureFixture) -> None:
     payload = '{"name":"Alice","ssn":"123-45-6789",invalid}'
     with caplog.at_level(logging.WARNING, logger="anonymizer.engine.detection.postprocess"):
-        result = _safe_json_loads(payload)
-    assert result == {}
+        result = parse_raw_entities(raw_response=payload, text="hello")
+    assert result == []
     assert any("Failed to parse JSON" in m for m in caplog.messages)
     assert any("length=" in m for m in caplog.messages)
     assert payload not in "\n".join(caplog.messages)

--- a/tests/engine/test_detection_postprocess.py
+++ b/tests/engine/test_detection_postprocess.py
@@ -639,7 +639,10 @@ def test_expand_case_insensitive_matching() -> None:
 def test_safe_json_loads_logs_warning_on_invalid_json(caplog: pytest.LogCaptureFixture) -> None:
     from anonymizer.engine.detection.postprocess import _safe_json_loads
 
+    payload = '{"name":"Alice","ssn":"123-45-6789",invalid}'
     with caplog.at_level(logging.WARNING, logger="anonymizer.engine.detection.postprocess"):
-        result = _safe_json_loads("{invalid json")
+        result = _safe_json_loads(payload)
     assert result == {}
     assert any("Failed to parse JSON" in m for m in caplog.messages)
+    assert any("length=" in m for m in caplog.messages)
+    assert payload not in "\n".join(caplog.messages)

--- a/tests/engine/test_detection_postprocess.py
+++ b/tests/engine/test_detection_postprocess.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import json
+import logging
+
+import pytest
 
 from anonymizer.engine.detection.postprocess import (
     EntitySpan,
@@ -631,3 +634,12 @@ def test_expand_case_insensitive_matching() -> None:
     entities = [EntitySpan("e1", "Alice", "first_name", 0, 5, 1.0, "detector")]
     expanded = expand_entity_occurrences(text=text, entities=entities)
     assert len(expanded) == 2
+
+
+def test_safe_json_loads_logs_warning_on_invalid_json(caplog: pytest.LogCaptureFixture) -> None:
+    from anonymizer.engine.detection.postprocess import _safe_json_loads
+
+    with caplog.at_level(logging.WARNING, logger="anonymizer.engine.detection.postprocess"):
+        result = _safe_json_loads("{invalid json")
+    assert result == {}
+    assert any("Failed to parse JSON" in m for m in caplog.messages)


### PR DESCRIPTION
## Summary

Malformed JSON responses from the LLM previously failed silently in key postprocessing steps (`apply_validation_decisions` and `apply_augmented_entities`), making diagnosis difficult.  
This change improves observability by:
- Adding warning logs when `_safe_json_loads` encounters malformed JSON in post processing, so failures are visible instead of silently acting as no-ops.
- Preserving existing fallback behavior (`{}`) to avoid changing runtime control flow.
- Redacting payload content from logs by emitting only safe metadata (`error` and `length`) instead of raw JSON previews.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes

Closes #13 