### PR TITLE
feat: improve validation id alignment with template-guided decisions

### DIFF
--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -30,6 +30,8 @@ COL_MERGED_TAGGED_TEXT = "_merged_tagged_text"
 COL_VALIDATION_CANDIDATES = "_validation_candidates"
 
 # Step 5: LLM validation
+COL_VALIDATION_SKELETON = "_validation_skeleton"
+COL_VALIDATION_DECISIONS = "_validation_decisions"
 COL_VALIDATED_ENTITIES = "_validated_entities"
 
 # Step 6: apply_validation_and_finalize

--- a/src/anonymizer/engine/detection/custom_columns.py
+++ b/src/anonymizer/engine/detection/custom_columns.py
@@ -45,6 +45,15 @@ from anonymizer.engine.detection.postprocess import (
     group_entities_by_value,
     parse_raw_entities,
 )
+from anonymizer.engine.schemas import (
+    EntitiesSchema,
+    RawValidationDecisionsSchema,
+    ValidatedDecisionSchema,
+    ValidatedDecisionsSchema,
+    ValidationCandidatesSchema,
+    ValidationSkeletonDecisionSchema,
+    ValidationSkeletonSchema,
+)
 
 
 @custom_column_generator(
@@ -118,21 +127,13 @@ def prepare_validation_inputs(row: dict[str, Any]) -> dict[str, Any]:
 @custom_column_generator(required_columns=[COL_VALIDATION_CANDIDATES])
 def build_validation_skeleton(row: dict[str, Any]) -> dict[str, Any]:
     """Pre-populate the decisions template with candidate IDs so the LLM only fills in decision/reason."""
-    candidates = row.get(COL_VALIDATION_CANDIDATES, [])
-    row[COL_VALIDATION_SKELETON] = {
-        "decisions": [
-            {
-                "id": c["id"],
-                "value": c["value"],
-                "label": c["label"],
-                "decision": None,
-                "proposed_label": None,
-                "reason": None,
-            }
-            for c in candidates
-            if isinstance(c, dict)
+    candidates = ValidationCandidatesSchema.from_raw(row.get(COL_VALIDATION_CANDIDATES, []))
+    skeleton = ValidationSkeletonSchema(
+        decisions=[
+            ValidationSkeletonDecisionSchema(id=c.id, value=c.value, label=c.label) for c in candidates.candidates
         ]
-    }
+    )
+    row[COL_VALIDATION_SKELETON] = skeleton.model_dump(mode="json")
     return row
 
 
@@ -141,26 +142,26 @@ def build_validation_skeleton(row: dict[str, Any]) -> dict[str, Any]:
 )
 def enrich_validation_decisions(row: dict[str, Any]) -> dict[str, Any]:
     """Enrich validation decisions with entity value and filter to known candidate IDs only."""
-    validated = row.get(COL_VALIDATION_DECISIONS, {})
-    # Both columns come from upstream structured/custom DD steps in the same cell-by-cell
-    # workflow, so they are expected as native Python objects (dict/list), not JSON strings.
-    candidates = row.get(COL_VALIDATION_CANDIDATES, [])
+    raw_decisions = RawValidationDecisionsSchema.from_raw(row.get(COL_VALIDATION_DECISIONS, {}))
+    candidates = ValidationCandidatesSchema.from_raw(row.get(COL_VALIDATION_CANDIDATES, []))
 
-    if not isinstance(validated, dict):
-        return row
+    candidate_lookup = {c.id: c for c in candidates.candidates}
+    valid_ids = set(candidate_lookup)
 
-    value_by_id = {c["id"]: c["value"] for c in candidates if isinstance(c, dict) and "id" in c and "value" in c}
-    valid_ids = set(value_by_id)
+    enriched = [
+        ValidatedDecisionSchema(
+            id=d.id,
+            decision=d.decision,
+            proposed_label=d.proposed_label,
+            reason=d.reason,
+            value=candidate_lookup[d.id].value,
+            label=candidate_lookup[d.id].label,
+        )
+        for d in raw_decisions.decisions
+        if d.id in valid_ids
+    ]
 
-    decisions = validated.get("decisions", [])
-    filtered: list[dict[str, str]] = []
-    if isinstance(decisions, list):
-        for d in decisions:
-            if not isinstance(d, dict) or d.get("id") not in valid_ids:
-                continue
-            filtered.append({**d, "value": value_by_id.get(d["id"], "")})
-
-    row[COL_VALIDATED_ENTITIES] = {"decisions": filtered}
+    row[COL_VALIDATED_ENTITIES] = ValidatedDecisionsSchema(decisions=enriched).model_dump(mode="json")
     return row
 
 
@@ -184,17 +185,16 @@ def apply_validation_and_finalize(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _from_dicts(entities: list[dict[str, str | int | float]]) -> list[EntitySpan]:
-    result: list[EntitySpan] = []
-    for entity in entities:
-        result.append(
-            EntitySpan(
-                entity_id=str(entity.get("id", "")),
-                value=str(entity.get("value", "")),
-                label=str(entity.get("label", "")),
-                start_position=int(entity.get("start_position", 0)),
-                end_position=int(entity.get("end_position", 0)),
-                score=float(entity.get("score", 0.0)),
-                source=str(entity.get("source", "detector")),
-            )
+    parsed = EntitiesSchema.from_raw(entities)
+    return [
+        EntitySpan(
+            entity_id=e.id,
+            value=e.value,
+            label=e.label,
+            start_position=e.start_position,
+            end_position=e.end_position,
+            score=e.score,
+            source=e.source,
         )
-    return result
+        for e in parsed.entities
+    ]

--- a/src/anonymizer/engine/detection/custom_columns.py
+++ b/src/anonymizer/engine/detection/custom_columns.py
@@ -31,6 +31,8 @@ from anonymizer.engine.constants import (
     COL_TEXT,
     COL_VALIDATED_ENTITIES,
     COL_VALIDATION_CANDIDATES,
+    COL_VALIDATION_DECISIONS,
+    COL_VALIDATION_SKELETON,
 )
 from anonymizer.engine.detection.postprocess import (
     EntitySpan,
@@ -110,6 +112,55 @@ def prepare_validation_inputs(row: dict[str, Any]) -> dict[str, Any]:
     seed_spans = _from_dicts(entities=row.get(COL_SEED_ENTITIES, []))
     row[COL_MERGED_TAGGED_TEXT] = build_tagged_text(text=text, entities=seed_spans)
     row[COL_VALIDATION_CANDIDATES] = build_validation_candidates(text=text, entities=seed_spans)
+    return row
+
+
+@custom_column_generator(required_columns=[COL_VALIDATION_CANDIDATES])
+def build_validation_skeleton(row: dict[str, Any]) -> dict[str, Any]:
+    """Pre-populate the decisions template with candidate IDs so the LLM only fills in decision/reason."""
+    candidates = row.get(COL_VALIDATION_CANDIDATES, [])
+    row[COL_VALIDATION_SKELETON] = {
+        "decisions": [
+            {
+                "id": c["id"],
+                "value": c["value"],
+                "label": c["label"],
+                "decision": None,
+                "proposed_label": None,
+                "reason": None,
+            }
+            for c in candidates
+            if isinstance(c, dict)
+        ]
+    }
+    return row
+
+
+@custom_column_generator(
+    required_columns=[COL_VALIDATION_DECISIONS, COL_VALIDATION_CANDIDATES],
+)
+def enrich_validation_decisions(row: dict[str, Any]) -> dict[str, Any]:
+    """Enrich validation decisions with entity value and filter to known candidate IDs only."""
+    validated = row.get(COL_VALIDATION_DECISIONS, {})
+    # Both columns come from upstream structured/custom DD steps in the same cell-by-cell
+    # workflow, so they are expected as native Python objects (dict/list), not JSON strings.
+    candidates = row.get(COL_VALIDATION_CANDIDATES, [])
+
+    if not isinstance(validated, dict):
+        return row
+
+    value_by_id = {c["id"]: c["value"] for c in candidates if isinstance(c, dict) and "id" in c and "value" in c}
+    valid_ids = set(value_by_id)
+
+    decisions = validated.get("decisions", [])
+    filtered: list[dict[str, str]] = []
+    if isinstance(decisions, list):
+        for d in decisions:
+            if not isinstance(d, dict) or d.get("id") not in valid_ids:
+                continue
+            filtered.append({**d, "value": value_by_id.get(d["id"], "")})
+
+    row[COL_VALIDATED_ENTITIES] = {"decisions": filtered}
     return row
 
 

--- a/src/anonymizer/engine/detection/custom_columns.py
+++ b/src/anonymizer/engine/detection/custom_columns.py
@@ -89,7 +89,7 @@ def merge_and_build_candidates(row: dict[str, Any]) -> dict[str, Any]:
     )
     row[COL_MERGED_ENTITIES] = [entity.as_dict() for entity in merged]
     row[COL_MERGED_TAGGED_TEXT] = build_tagged_text(text=text, entities=merged)
-    row[COL_VALIDATION_CANDIDATES] = build_validation_candidates(text=text, entities=merged)
+    row[COL_VALIDATION_CANDIDATES] = {"candidates": build_validation_candidates(text=text, entities=merged)}
     return row
 
 
@@ -120,14 +120,14 @@ def prepare_validation_inputs(row: dict[str, Any]) -> dict[str, Any]:
     text = str(row.get(COL_TEXT, ""))
     seed_spans = _from_dicts(entities=row.get(COL_SEED_ENTITIES, []))
     row[COL_MERGED_TAGGED_TEXT] = build_tagged_text(text=text, entities=seed_spans)
-    row[COL_VALIDATION_CANDIDATES] = build_validation_candidates(text=text, entities=seed_spans)
+    row[COL_VALIDATION_CANDIDATES] = {"candidates": build_validation_candidates(text=text, entities=seed_spans)}
     return row
 
 
 @custom_column_generator(required_columns=[COL_VALIDATION_CANDIDATES])
 def build_validation_skeleton(row: dict[str, Any]) -> dict[str, Any]:
     """Pre-populate the decisions template with candidate IDs so the LLM only fills in decision/reason."""
-    candidates = ValidationCandidatesSchema.from_raw(row.get(COL_VALIDATION_CANDIDATES, []))
+    candidates = ValidationCandidatesSchema.from_raw(row.get(COL_VALIDATION_CANDIDATES, {}))
     skeleton = ValidationSkeletonSchema(
         decisions=[
             ValidationSkeletonDecisionSchema(id=c.id, value=c.value, label=c.label) for c in candidates.candidates
@@ -143,7 +143,7 @@ def build_validation_skeleton(row: dict[str, Any]) -> dict[str, Any]:
 def enrich_validation_decisions(row: dict[str, Any]) -> dict[str, Any]:
     """Enrich validation decisions with entity value and filter to known candidate IDs only."""
     raw_decisions = RawValidationDecisionsSchema.from_raw(row.get(COL_VALIDATION_DECISIONS, {}))
-    candidates = ValidationCandidatesSchema.from_raw(row.get(COL_VALIDATION_CANDIDATES, []))
+    candidates = ValidationCandidatesSchema.from_raw(row.get(COL_VALIDATION_CANDIDATES, {}))
 
     candidate_lookup = {c.id: c for c in candidates.candidates}
     valid_ids = set(candidate_lookup)
@@ -178,14 +178,16 @@ def apply_validation_and_finalize(row: dict[str, Any]) -> dict[str, Any]:
         validation_output=row.get(COL_VALIDATED_ENTITIES, {}),
     )
     expanded = expand_entity_occurrences(text=text, entities=validated)
-    row[COL_DETECTED_ENTITIES] = [entity.as_dict() for entity in expanded]
+    row[COL_DETECTED_ENTITIES] = EntitiesSchema(entities=[entity.as_dict() for entity in expanded]).model_dump(
+        mode="json"
+    )
     row[COL_TAGGED_TEXT] = build_tagged_text(text=text, entities=expanded)
-    row[COL_ENTITIES_BY_VALUE] = group_entities_by_value(entities=expanded)
+    row[COL_ENTITIES_BY_VALUE] = {"entities_by_value": group_entities_by_value(entities=expanded)}
     return row
 
 
 def _from_dicts(entities: list[dict[str, str | int | float]]) -> list[EntitySpan]:
-    parsed = EntitiesSchema.from_raw(entities)
+    parsed = EntitiesSchema.from_raw({"entities": entities})
     return [
         EntitySpan(
             entity_id=e.id,

--- a/src/anonymizer/engine/detection/custom_columns.py
+++ b/src/anonymizer/engine/detection/custom_columns.py
@@ -46,6 +46,7 @@ from anonymizer.engine.detection.postprocess import (
     parse_raw_entities,
 )
 from anonymizer.engine.schemas import (
+    EntitiesByValueSchema,
     EntitiesSchema,
     RawValidationDecisionsSchema,
     ValidatedDecisionSchema,
@@ -67,9 +68,11 @@ def parse_detected_entities(row: dict[str, Any]) -> dict[str, Any]:
         raw_response=str(row.get(COL_RAW_DETECTED, "")),
         text=text,
     )
-    row[COL_SEED_ENTITIES] = [entity.as_dict() for entity in entities]
+    seed_entities = [entity.as_dict() for entity in entities]
+    row[COL_SEED_ENTITIES] = EntitiesSchema(entities=seed_entities).model_dump(mode="json")
     row[COL_INITIAL_TAGGED_TEXT] = build_tagged_text(text=text, entities=entities)
-    row[COL_SEED_ENTITIES_JSON] = json.dumps(row[COL_SEED_ENTITIES])
+    # Keep this as a plain JSON list for prompt template readability/stability.
+    row[COL_SEED_ENTITIES_JSON] = json.dumps(seed_entities)
     row[COL_TAG_NOTATION] = get_tag_notation(text=text)
     return row
 
@@ -79,17 +82,25 @@ def parse_detected_entities(row: dict[str, Any]) -> dict[str, Any]:
     side_effect_columns=[COL_MERGED_TAGGED_TEXT, COL_VALIDATION_CANDIDATES],
 )
 def merge_and_build_candidates(row: dict[str, Any]) -> dict[str, Any]:
-    """Merge seed + augmented entities, then build tagged text and validation candidates."""
+    """Merge seed + augmented entities, then build tagged text and validation candidates.
+
+    Contract:
+    - ``COL_SEED_ENTITIES`` and ``COL_MERGED_ENTITIES`` store ``EntitiesSchema`` payloads.
+    - ``COL_VALIDATION_CANDIDATES`` stores ``ValidationCandidatesSchema`` payloads.
+    """
     text = str(row.get(COL_TEXT, ""))
-    seed_spans = _from_dicts(entities=row.get(COL_SEED_ENTITIES, []))
+    seed_spans = _parse_entity_spans(row.get(COL_SEED_ENTITIES, {}))
     merged = apply_augmented_entities(
         text=text,
         entities=seed_spans,
         augmented_output=row.get(COL_AUGMENTED_ENTITIES, {}),
     )
-    row[COL_MERGED_ENTITIES] = [entity.as_dict() for entity in merged]
+    merged_entities = [entity.as_dict() for entity in merged]
+    row[COL_MERGED_ENTITIES] = EntitiesSchema(entities=merged_entities).model_dump(mode="json")
     row[COL_MERGED_TAGGED_TEXT] = build_tagged_text(text=text, entities=merged)
-    row[COL_VALIDATION_CANDIDATES] = {"candidates": build_validation_candidates(text=text, entities=merged)}
+    row[COL_VALIDATION_CANDIDATES] = ValidationCandidatesSchema(
+        candidates=build_validation_candidates(text=text, entities=merged)
+    ).model_dump(mode="json")
     return row
 
 
@@ -100,13 +111,14 @@ def merge_and_build_candidates(row: dict[str, Any]) -> dict[str, Any]:
 def apply_validation_to_seed_entities(row: dict[str, Any]) -> dict[str, Any]:
     """Apply validation decisions to detector entities before augmentation."""
     text = str(row.get(COL_TEXT, ""))
-    seed_spans = _from_dicts(entities=row.get(COL_SEED_ENTITIES, []))
+    seed_spans = _parse_entity_spans(row.get(COL_SEED_ENTITIES, {}))
     validated_seed = apply_validation_decisions(
         entities=seed_spans,
         validation_output=row.get(COL_VALIDATED_ENTITIES, {}),
     )
-    row[COL_SEED_ENTITIES] = [entity.as_dict() for entity in validated_seed]
-    row[COL_SEED_ENTITIES_JSON] = json.dumps(row[COL_SEED_ENTITIES])
+    seed_entities = [entity.as_dict() for entity in validated_seed]
+    row[COL_SEED_ENTITIES] = EntitiesSchema(entities=seed_entities).model_dump(mode="json")
+    row[COL_SEED_ENTITIES_JSON] = json.dumps(seed_entities)
     row[COL_INITIAL_TAGGED_TEXT] = build_tagged_text(text=text, entities=validated_seed)
     return row
 
@@ -118,9 +130,11 @@ def apply_validation_to_seed_entities(row: dict[str, Any]) -> dict[str, Any]:
 def prepare_validation_inputs(row: dict[str, Any]) -> dict[str, Any]:
     """Build validation prompt inputs from detector entities only."""
     text = str(row.get(COL_TEXT, ""))
-    seed_spans = _from_dicts(entities=row.get(COL_SEED_ENTITIES, []))
+    seed_spans = _parse_entity_spans(row.get(COL_SEED_ENTITIES, {}))
     row[COL_MERGED_TAGGED_TEXT] = build_tagged_text(text=text, entities=seed_spans)
-    row[COL_VALIDATION_CANDIDATES] = {"candidates": build_validation_candidates(text=text, entities=seed_spans)}
+    row[COL_VALIDATION_CANDIDATES] = ValidationCandidatesSchema(
+        candidates=build_validation_candidates(text=text, entities=seed_spans)
+    ).model_dump(mode="json")
     return row
 
 
@@ -172,7 +186,7 @@ def enrich_validation_decisions(row: dict[str, Any]) -> dict[str, Any]:
 def apply_validation_and_finalize(row: dict[str, Any]) -> dict[str, Any]:
     """Apply keep/reclass/drop decisions, expand to all occurrences, and produce final outputs."""
     text = str(row.get(COL_TEXT, ""))
-    merged = _from_dicts(entities=row.get(COL_MERGED_ENTITIES, []))
+    merged = _parse_entity_spans(row.get(COL_MERGED_ENTITIES, {}))
     validated = apply_validation_decisions(
         entities=merged,
         validation_output=row.get(COL_VALIDATED_ENTITIES, {}),
@@ -182,12 +196,14 @@ def apply_validation_and_finalize(row: dict[str, Any]) -> dict[str, Any]:
         mode="json"
     )
     row[COL_TAGGED_TEXT] = build_tagged_text(text=text, entities=expanded)
-    row[COL_ENTITIES_BY_VALUE] = {"entities_by_value": group_entities_by_value(entities=expanded)}
+    row[COL_ENTITIES_BY_VALUE] = EntitiesByValueSchema(
+        entities_by_value=group_entities_by_value(entities=expanded)
+    ).model_dump(mode="json")
     return row
 
 
-def _from_dicts(entities: list[dict[str, str | int | float]]) -> list[EntitySpan]:
-    parsed = EntitiesSchema.from_raw({"entities": entities})
+def _parse_entity_spans(raw_payload: object) -> list[EntitySpan]:
+    parsed = EntitiesSchema.from_raw(raw_payload)
     return [
         EntitySpan(
             entity_id=e.id,

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from enum import Enum
 
 import pandas as pd
 from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig, LLMTextColumnConfig
 from data_designer.config.models import ModelConfig
-from pydantic import BaseModel, Field
 
 from anonymizer.config.models import DetectionModelSelection
 from anonymizer.config.rewrite import PrivacyGoal
@@ -48,75 +46,12 @@ from anonymizer.engine.detection.custom_columns import (
 )
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
-from anonymizer.engine.schemas import EntitiesSchema, ValidationChoice
-
-
-class ValidationDecision(BaseModel):
-    """Per-entity validation decision from the LLM validator."""
-
-    id: str
-    value: str = Field(default="", description="Entity value (echoed from skeleton)")
-    label: str = Field(default="", description="Entity label (echoed from skeleton)")
-    decision: ValidationChoice
-    proposed_label: str = Field(
-        default="",
-        description="Correct label when decision is 'reclass', otherwise empty",
-    )
-    reason: str | None = None
-
-
-class ValidationDecisions(BaseModel):
-    decisions: list[ValidationDecision] = Field(default_factory=list)
-
-
-class AugmentedEntity(BaseModel):
-    value: str = Field(min_length=1)
-    label: str = Field(min_length=1)
-    reason: str | None = None
-
-
-class AugmentedEntities(BaseModel):
-    entities: list[AugmentedEntity] = Field(default_factory=list)
-
-
-class LatentEntity(BaseModel):
-    category: LatentCategory
-    label: str = Field(
-        min_length=1,
-        description=(
-            "General category/class of the inference in snake_case "
-            "(e.g., employer, specific_institution, home_location, medication, health_condition)"
-        ),
-    )
-    value: str = Field(
-        min_length=1,
-        description="Concise inferred value (generalize if not pinned down strongly by evidence)",
-    )
-    confidence: LatentConfidence
-    evidence: list[str] = Field(
-        min_length=1,
-        max_length=2,
-        description="One or two short quotes from the text that support this inference",
-    )
-    rationale: str = Field(
-        min_length=20,
-        max_length=150,
-        description="One sentence explaining the inference without adding new facts",
-    )
-
-
-class LatentEntities(BaseModel):
-    latent_entities: list[LatentEntity] = Field(default_factory=list)
-
-
-class LatentCategory(str, Enum):
-    latent_identifier = "latent_identifier"
-    latent_sensitive_attribute = "latent_sensitive_attribute"
-
-
-class LatentConfidence(str, Enum):
-    high = "high"
-    medium = "medium"
+from anonymizer.engine.schemas import (
+    AugmentedEntitiesSchema,
+    EntitiesSchema,
+    LatentEntitiesSchema,
+    ValidationDecisionsSchema,
+)
 
 
 @dataclass(frozen=True)
@@ -186,7 +121,7 @@ class EntityDetectionWorkflow:
                     name=COL_VALIDATION_DECISIONS,
                     prompt=_get_validation_prompt(data_summary=data_summary, labels=labels),
                     model_alias=validator_alias,
-                    output_format=ValidationDecisions,
+                    output_format=ValidationDecisionsSchema,
                     drop=True,
                 ),
                 CustomColumnConfig(
@@ -201,7 +136,7 @@ class EntityDetectionWorkflow:
                     name=COL_AUGMENTED_ENTITIES,
                     prompt=_get_augment_prompt(data_summary=data_summary, labels=labels),
                     model_alias=augmenter_alias,
-                    output_format=AugmentedEntities,
+                    output_format=AugmentedEntitiesSchema,
                 ),
                 CustomColumnConfig(
                     name=COL_MERGED_ENTITIES,
@@ -256,7 +191,7 @@ class EntityDetectionWorkflow:
                         privacy_goal=privacy_goal,
                     ),
                     model_alias=latent_alias,
-                    output_format=LatentEntities,
+                    output_format=LatentEntitiesSchema,
                 )
             ],
             workflow_name="latent-entity-detection",

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -48,18 +48,15 @@ from anonymizer.engine.detection.custom_columns import (
 )
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
-
-
-class ValidationChoice(str, Enum):
-    keep = "keep"
-    reclass = "reclass"
-    drop = "drop"
+from anonymizer.engine.schemas import EntitiesSchema, ValidationChoice
 
 
 class ValidationDecision(BaseModel):
     """Per-entity validation decision from the LLM validator."""
 
     id: str
+    value: str = Field(default="", description="Entity value (echoed from skeleton)")
+    label: str = Field(default="", description="Entity label (echoed from skeleton)")
     decision: ValidationChoice
     proposed_label: str = Field(
         default="",
@@ -321,9 +318,7 @@ class EntityDetectionWorkflow:
 
         if COL_DETECTED_ENTITIES in final_df.columns:
             final_df[COL_FINAL_ENTITIES] = final_df[COL_DETECTED_ENTITIES].apply(
-                lambda x: (
-                    {"entities": x.tolist() if hasattr(x, "tolist") else list(x)} if x is not None else {"entities": []}
-                )
+                lambda x: EntitiesSchema.from_raw(x).model_dump()
             )
         if "original_text_column" in dataframe.attrs:
             final_df.attrs["original_text_column"] = dataframe.attrs["original_text_column"]

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -31,6 +31,8 @@ from anonymizer.engine.constants import (
     COL_TEXT,
     COL_VALIDATED_ENTITIES,
     COL_VALIDATION_CANDIDATES,
+    COL_VALIDATION_DECISIONS,
+    COL_VALIDATION_SKELETON,
     DEFAULT_ENTITY_LABELS,
     ENTITY_LABEL_EXAMPLES,
 )
@@ -38,6 +40,8 @@ from anonymizer.engine.detection.constants import _jinja
 from anonymizer.engine.detection.custom_columns import (
     apply_validation_and_finalize,
     apply_validation_to_seed_entities,
+    build_validation_skeleton,
+    enrich_validation_decisions,
     merge_and_build_candidates,
     parse_detected_entities,
     prepare_validation_inputs,
@@ -178,11 +182,19 @@ class EntityDetectionWorkflow:
                     name=COL_VALIDATION_CANDIDATES,
                     generator_function=prepare_validation_inputs,
                 ),
+                CustomColumnConfig(
+                    name=COL_VALIDATION_SKELETON, generator_function=build_validation_skeleton, drop=True
+                ),
                 LLMStructuredColumnConfig(
-                    name=COL_VALIDATED_ENTITIES,
+                    name=COL_VALIDATION_DECISIONS,
                     prompt=_get_validation_prompt(data_summary=data_summary, labels=labels),
                     model_alias=validator_alias,
                     output_format=ValidationDecisions,
+                    drop=True,
+                ),
+                CustomColumnConfig(
+                    name=COL_VALIDATED_ENTITIES,
+                    generator_function=enrich_validation_decisions,
                 ),
                 CustomColumnConfig(
                     name=COL_SEED_ENTITIES_JSON,
@@ -308,7 +320,11 @@ class EntityDetectionWorkflow:
             final_failures = detected_result.failed_records
 
         if COL_DETECTED_ENTITIES in final_df.columns:
-            final_df[COL_FINAL_ENTITIES] = final_df[COL_DETECTED_ENTITIES]
+            final_df[COL_FINAL_ENTITIES] = final_df[COL_DETECTED_ENTITIES].apply(
+                lambda x: (
+                    {"entities": x.tolist() if hasattr(x, "tolist") else list(x)} if x is not None else {"entities": []}
+                )
+            )
         if "original_text_column" in dataframe.attrs:
             final_df.attrs["original_text_column"] = dataframe.attrs["original_text_column"]
         return EntityDetectionResult(
@@ -365,7 +381,7 @@ def _format_label_examples(labels: list[str]) -> str:
 
 
 def _get_validation_prompt(*, data_summary: str | None, labels: list[str]) -> str:
-    prompt = """Validate entity tags for privacy-sensitive information. For each entity, decide: keep, reclassify, or drop.
+    prompt = """Validate entity tags for privacy-sensitive information. For each entity in the template below, fill in the "decision" and "reason" fields. Fill in "proposed_label" only when decision is "reclass".
 <<DATA_SUMMARY>>
 
 Here are all the valid entity classes with examples (only classes from this list can be proposed):
@@ -388,17 +404,18 @@ What to DROP:
 - Placeholders or label names (e.g., "name", "email", "date")
 - Syntax/metadata in structured formats (field names, column headers, keywords)
 - Generic time references that are not specific dates (e.g., "today", "now", "soon")
+- Kinship and family-role terms used as relationship descriptors are not quasi-identifiers.
 
 Additional rules:
 - Check context matches label (not just format)
-- Use exact text from the tagged span
 - Prefer ssn over national_id or account_number if ambiguous
 - Prefer phone_number over fax_number unless "fax" is explicit
 - VIN length 17 is vehicle_identifier, shorter is license_plate (check context for regional variations)
 - Numbers preceded by '$' are monetary values, not entities like age or account number
 - If classified as date_of_birth, verify context is appropriate; otherwise use date
-
-Use the candidates list as the authoritative source for entity values and labels.
+- You MUST fill in a decision for EVERY entry in the template — do not skip any
+- Return ONLY the entries from the template — do not add new entries for entities not already in the template
+- Copy ids exactly as given; never modify entries
 
 Example:
 {%- if <<TAG_NOTATION>> == "xml" -%}
@@ -410,17 +427,17 @@ Input text: My ((PII:first_name|name)) is ((PII:first_name|Amy)), ((PII:age|35))
 {%- else -%}
 Input text: My <<PII:first_name>>name<</PII:first_name>> is <<PII:first_name>>Amy<</PII:first_name>>, <<PII:age>>35<</PII:age>> in <<PII:country>>San Diego<</PII:country>>, <<PII:state>>California<</PII:state>>.
 {%- endif -%}
-Candidates: [{"id": "id_name", "value": "name", "label": "first_name", "context_before": "My ", "context_after": " is Amy"}, {"id": "id_amy", "value": "Amy", "label": "first_name", "context_before": " is ", "context_after": ", 35"}, {"id": "id_35", "value": "35", "label": "age", "context_before": "Amy, ", "context_after": ", software"}, {"id": "id_sd", "value": "San Diego", "label": "country", "context_before": " in ", "context_after": ", California"}, {"id": "id_ca", "value": "California", "label": "state", "context_before": "Diego, ", "context_after": "."}]
-Output: {"decisions": [{"id": "id_name", "decision": "drop", "proposed_label": "", "reason": "placeholder not actual name"}, {"id": "id_amy", "decision": "keep", "proposed_label": "", "reason": "valid first name"}, {"id": "id_35", "decision": "keep", "proposed_label": "", "reason": "quasi-identifier"}, {"id": "id_sd", "decision": "reclass", "proposed_label": "city", "reason": "city not country"}, {"id": "id_ca", "decision": "keep", "proposed_label": "", "reason": "valid state"}]}
+Template: {"decisions": [{"id": "first_name_3_7", "value": "name", "label": "first_name", "decision": null, "proposed_label": null, "reason": null}, {"id": "first_name_11_14", "value": "Amy", "label": "first_name", "decision": null, "proposed_label": null, "reason": null}, {"id": "age_16_18", "value": "35", "label": "age", "decision": null, "proposed_label": null, "reason": null}, {"id": "country_22_31", "value": "San Diego", "label": "country", "decision": null, "proposed_label": null, "reason": null}, {"id": "state_33_43", "value": "California", "label": "state", "decision": null, "proposed_label": null, "reason": null}]}
+Output: {"decisions": [{"id": "first_name_3_7", "value": "name", "label": "first_name", "decision": "drop", "proposed_label": "", "reason": "placeholder not actual name"}, {"id": "first_name_11_14", "value": "Amy", "label": "first_name", "decision": "keep", "proposed_label": "", "reason": "real first name"}, {"id": "age_16_18", "value": "35", "label": "age", "decision": "keep", "proposed_label": "", "reason": "age quasi-identifier"}, {"id": "country_22_31", "value": "San Diego", "label": "country", "decision": "reclass", "proposed_label": "city", "reason": "city not country"}, {"id": "state_33_43", "value": "California", "label": "state", "decision": "keep", "proposed_label": "", "reason": "state quasi-identifier"}]}
 
 ---
 Input text: <<TAGGED_TEXT>>
-Candidates: <<CANDIDATES>>
+Template: <<VALIDATION_SKELETON>>
 """
     prompt = (
         prompt.replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
         .replace("<<TAGGED_TEXT>>", _jinja(COL_MERGED_TAGGED_TEXT))
-        .replace("<<CANDIDATES>>", _jinja(COL_VALIDATION_CANDIDATES))
+        .replace("<<VALIDATION_SKELETON>>", _jinja(COL_VALIDATION_SKELETON))
         .replace("<<LABEL_EXAMPLES>>", _format_label_examples(labels))
     )
     context_section = f"\nData context: {data_summary}\n" if data_summary else ""

--- a/src/anonymizer/engine/detection/postprocess.py
+++ b/src/anonymizer/engine/detection/postprocess.py
@@ -7,7 +7,6 @@ import json
 import re
 from dataclasses import dataclass
 from enum import Enum
-from hashlib import sha1
 
 VALIDATION_CONTEXT_WINDOW = 32
 
@@ -67,7 +66,7 @@ def parse_raw_entities(raw_response: str, text: str) -> list[EntitySpan]:
             continue
         if start is None or end is None or start < 0 or end <= start or end > len(text):
             continue
-        entity_id = _build_entity_id(index=idx, value=value, label=label, start=start, end=end)
+        entity_id = _build_entity_id(label=label, start=start, end=end)
         parsed.append(
             EntitySpan(
                 entity_id=entity_id,
@@ -173,14 +172,7 @@ def apply_augmented_entities(
         if not value or not label:
             continue
         for start, end in _find_all_occurrences(text=text, needle=value):
-            entity_id = _build_entity_id(
-                index=idx,
-                value=value,
-                label=label,
-                start=start,
-                end=end,
-                source="augmenter",
-            )
+            entity_id = _build_entity_id(label=label, start=start, end=end)
             merged.append(
                 EntitySpan(
                     entity_id=entity_id,
@@ -224,14 +216,7 @@ def _split_full_names(text: str, entities: list[EntitySpan]) -> list[EntitySpan]
             else:
                 part_label = "middle_name"
             for start, end in _find_all_occurrences(text=text, needle=part):
-                entity_id = _build_entity_id(
-                    index=idx,
-                    value=part,
-                    label=part_label,
-                    start=start,
-                    end=end,
-                    source="name_split",
-                )
+                entity_id = _build_entity_id(label=part_label, start=start, end=end)
                 extra.append(
                     EntitySpan(
                         entity_id=entity_id,
@@ -314,14 +299,7 @@ def expand_entity_occurrences(text: str, entities: list[EntitySpan]) -> list[Ent
     for idx, (key, label) in enumerate(entity_map.items()):
         original_value = next(e.value for e in entities if e.value.lower() == key)
         for start, end in _find_all_occurrences(text=text, needle=original_value):
-            entity_id = _build_entity_id(
-                index=idx,
-                value=text[start:end],
-                label=label,
-                start=start,
-                end=end,
-                source="propagation",
-            )
+            entity_id = _build_entity_id(label=label, start=start, end=end)
             expanded.append(
                 EntitySpan(
                     entity_id=entity_id,
@@ -395,17 +373,8 @@ def _find_all_occurrences(text: str, needle: str) -> list[tuple[int, int]]:
     return positions
 
 
-def _build_entity_id(
-    *,
-    index: int,
-    value: str,
-    label: str,
-    start: int,
-    end: int,
-    source: str = "detector",
-) -> str:
-    digest = sha1(f"{source}:{index}:{value}:{label}:{start}:{end}".encode("utf-8")).hexdigest()
-    return digest[:16]
+def _build_entity_id(*, label: str, start: int, end: int) -> str:
+    return f"{label}_{start}_{end}"
 
 
 def _choose_tag_notation(text: str) -> TagNotation:

--- a/src/anonymizer/engine/ndd/model_loader.py
+++ b/src/anonymizer/engine/ndd/model_loader.py
@@ -118,7 +118,10 @@ def get_model_alias(workflow_name: WorkflowName, role: str, config_dir: Path | N
     return selected_models[role]
 
 
-def resolve_model_alias(role: str, selection_model: object) -> str:
+def resolve_model_alias(
+    role: str,
+    selection_model: DetectionModelSelection | ReplaceModelSelection | RewriteModelSelection,
+) -> str:
     """Read model alias directly from the selection model.
 
     The selection model is already populated with defaults from YAML

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -9,23 +9,12 @@ from dataclasses import dataclass
 import pandas as pd
 from data_designer.config.column_configs import LLMStructuredColumnConfig
 from data_designer.config.models import ModelConfig
-from pydantic import BaseModel, Field
 
 from anonymizer.config.models import ReplaceModelSelection
 from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, ENTITY_LABEL_EXAMPLES
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
-from anonymizer.engine.schemas import EntitiesByValueSchema
-
-
-class EntityReplacement(BaseModel):
-    original: str = Field(min_length=1, description="The original entity value")
-    label: str = Field(min_length=1, description="The entity label/type")
-    synthetic: str = Field(min_length=1, description="The synthetic replacement value")
-
-
-class ReplacementMap(BaseModel):
-    replacements: list[EntityReplacement] = Field(default_factory=list, description="List of entity replacements")
+from anonymizer.engine.schemas import EntitiesByValueSchema, EntityReplacementMapSchema
 
 
 @dataclass(frozen=True)
@@ -74,7 +63,7 @@ class LlmReplaceWorkflow:
                         instructions=instructions,
                     ),
                     model_alias=replace_alias,
-                    output_format=ReplacementMap,
+                    output_format=EntityReplacementMapSchema,
                 )
             ],
             workflow_name="replace-map-generation",

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -54,11 +54,11 @@ class LlmReplaceWorkflow:
 
         working_df = dataframe.copy()
         working_df["_entity_examples"] = working_df.apply(
-            lambda row: _create_entity_examples(EntitiesByValueSchema.from_raw(row.get(entities_column, []))),
+            lambda row: _create_entity_examples(EntitiesByValueSchema.from_raw(row.get(entities_column, {}))),
             axis=1,
         )
         working_df["_entities_for_replace"] = working_df.apply(
-            lambda row: _enrich_entities_for_template(EntitiesByValueSchema.from_raw(row.get(entities_column, []))),
+            lambda row: _enrich_entities_for_template(EntitiesByValueSchema.from_raw(row.get(entities_column, {}))),
             axis=1,
         )
         working_df["_entities_for_replace_json"] = working_df["_entities_for_replace"].apply(json.dumps)

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -148,6 +148,9 @@ Rules:
    - Same structure, length patterns, character types
    - Same demographic characteristics (Indian name → Indian name)
 
+4. Fit the surrounding text naturally:
+   - Check that the synthetic value reads correctly with the words immediately before and after it in the original text.
+
 CRITICAL: Every entity MUST have a different synthetic value. Never return original=synthetic.
 """
     return prompt.replace("<<INSTRUCTION_BLOCK>>", instruction_block).replace("<<ENTITIES_COLUMN>>", entities_column)

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
 
 import pandas as pd
 from data_designer.config.column_configs import LLMStructuredColumnConfig
@@ -16,6 +15,7 @@ from anonymizer.config.models import ReplaceModelSelection
 from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, ENTITY_LABEL_EXAMPLES
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.schemas import EntitiesByValueSchema
 
 
 class EntityReplacement(BaseModel):
@@ -54,11 +54,11 @@ class LlmReplaceWorkflow:
 
         working_df = dataframe.copy()
         working_df["_entity_examples"] = working_df.apply(
-            lambda row: _create_entity_examples(row.get(entities_column, [])),
+            lambda row: _create_entity_examples(EntitiesByValueSchema.from_raw(row.get(entities_column, []))),
             axis=1,
         )
         working_df["_entities_for_replace"] = working_df.apply(
-            lambda row: _normalize_entities_by_value(row.get(entities_column, [])),
+            lambda row: _enrich_entities_for_template(EntitiesByValueSchema.from_raw(row.get(entities_column, []))),
             axis=1,
         )
         working_df["_entities_for_replace_json"] = working_df["_entities_for_replace"].apply(json.dumps)
@@ -89,25 +89,15 @@ class LlmReplaceWorkflow:
         return LlmReplaceResult(dataframe=output_df, failed_records=run_result.failed_records)
 
 
-def _normalize_entities_by_value(raw: Any) -> list[dict[str, Any]]:
-    if not isinstance(raw, list):
-        return []
-    normalized: list[dict[str, Any]] = []
-    for entity in raw:
-        if not isinstance(entity, dict):
-            continue
-        enriched = {**entity}
-        labels = enriched.get("labels", [])
-        enriched["labels_str"] = ", ".join(str(label) for label in labels) if isinstance(labels, list) else ""
-        normalized.append(enriched)
-    return normalized
+def _enrich_entities_for_template(parsed: EntitiesByValueSchema) -> list[dict[str, str | list[str]]]:
+    """Add ``labels_str`` for Jinja template rendering."""
+    return [{"value": e.value, "labels": e.labels, "labels_str": ", ".join(e.labels)} for e in parsed.entities_by_value]
 
 
-def _create_entity_examples(entities_by_value: Any) -> str:
-    normalized = _normalize_entities_by_value(entities_by_value)
+def _create_entity_examples(parsed: EntitiesByValueSchema) -> str:
     labels: set[str] = set()
-    for entity in normalized:
-        labels.update(str(label) for label in entity.get("labels", []) if str(label))
+    for entity in parsed.entities_by_value:
+        labels.update(label for label in entity.labels if label)
     if not labels:
         return ""
     examples = {

--- a/src/anonymizer/engine/replace/replace_runner.py
+++ b/src/anonymizer/engine/replace/replace_runner.py
@@ -20,6 +20,7 @@ from anonymizer.engine.constants import COL_FINAL_ENTITIES
 from anonymizer.engine.ndd.adapter import FailedRecord
 from anonymizer.engine.replace.llm_replace_workflow import LlmReplaceWorkflow
 from anonymizer.engine.replace.strategies import apply_local_replace_strategy, apply_replacement_map
+from anonymizer.engine.schemas import EntitiesSchema
 
 
 @dataclass(frozen=True)
@@ -78,6 +79,10 @@ def _filter_entities_by_label(
     allowed = {label.lower() for label in filter_labels}
     filtered = dataframe.copy()
     filtered[entities_column] = filtered[entities_column].apply(
-        lambda entities: [e for e in entities if isinstance(e, dict) and e.get("label", "").lower() in allowed]
+        lambda raw: _filter_entities(EntitiesSchema.from_raw(raw), allowed).model_dump()
     )
     return filtered
+
+
+def _filter_entities(entities: EntitiesSchema, allowed: set[str]) -> EntitiesSchema:
+    return EntitiesSchema(entities=[e for e in entities.entities if e.label.lower() in allowed])

--- a/src/anonymizer/engine/replace/strategies.py
+++ b/src/anonymizer/engine/replace/strategies.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
 
 import pandas as pd
 
 from anonymizer.config.replace_strategies import LocalReplaceMethod
 from anonymizer.engine.constants import COL_FINAL_ENTITIES, COL_REPLACED_TEXT, COL_REPLACEMENT_MAP, COL_TEXT
+from anonymizer.engine.schemas import EntitiesSchema
 
 
 @dataclass(frozen=True)
@@ -31,17 +31,16 @@ def apply_local_replace_strategy(
     output_df = dataframe.copy()
     output_df[COL_REPLACEMENT_MAP] = output_df.apply(
         lambda row: _build_local_replacement_map(
-            row=row,
+            entities=EntitiesSchema.from_raw(row.get(entities_column, [])),
             strategy=strategy,
-            entities_column=entities_column,
         ),
         axis=1,
     )
     output_df[COL_REPLACED_TEXT] = output_df.apply(
         lambda row: _apply_replacement_map_to_text(
             text=str(row.get(text_column, "")),
-            entities=row.get(entities_column, []),
-            replacement_map=row[COL_REPLACEMENT_MAP],
+            entities=EntitiesSchema.from_raw(row.get(entities_column, [])),
+            replacements=_parse_replacements(row[COL_REPLACEMENT_MAP]),
         ),
         axis=1,
     )
@@ -60,38 +59,35 @@ def apply_replacement_map(
     output_df[COL_REPLACED_TEXT] = output_df.apply(
         lambda row: _apply_replacement_map_to_text(
             text=str(row.get(text_column, "")),
-            entities=row.get(entities_column, []),
-            replacement_map=row.get(replacement_map_column, {"replacements": []}),
+            entities=EntitiesSchema.from_raw(row.get(entities_column, [])),
+            replacements=_parse_replacements(row.get(replacement_map_column, {"replacements": []})),
         ),
         axis=1,
     )
     return output_df
 
 
-def _build_local_replacement_map(row: pd.Series, strategy: LocalReplaceMethod, entities_column: str) -> dict[str, Any]:
-    entities = [e for e in row.get(entities_column, []) if isinstance(e, dict)]
-    if not entities:
+def _build_local_replacement_map(
+    entities: EntitiesSchema, strategy: LocalReplaceMethod
+) -> dict[str, list[dict[str, str]]]:
+    if not entities.entities:
         return {"replacements": []}
     replacements: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
-    for entity in entities:
-        value = str(entity.get("value", ""))
-        label = str(entity.get("label", ""))
-        if not value or not label:
+    for entity in entities.entities:
+        if not entity.value or not entity.label:
             continue
-        key = (value, label)
+        key = (entity.value, entity.label)
         if key in seen:
             continue
         seen.add(key)
-        synthetic = strategy.replace(text=value, label=label)
-        replacements.append({"original": value, "label": label, "synthetic": synthetic})
+        synthetic = strategy.replace(text=entity.value, label=entity.label)
+        replacements.append({"original": entity.value, "label": entity.label, "synthetic": synthetic})
     return {"replacements": replacements}
 
 
-def _apply_replacement_map_to_text(text: str, entities: Any, replacement_map: Any) -> str:
-    normalized_entities = [e for e in entities if isinstance(e, dict)]
-    replacements = _normalize_replacements(replacement_map)
-    if not normalized_entities or not replacements:
+def _apply_replacement_map_to_text(text: str, entities: EntitiesSchema, replacements: list[ReplacementEntry]) -> str:
+    if not entities.entities or not replacements:
         return text
 
     by_value_label: dict[tuple[str, str], str] = {}
@@ -101,16 +97,7 @@ def _apply_replacement_map_to_text(text: str, entities: Any, replacement_map: An
         by_value[replacement.original] = replacement.synthetic
 
     spans = sorted(
-        (
-            (
-                int(entity.get("start_position", 0)),
-                int(entity.get("end_position", 0)),
-                str(entity.get("value", "")),
-                str(entity.get("label", "")),
-            )
-            for entity in normalized_entities
-            if entity.get("start_position") is not None and entity.get("end_position") is not None
-        ),
+        ((entity.start_position, entity.end_position, entity.value, entity.label) for entity in entities.entities),
         key=lambda item: item[0],
     )
 
@@ -127,7 +114,8 @@ def _apply_replacement_map_to_text(text: str, entities: Any, replacement_map: An
     return "".join(parts)
 
 
-def _normalize_replacements(raw: Any) -> list[ReplacementEntry]:
+def _parse_replacements(raw: str | dict | object) -> list[ReplacementEntry]:
+    """Parse raw replacement map (JSON string or dict) into typed entries."""
     parsed = raw
     if isinstance(raw, str):
         try:

--- a/src/anonymizer/engine/replace/strategies.py
+++ b/src/anonymizer/engine/replace/strategies.py
@@ -31,7 +31,7 @@ def apply_local_replace_strategy(
     output_df = dataframe.copy()
     output_df[COL_REPLACEMENT_MAP] = output_df.apply(
         lambda row: _build_local_replacement_map(
-            entities=EntitiesSchema.from_raw(row.get(entities_column, [])),
+            entities=EntitiesSchema.from_raw(row.get(entities_column, {})),
             strategy=strategy,
         ),
         axis=1,
@@ -39,7 +39,7 @@ def apply_local_replace_strategy(
     output_df[COL_REPLACED_TEXT] = output_df.apply(
         lambda row: _apply_replacement_map_to_text(
             text=str(row.get(text_column, "")),
-            entities=EntitiesSchema.from_raw(row.get(entities_column, [])),
+            entities=EntitiesSchema.from_raw(row.get(entities_column, {})),
             replacements=_parse_replacements(row[COL_REPLACEMENT_MAP]),
         ),
         axis=1,
@@ -59,7 +59,7 @@ def apply_replacement_map(
     output_df[COL_REPLACED_TEXT] = output_df.apply(
         lambda row: _apply_replacement_map_to_text(
             text=str(row.get(text_column, "")),
-            entities=EntitiesSchema.from_raw(row.get(entities_column, [])),
+            entities=EntitiesSchema.from_raw(row.get(entities_column, {})),
             replacements=_parse_replacements(row.get(replacement_map_column, {"replacements": []})),
         ),
         axis=1,

--- a/src/anonymizer/engine/schemas.py
+++ b/src/anonymizer/engine/schemas.py
@@ -17,7 +17,7 @@ def _parse_raw_wrapper(
     key: str,
     fallback_keys: tuple[str, ...] = (),
 ) -> T:
-    """Parse raw DataFrame cell value (dict, list, or numpy array) into a wrapper schema."""
+    """Parse raw DataFrame cell value into a wrapper schema."""
 
     def _safe_validate(candidate_list: list[object]) -> T:
         try:
@@ -38,13 +38,6 @@ def _parse_raw_wrapper(
             as_list = candidate.tolist()
             if isinstance(as_list, list):
                 return _safe_validate(as_list)
-        return model_cls()
-    if isinstance(raw, list):
-        return _safe_validate(raw)
-    if hasattr(raw, "tolist"):
-        as_list = raw.tolist()
-        if isinstance(as_list, list):
-            return _safe_validate(as_list)
     return model_cls()
 
 

--- a/src/anonymizer/engine/schemas.py
+++ b/src/anonymizer/engine/schemas.py
@@ -25,6 +25,11 @@ def _parse_raw_wrapper(
         except ValidationError:
             return model_cls()
 
+    if isinstance(raw, model_cls):
+        return raw
+    if isinstance(raw, BaseModel):
+        raw = raw.model_dump(mode="python")
+
     if isinstance(raw, dict):
         candidate = raw.get(key)
         if candidate is None:
@@ -32,6 +37,10 @@ def _parse_raw_wrapper(
                 candidate = raw.get(fk)
                 if candidate is not None:
                     break
+        if isinstance(candidate, model_cls):
+            return candidate
+        if isinstance(candidate, BaseModel):
+            candidate = candidate.model_dump(mode="python")
         if isinstance(candidate, list):
             return _safe_validate(candidate)
         if hasattr(candidate, "tolist"):

--- a/src/anonymizer/engine/schemas.py
+++ b/src/anonymizer/engine/schemas.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -18,6 +18,13 @@ def _parse_raw_wrapper(
     fallback_keys: tuple[str, ...] = (),
 ) -> T:
     """Parse raw DataFrame cell value (dict, list, or numpy array) into a wrapper schema."""
+
+    def _safe_validate(candidate_list: list[object]) -> T:
+        try:
+            return model_cls.model_validate({key: candidate_list})
+        except ValidationError:
+            return model_cls()
+
     if isinstance(raw, dict):
         candidate = raw.get(key)
         if candidate is None:
@@ -26,18 +33,18 @@ def _parse_raw_wrapper(
                 if candidate is not None:
                     break
         if isinstance(candidate, list):
-            return model_cls.model_validate({key: candidate})
+            return _safe_validate(candidate)
         if hasattr(candidate, "tolist"):
             as_list = candidate.tolist()
             if isinstance(as_list, list):
-                return model_cls.model_validate({key: as_list})
+                return _safe_validate(as_list)
         return model_cls()
     if isinstance(raw, list):
-        return model_cls.model_validate({key: raw})
+        return _safe_validate(raw)
     if hasattr(raw, "tolist"):
         as_list = raw.tolist()
         if isinstance(as_list, list):
-            return model_cls.model_validate({key: as_list})
+            return _safe_validate(as_list)
     return model_cls()
 
 

--- a/src/anonymizer/engine/schemas.py
+++ b/src/anonymizer/engine/schemas.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TypeVar
+
+from pydantic import BaseModel, Field
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _parse_raw_wrapper(
+    model_cls: type[T],
+    raw: object,
+    key: str,
+    fallback_keys: tuple[str, ...] = (),
+) -> T:
+    """Parse raw DataFrame cell value (dict, list, or numpy array) into a wrapper schema."""
+    if isinstance(raw, dict):
+        candidate = raw.get(key)
+        if candidate is None:
+            for fk in fallback_keys:
+                candidate = raw.get(fk)
+                if candidate is not None:
+                    break
+        if isinstance(candidate, list):
+            return model_cls.model_validate({key: candidate})
+        if hasattr(candidate, "tolist"):
+            as_list = candidate.tolist()
+            if isinstance(as_list, list):
+                return model_cls.model_validate({key: as_list})
+        return model_cls()
+    if isinstance(raw, list):
+        return model_cls.model_validate({key: raw})
+    if hasattr(raw, "tolist"):
+        as_list = raw.tolist()
+        if isinstance(as_list, list):
+            return model_cls.model_validate({key: as_list})
+    return model_cls()
+
+
+# ---------------------------------------------------------------------------
+# Shared enums
+# ---------------------------------------------------------------------------
+
+
+class ValidationChoice(str, Enum):
+    keep = "keep"
+    reclass = "reclass"
+    drop = "drop"
+
+
+# ---------------------------------------------------------------------------
+# Entity schemas
+# ---------------------------------------------------------------------------
+
+
+class EntitySchema(BaseModel):
+    """Canonical entity span used across workflow columns."""
+
+    id: str = Field(default="")
+    value: str = Field(default="")
+    label: str = Field(default="")
+    start_position: int = Field(default=0)
+    end_position: int = Field(default=0)
+    score: float = Field(default=0.0)
+    source: str = Field(default="detector")
+
+
+class EntitiesSchema(BaseModel):
+    """Canonical ``{"entities": [...]}`` wrapper for entity spans."""
+
+    entities: list[EntitySchema] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: object) -> EntitiesSchema:
+        return _parse_raw_wrapper(cls, raw, "entities")
+
+
+# ---------------------------------------------------------------------------
+# Validation candidate schemas
+# ---------------------------------------------------------------------------
+
+
+class ValidationCandidateSchema(BaseModel):
+    id: str = Field(default="")
+    value: str = Field(default="")
+    label: str = Field(default="")
+    context_before: str = Field(default="")
+    context_after: str = Field(default="")
+
+
+class ValidationCandidatesSchema(BaseModel):
+    candidates: list[ValidationCandidateSchema] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: object) -> ValidationCandidatesSchema:
+        return _parse_raw_wrapper(cls, raw, "candidates", fallback_keys=("entities",))
+
+
+# ---------------------------------------------------------------------------
+# Raw validation decision schemas (LLM output before enrichment)
+# ---------------------------------------------------------------------------
+
+
+class RawValidationDecisionSchema(BaseModel):
+    id: str = Field(default="")
+    decision: ValidationChoice | None = None
+    proposed_label: str = Field(default="")
+    reason: str | None = None
+
+
+class RawValidationDecisionsSchema(BaseModel):
+    decisions: list[RawValidationDecisionSchema] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: object) -> RawValidationDecisionsSchema:
+        return _parse_raw_wrapper(cls, raw, "decisions")
+
+
+# ---------------------------------------------------------------------------
+# Validated (enriched) decision schemas
+# ---------------------------------------------------------------------------
+
+
+class ValidatedDecisionSchema(BaseModel):
+    id: str = Field(default="")
+    decision: ValidationChoice | None = None
+    proposed_label: str = Field(default="")
+    reason: str | None = None
+    value: str = Field(default="")
+    label: str = Field(default="")
+
+
+class ValidatedDecisionsSchema(BaseModel):
+    decisions: list[ValidatedDecisionSchema] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: object) -> ValidatedDecisionsSchema:
+        return _parse_raw_wrapper(cls, raw, "decisions")
+
+
+# ---------------------------------------------------------------------------
+# Validation skeleton schemas
+# ---------------------------------------------------------------------------
+
+
+class ValidationSkeletonDecisionSchema(BaseModel):
+    id: str = Field(default="")
+    value: str = Field(default="")
+    label: str = Field(default="")
+    decision: ValidationChoice | None = None
+    proposed_label: str | None = None
+    reason: str | None = None
+
+
+class ValidationSkeletonSchema(BaseModel):
+    decisions: list[ValidationSkeletonDecisionSchema] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: object) -> ValidationSkeletonSchema:
+        return _parse_raw_wrapper(cls, raw, "decisions")
+
+
+# ---------------------------------------------------------------------------
+# Entities-by-value schemas (grouped for replacement)
+# ---------------------------------------------------------------------------
+
+
+class EntityByValueSchema(BaseModel):
+    value: str = Field(default="")
+    labels: list[str] = Field(default_factory=list)
+
+
+class EntitiesByValueSchema(BaseModel):
+    entities_by_value: list[EntityByValueSchema] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: object) -> EntitiesByValueSchema:
+        return _parse_raw_wrapper(cls, raw, "entities_by_value", fallback_keys=("entities",))

--- a/src/anonymizer/engine/schemas/__init__.py
+++ b/src/anonymizer/engine/schemas/__init__.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from anonymizer.engine.schemas.detection import (
+    AugmentedEntitiesSchema,
+    AugmentedEntitySchema,
+    EntitiesByValueSchema,
+    EntitiesSchema,
+    EntityByValueSchema,
+    EntitySchema,
+    LatentCategory,
+    LatentConfidence,
+    LatentEntitiesSchema,
+    LatentEntitySchema,
+    RawValidationDecisionSchema,
+    RawValidationDecisionsSchema,
+    ValidatedDecisionSchema,
+    ValidatedDecisionsSchema,
+    ValidationCandidateSchema,
+    ValidationCandidatesSchema,
+    ValidationChoice,
+    ValidationDecisionSchema,
+    ValidationDecisionsSchema,
+    ValidationSkeletonDecisionSchema,
+    ValidationSkeletonSchema,
+)
+from anonymizer.engine.schemas.replace import EntityReplacementMapSchema, EntityReplacementSchema
+
+__all__ = [
+    "AugmentedEntitiesSchema",
+    "AugmentedEntitySchema",
+    "EntitiesByValueSchema",
+    "EntitiesSchema",
+    "EntityByValueSchema",
+    "EntityReplacementMapSchema",
+    "EntityReplacementSchema",
+    "EntitySchema",
+    "LatentCategory",
+    "LatentConfidence",
+    "LatentEntitiesSchema",
+    "LatentEntitySchema",
+    "RawValidationDecisionsSchema",
+    "RawValidationDecisionSchema",
+    "ValidatedDecisionsSchema",
+    "ValidatedDecisionSchema",
+    "ValidationCandidatesSchema",
+    "ValidationCandidateSchema",
+    "ValidationChoice",
+    "ValidationDecisionsSchema",
+    "ValidationDecisionSchema",
+    "ValidationSkeletonDecisionSchema",
+    "ValidationSkeletonSchema",
+]

--- a/src/anonymizer/engine/schemas/detection.py
+++ b/src/anonymizer/engine/schemas/detection.py
@@ -4,66 +4,16 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TypeVar
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
-T = TypeVar("T", bound=BaseModel)
-
-
-def _parse_raw_wrapper(
-    model_cls: type[T],
-    raw: object,
-    key: str,
-    fallback_keys: tuple[str, ...] = (),
-) -> T:
-    """Parse raw DataFrame cell value into a wrapper schema."""
-
-    def _safe_validate(candidate_list: list[object]) -> T:
-        try:
-            return model_cls.model_validate({key: candidate_list})
-        except ValidationError:
-            return model_cls()
-
-    if isinstance(raw, model_cls):
-        return raw
-    if isinstance(raw, BaseModel):
-        raw = raw.model_dump(mode="python")
-
-    if isinstance(raw, dict):
-        candidate = raw.get(key)
-        if candidate is None:
-            for fk in fallback_keys:
-                candidate = raw.get(fk)
-                if candidate is not None:
-                    break
-        if isinstance(candidate, model_cls):
-            return candidate
-        if isinstance(candidate, BaseModel):
-            candidate = candidate.model_dump(mode="python")
-        if isinstance(candidate, list):
-            return _safe_validate(candidate)
-        if hasattr(candidate, "tolist"):
-            as_list = candidate.tolist()
-            if isinstance(as_list, list):
-                return _safe_validate(as_list)
-    return model_cls()
-
-
-# ---------------------------------------------------------------------------
-# Shared enums
-# ---------------------------------------------------------------------------
+from anonymizer.engine.schemas.shared import _parse_raw_wrapper
 
 
 class ValidationChoice(str, Enum):
     keep = "keep"
     reclass = "reclass"
     drop = "drop"
-
-
-# ---------------------------------------------------------------------------
-# Entity schemas
-# ---------------------------------------------------------------------------
 
 
 class EntitySchema(BaseModel):
@@ -88,11 +38,6 @@ class EntitiesSchema(BaseModel):
         return _parse_raw_wrapper(cls, raw, "entities")
 
 
-# ---------------------------------------------------------------------------
-# Validation candidate schemas
-# ---------------------------------------------------------------------------
-
-
 class ValidationCandidateSchema(BaseModel):
     id: str = Field(default="")
     value: str = Field(default="")
@@ -107,11 +52,6 @@ class ValidationCandidatesSchema(BaseModel):
     @classmethod
     def from_raw(cls, raw: object) -> ValidationCandidatesSchema:
         return _parse_raw_wrapper(cls, raw, "candidates", fallback_keys=("entities",))
-
-
-# ---------------------------------------------------------------------------
-# Raw validation decision schemas (LLM output before enrichment)
-# ---------------------------------------------------------------------------
 
 
 class RawValidationDecisionSchema(BaseModel):
@@ -129,16 +69,7 @@ class RawValidationDecisionsSchema(BaseModel):
         return _parse_raw_wrapper(cls, raw, "decisions")
 
 
-# ---------------------------------------------------------------------------
-# Validated (enriched) decision schemas
-# ---------------------------------------------------------------------------
-
-
-class ValidatedDecisionSchema(BaseModel):
-    id: str = Field(default="")
-    decision: ValidationChoice | None = None
-    proposed_label: str = Field(default="")
-    reason: str | None = None
+class ValidatedDecisionSchema(RawValidationDecisionSchema):
     value: str = Field(default="")
     label: str = Field(default="")
 
@@ -149,11 +80,6 @@ class ValidatedDecisionsSchema(BaseModel):
     @classmethod
     def from_raw(cls, raw: object) -> ValidatedDecisionsSchema:
         return _parse_raw_wrapper(cls, raw, "decisions")
-
-
-# ---------------------------------------------------------------------------
-# Validation skeleton schemas
-# ---------------------------------------------------------------------------
 
 
 class ValidationSkeletonDecisionSchema(BaseModel):
@@ -173,9 +99,72 @@ class ValidationSkeletonSchema(BaseModel):
         return _parse_raw_wrapper(cls, raw, "decisions")
 
 
-# ---------------------------------------------------------------------------
-# Entities-by-value schemas (grouped for replacement)
-# ---------------------------------------------------------------------------
+class ValidationDecisionSchema(BaseModel):
+    """Per-entity validation decision from the LLM validator."""
+
+    id: str
+    value: str = Field(default="", description="Entity value (echoed from skeleton)")
+    label: str = Field(default="", description="Entity label (echoed from skeleton)")
+    decision: ValidationChoice
+    proposed_label: str = Field(
+        default="",
+        description="Correct label when decision is 'reclass', otherwise empty",
+    )
+    reason: str | None = None
+
+
+class ValidationDecisionsSchema(BaseModel):
+    decisions: list[ValidationDecisionSchema] = Field(default_factory=list)
+
+
+class AugmentedEntitySchema(BaseModel):
+    value: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    reason: str | None = None
+
+
+class AugmentedEntitiesSchema(BaseModel):
+    entities: list[AugmentedEntitySchema] = Field(default_factory=list)
+
+
+class LatentCategory(str, Enum):
+    latent_identifier = "latent_identifier"
+    latent_sensitive_attribute = "latent_sensitive_attribute"
+
+
+class LatentConfidence(str, Enum):
+    high = "high"
+    medium = "medium"
+
+
+class LatentEntitySchema(BaseModel):
+    category: LatentCategory
+    label: str = Field(
+        min_length=1,
+        description=(
+            "General category/class of the inference in snake_case "
+            "(e.g., employer, specific_institution, home_location, medication, health_condition)"
+        ),
+    )
+    value: str = Field(
+        min_length=1,
+        description="Concise inferred value (generalize if not pinned down strongly by evidence)",
+    )
+    confidence: LatentConfidence
+    evidence: list[str] = Field(
+        min_length=1,
+        max_length=2,
+        description="One or two short quotes from the text that support this inference",
+    )
+    rationale: str = Field(
+        min_length=20,
+        max_length=150,
+        description="One sentence explaining the inference without adding new facts",
+    )
+
+
+class LatentEntitiesSchema(BaseModel):
+    latent_entities: list[LatentEntitySchema] = Field(default_factory=list)
 
 
 class EntityByValueSchema(BaseModel):

--- a/src/anonymizer/engine/schemas/replace.py
+++ b/src/anonymizer/engine/schemas/replace.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class EntityReplacementSchema(BaseModel):
+    original: str = Field(min_length=1, description="The original entity value")
+    label: str = Field(min_length=1, description="The entity label/type")
+    synthetic: str = Field(min_length=1, description="The synthetic replacement value")
+
+
+class EntityReplacementMapSchema(BaseModel):
+    replacements: list[EntityReplacementSchema] = Field(default_factory=list, description="List of entity replacements")

--- a/src/anonymizer/engine/schemas/shared.py
+++ b/src/anonymizer/engine/schemas/shared.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _parse_raw_wrapper(
+    model_cls: type[T],
+    raw: object,
+    key: str,
+    fallback_keys: tuple[str, ...] = (),
+) -> T:
+    """Parse raw DataFrame cell value into a wrapper schema."""
+
+    def _safe_validate(candidate_list: list[object]) -> T:
+        try:
+            return model_cls.model_validate({key: candidate_list})
+        except ValidationError:
+            return model_cls()
+
+    if isinstance(raw, model_cls):
+        return raw
+    if isinstance(raw, BaseModel):
+        raw = raw.model_dump(mode="python")
+
+    if isinstance(raw, dict):
+        candidate = raw.get(key)
+        if candidate is None:
+            for fk in fallback_keys:
+                candidate = raw.get(fk)
+                if candidate is not None:
+                    break
+        if isinstance(candidate, model_cls):
+            return candidate
+        if isinstance(candidate, BaseModel):
+            candidate = candidate.model_dump(mode="python")
+        if isinstance(candidate, list):
+            return _safe_validate(candidate)
+        if hasattr(candidate, "tolist"):
+            as_list = candidate.tolist()
+            if isinstance(as_list, list):
+                return _safe_validate(as_list)
+    return model_cls()

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -123,6 +123,7 @@ class Anonymizer:
             privacy_goal=config.rewrite.privacy_goal if config.rewrite else None,
             data_summary=data.data_summary,
             tag_latent_entities=config.rewrite is not None,
+            compute_grouped_entities=True if config.replace is not None else None,
             preview_num_records=preview_num_records,
         )
 

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -59,7 +59,7 @@ def render_record_html(row: pd.Series, record_index: int | None = None, original
     text_col = original_text_column or "text"
     text = str(row.get(text_col, ""))
     replaced_text = str(row.get(f"{text_col}_replaced", ""))
-    entities = EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, [])).entities
+    entities = EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, {})).entities
     replacement_map = _normalize_replacement_map(row.get(COL_REPLACEMENT_MAP, {}))
 
     if not entities and replacement_map:

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -166,11 +166,7 @@ def _build_replaced_entities(
         end = entity.end_position
         value = entity.value
         label = entity.label
-        if (
-            start < original_cursor
-            or end <= start
-            or end > len(original_text)
-        ):
+        if start < original_cursor or end <= start or end > len(original_text):
             continue
 
         synthetic = _resolve_synthetic(value, label, lookups)

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import html
 import json
 import re
-from typing import Any
 
 import pandas as pd
 
 from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_REPLACEMENT_MAP
+from anonymizer.engine.schemas import EntitiesSchema, EntitySchema
 
 ENTITY_COLORS: list[str] = [
     "#dbeafe",  # blue
@@ -59,7 +59,7 @@ def render_record_html(row: pd.Series, record_index: int | None = None, original
     text_col = original_text_column or "text"
     text = str(row.get(text_col, ""))
     replaced_text = str(row.get(f"{text_col}_replaced", ""))
-    entities = _normalize_entity_list(row.get(COL_DETECTED_ENTITIES, []))
+    entities = EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, [])).entities
     replacement_map = _normalize_replacement_map(row.get(COL_REPLACEMENT_MAP, {}))
 
     if not entities and replacement_map:
@@ -67,7 +67,7 @@ def render_record_html(row: pd.Series, record_index: int | None = None, original
 
     original_html = _render_highlighted_text(text, entities)
 
-    replaced_entities = _build_replaced_entities(entities, replacement_map, text, replaced_text)
+    replaced_entities = _build_replaced_entities(entities, replacement_map, text)
     if not replaced_entities and replacement_map:
         replaced_entities = _build_replaced_entities_from_map(replacement_map, replaced_text)
     replaced_html = _render_highlighted_text(replaced_text, replaced_entities)
@@ -83,45 +83,44 @@ def render_record_html(row: pd.Series, record_index: int | None = None, original
     )
 
 
-def _render_highlighted_text(text: str, entities: list[dict[str, Any]]) -> str:
+def _render_highlighted_text(text: str, entities: list[EntitySchema]) -> str:
     """Render text with inline entity highlights using positioned spans."""
     if not entities:
         return f"<span>{html.escape(text)}</span>"
 
-    sorted_entities = sorted(entities, key=lambda e: (int(e.get("start_position", 0)), int(e.get("end_position", 0))))
+    sorted_entities = sorted(entities, key=lambda e: (e.start_position, e.end_position))
 
     parts: list[str] = []
     cursor = 0
     for entity in sorted_entities:
-        start = int(entity.get("start_position", 0))
-        end = int(entity.get("end_position", 0))
-        label = str(entity.get("label", ""))
-
-        if start < cursor or end <= start or end > len(text):
+        if (
+            entity.start_position < cursor
+            or entity.end_position <= entity.start_position
+            or entity.end_position > len(text)
+        ):
             continue
 
-        _, border_color = _color_for_label(label)
-        parts.append(html.escape(text[cursor:start]))
-        entity_value = html.escape(text[start:end])
+        _, border_color = _color_for_label(entity.label)
+        parts.append(html.escape(text[cursor : entity.start_position]))
+        entity_value = html.escape(text[entity.start_position : entity.end_position])
         parts.append(
             f'<span style="border:1.5px solid {border_color};'
             f'padding:1px 4px;border-radius:3px">'
             f"{entity_value}"
             f'<span style="color:{border_color};font-size:0.75em;font-weight:600;'
-            f'margin-left:3px;opacity:0.85">| {html.escape(label)}</span></span>'
+            f'margin-left:3px;opacity:0.85">| {html.escape(entity.label)}</span></span>'
         )
-        cursor = end
+        cursor = entity.end_position
 
     parts.append(html.escape(text[cursor:]))
     return "".join(parts)
 
 
 def _build_replaced_entities(
-    original_entities: list[dict[str, Any]],
+    original_entities: list[EntitySchema],
     replacement_map: list[dict[str, str]],
     original_text: str,
-    replaced_text: str,
-) -> list[dict[str, Any]]:
+) -> list[EntitySchema]:
     """Compute entity positions in the replaced text by replaying the replacement splicing."""
     by_value_label: dict[tuple[str, str], str] = {}
     by_value: dict[str, str] = {}
@@ -132,39 +131,35 @@ def _build_replaced_entities(
         by_value_label[(orig, label)] = synth
         by_value[orig] = synth
 
-    sorted_entities = sorted(
-        original_entities,
-        key=lambda e: (int(e.get("start_position", 0)), int(e.get("end_position", 0))),
-    )
+    sorted_entities = sorted(original_entities, key=lambda e: (e.start_position, e.end_position))
 
-    replaced_entities: list[dict[str, Any]] = []
+    replaced_entities: list[EntitySchema] = []
     original_cursor = 0
     replaced_cursor = 0
 
     for entity in sorted_entities:
-        start = int(entity.get("start_position", 0))
-        end = int(entity.get("end_position", 0))
-        value = str(entity.get("value", ""))
-        label = str(entity.get("label", ""))
-
-        if start < original_cursor or end <= start or end > len(original_text):
+        if (
+            entity.start_position < original_cursor
+            or entity.end_position <= entity.start_position
+            or entity.end_position > len(original_text)
+        ):
             continue
 
-        gap = start - original_cursor
+        gap = entity.start_position - original_cursor
         replaced_cursor += gap
 
-        synthetic = by_value_label.get((value, label), by_value.get(value, value))
+        synthetic = by_value_label.get((entity.value, entity.label), by_value.get(entity.value, entity.value))
         replaced_entities.append(
-            {
-                "value": synthetic,
-                "label": label,
-                "start_position": replaced_cursor,
-                "end_position": replaced_cursor + len(synthetic),
-            }
+            EntitySchema(
+                value=synthetic,
+                label=entity.label,
+                start_position=replaced_cursor,
+                end_position=replaced_cursor + len(synthetic),
+            )
         )
 
         replaced_cursor += len(synthetic)
-        original_cursor = end
+        original_cursor = entity.end_position
 
     return replaced_entities
 
@@ -172,14 +167,14 @@ def _build_replaced_entities(
 def _build_original_entities_from_map(
     replacement_map: list[dict[str, str]],
     original_text: str,
-) -> list[dict[str, Any]]:
+) -> list[EntitySchema]:
     """Build entity positions by finding original values in original text.
 
     Fallback when _detected_entities is empty but replacement_map exists.
     Uses case-insensitive matching to align with how the detection engine
     finds entities (e.g. "The Lantern" matching "the Lantern" in text).
     """
-    result: list[dict[str, Any]] = []
+    result: list[EntitySchema] = []
     for entry in replacement_map:
         original = str(entry.get("original", ""))
         label = str(entry.get("label", ""))
@@ -187,26 +182,26 @@ def _build_original_entities_from_map(
             continue
         for match in re.finditer(re.escape(original), original_text, flags=re.IGNORECASE):
             result.append(
-                {
-                    "value": original_text[match.start() : match.end()],
-                    "label": label,
-                    "start_position": match.start(),
-                    "end_position": match.end(),
-                }
+                EntitySchema(
+                    value=original_text[match.start() : match.end()],
+                    label=label,
+                    start_position=match.start(),
+                    end_position=match.end(),
+                )
             )
-    return sorted(result, key=lambda e: (e["start_position"], e["end_position"]))
+    return sorted(result, key=lambda e: (e.start_position, e.end_position))
 
 
 def _build_replaced_entities_from_map(
     replacement_map: list[dict[str, str]],
     replaced_text: str,
-) -> list[dict[str, Any]]:
+) -> list[EntitySchema]:
     """Build entity positions by finding synthetic values in replaced text.
 
     Fallback when _detected_entities is empty but replacement_map exists (e.g. LLM
     replace path where entity format differs).
     """
-    result: list[dict[str, Any]] = []
+    result: list[EntitySchema] = []
     for entry in replacement_map:
         synthetic = str(entry.get("synthetic", ""))
         label = str(entry.get("label", ""))
@@ -218,15 +213,15 @@ def _build_replaced_entities_from_map(
             if pos < 0:
                 break
             result.append(
-                {
-                    "value": synthetic,
-                    "label": label,
-                    "start_position": pos,
-                    "end_position": pos + len(synthetic),
-                }
+                EntitySchema(
+                    value=synthetic,
+                    label=label,
+                    start_position=pos,
+                    end_position=pos + len(synthetic),
+                )
             )
             start = pos + len(synthetic)
-    return sorted(result, key=lambda e: (e["start_position"], e["end_position"]))
+    return sorted(result, key=lambda e: (e.start_position, e.end_position))
 
 
 def _render_replacement_table(replacement_map: list[dict[str, str]]) -> str:
@@ -259,32 +254,28 @@ def _render_replacement_table(replacement_map: list[dict[str, str]]) -> str:
     )
 
 
-def _normalize_entity_list(raw: Any) -> list[dict[str, Any]]:
-    if isinstance(raw, list):
-        return [e for e in raw if isinstance(e, dict)]
-    return []
-
-
-def _normalize_replacement_map(raw: Any) -> list[dict[str, str]]:
-    parsed: Any = raw
+def _normalize_replacement_map(raw: str | dict | object) -> list[dict[str, str]]:
     if isinstance(raw, str):
         try:
-            parsed = json.loads(raw)
+            data = json.loads(raw)
         except json.JSONDecodeError:
             return []
     elif hasattr(raw, "model_dump"):
-        parsed = raw.model_dump()
-    if isinstance(parsed, dict):
-        replacements = parsed.get("replacements", [])
-        if isinstance(replacements, list):
-            result: list[dict[str, str]] = []
-            for r in replacements:
-                if isinstance(r, dict):
-                    result.append(r)
-                elif hasattr(r, "model_dump"):
-                    result.append(r.model_dump())
-            return result
-    return []
+        data = raw.model_dump()
+    else:
+        data = raw
+    if not isinstance(data, dict):
+        return []
+    replacements = data.get("replacements", [])
+    if not isinstance(replacements, list):
+        return []
+    result: list[dict[str, str]] = []
+    for r in replacements:
+        if isinstance(r, dict):
+            result.append(r)
+        elif hasattr(r, "model_dump"):
+            result.append(r.model_dump())
+    return result
 
 
 _TEMPLATE = """\

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def stub_entities() -> list[dict]:
 
 @pytest.fixture
 def stub_dataframe_with_entities(stub_dataframe: pd.DataFrame, stub_entities: list[dict]) -> pd.DataFrame:
-    """DataFrame with text + detected entities — input shape for replace runner."""
+    """DataFrame with text + detected entities — canonical dict-wrapped shape from detection."""
     df = stub_dataframe.copy()
-    df[COL_FINAL_ENTITIES] = [stub_entities]
+    df[COL_FINAL_ENTITIES] = [{"entities": stub_entities}]
     return df

--- a/tests/engine/test_detection_custom_columns.py
+++ b/tests/engine/test_detection_custom_columns.py
@@ -23,9 +23,11 @@ from anonymizer.engine.constants import (
     COL_VALIDATED_ENTITIES,
     COL_VALIDATION_CANDIDATES,
     COL_VALIDATION_DECISIONS,
+    COL_VALIDATION_SKELETON,
 )
 from anonymizer.engine.detection.custom_columns import (
     _from_dicts,
+    build_validation_skeleton,
     enrich_validation_decisions,
     parse_detected_entities,
 )
@@ -105,4 +107,45 @@ def test_enrich_validation_decisions_ignores_non_dict_validation_payload() -> No
         ],
     }
     result = enrich_validation_decisions(row)
-    assert result == row
+    assert result[COL_VALIDATED_ENTITIES] == {"decisions": []}
+
+
+def test_build_validation_skeleton_produces_null_decisions() -> None:
+    row: dict[str, Any] = {
+        COL_VALIDATION_CANDIDATES: [
+            {
+                "id": "first_name_0_5",
+                "value": "Alice",
+                "label": "first_name",
+                "context_before": "",
+                "context_after": " works",
+            },
+            {"id": "org_15_19", "value": "Acme", "label": "organization", "context_before": "at ", "context_after": ""},
+        ],
+    }
+    result = build_validation_skeleton(row)
+    skeleton = result[COL_VALIDATION_SKELETON]
+    assert len(skeleton["decisions"]) == 2
+    assert skeleton["decisions"][0]["id"] == "first_name_0_5"
+    assert skeleton["decisions"][0]["value"] == "Alice"
+    assert skeleton["decisions"][0]["label"] == "first_name"
+    assert skeleton["decisions"][0]["decision"] is None
+    assert skeleton["decisions"][0]["proposed_label"] is None
+    assert skeleton["decisions"][1]["id"] == "org_15_19"
+
+
+def test_build_validation_skeleton_handles_candidates_with_missing_keys() -> None:
+    row: dict[str, Any] = {
+        COL_VALIDATION_CANDIDATES: [
+            {"id": "x"},
+            {"value": "Alice"},
+            {},
+        ],
+    }
+    result = build_validation_skeleton(row)
+    skeleton = result[COL_VALIDATION_SKELETON]
+    assert len(skeleton["decisions"]) == 3
+    assert skeleton["decisions"][0]["id"] == "x"
+    assert skeleton["decisions"][0]["value"] == ""
+    assert skeleton["decisions"][1]["id"] == ""
+    assert skeleton["decisions"][1]["value"] == "Alice"

--- a/tests/engine/test_detection_custom_columns.py
+++ b/tests/engine/test_detection_custom_columns.py
@@ -20,9 +20,13 @@ from anonymizer.engine.constants import (
     COL_SEED_ENTITIES_JSON,
     COL_TAG_NOTATION,
     COL_TEXT,
+    COL_VALIDATED_ENTITIES,
+    COL_VALIDATION_CANDIDATES,
+    COL_VALIDATION_DECISIONS,
 )
 from anonymizer.engine.detection.custom_columns import (
     _from_dicts,
+    enrich_validation_decisions,
     parse_detected_entities,
 )
 
@@ -63,3 +67,42 @@ def test_parse_produces_valid_tagged_text_and_notation() -> None:
     assert "phone_number" in result[COL_INITIAL_TAGGED_TEXT]
     assert result[COL_TAG_NOTATION] in {"xml", "bracket", "paren", "sentinel"}
     assert json.loads(result[COL_SEED_ENTITIES_JSON]) == result[COL_SEED_ENTITIES]
+
+
+def test_enrich_validation_decisions_adds_value_from_candidates() -> None:
+    row = {
+        COL_VALIDATION_DECISIONS: {
+            "decisions": [
+                {"id": "id1", "decision": "keep", "proposed_label": "", "reason": "direct identifier"},
+                {"id": "id2", "decision": "drop", "proposed_label": "", "reason": "placeholder"},
+            ]
+        },
+        COL_VALIDATION_CANDIDATES: [
+            {"id": "id1", "value": "Alice", "label": "first_name", "context_before": "", "context_after": ""},
+            {"id": "id2", "value": "name", "label": "first_name", "context_before": "", "context_after": ""},
+        ],
+    }
+    result = enrich_validation_decisions(row)
+    decisions = result[COL_VALIDATED_ENTITIES]["decisions"]
+    assert decisions[0]["value"] == "Alice"
+    assert decisions[1]["value"] == "name"
+
+
+def test_enrich_validation_decisions_filters_unknown_ids() -> None:
+    row = {
+        COL_VALIDATION_DECISIONS: {"decisions": [{"id": "unknown_id", "decision": "keep", "proposed_label": ""}]},
+        COL_VALIDATION_CANDIDATES: [],
+    }
+    result = enrich_validation_decisions(row)
+    assert result[COL_VALIDATED_ENTITIES]["decisions"] == []
+
+
+def test_enrich_validation_decisions_ignores_non_dict_validation_payload() -> None:
+    row = {
+        COL_VALIDATION_DECISIONS: "unexpected-string-payload",
+        COL_VALIDATION_CANDIDATES: [
+            {"id": "id1", "value": "Alice", "label": "first_name", "context_before": "", "context_after": ""}
+        ],
+    }
+    result = enrich_validation_decisions(row)
+    assert result == row

--- a/tests/engine/test_detection_custom_columns.py
+++ b/tests/engine/test_detection_custom_columns.py
@@ -79,10 +79,12 @@ def test_enrich_validation_decisions_adds_value_from_candidates() -> None:
                 {"id": "id2", "decision": "drop", "proposed_label": "", "reason": "placeholder"},
             ]
         },
-        COL_VALIDATION_CANDIDATES: [
-            {"id": "id1", "value": "Alice", "label": "first_name", "context_before": "", "context_after": ""},
-            {"id": "id2", "value": "name", "label": "first_name", "context_before": "", "context_after": ""},
-        ],
+        COL_VALIDATION_CANDIDATES: {
+            "candidates": [
+                {"id": "id1", "value": "Alice", "label": "first_name", "context_before": "", "context_after": ""},
+                {"id": "id2", "value": "name", "label": "first_name", "context_before": "", "context_after": ""},
+            ]
+        },
     }
     result = enrich_validation_decisions(row)
     decisions = result[COL_VALIDATED_ENTITIES]["decisions"]
@@ -93,7 +95,7 @@ def test_enrich_validation_decisions_adds_value_from_candidates() -> None:
 def test_enrich_validation_decisions_filters_unknown_ids() -> None:
     row = {
         COL_VALIDATION_DECISIONS: {"decisions": [{"id": "unknown_id", "decision": "keep", "proposed_label": ""}]},
-        COL_VALIDATION_CANDIDATES: [],
+        COL_VALIDATION_CANDIDATES: {"candidates": []},
     }
     result = enrich_validation_decisions(row)
     assert result[COL_VALIDATED_ENTITIES]["decisions"] == []
@@ -102,9 +104,11 @@ def test_enrich_validation_decisions_filters_unknown_ids() -> None:
 def test_enrich_validation_decisions_ignores_non_dict_validation_payload() -> None:
     row = {
         COL_VALIDATION_DECISIONS: "unexpected-string-payload",
-        COL_VALIDATION_CANDIDATES: [
-            {"id": "id1", "value": "Alice", "label": "first_name", "context_before": "", "context_after": ""}
-        ],
+        COL_VALIDATION_CANDIDATES: {
+            "candidates": [
+                {"id": "id1", "value": "Alice", "label": "first_name", "context_before": "", "context_after": ""}
+            ]
+        },
     }
     result = enrich_validation_decisions(row)
     assert result[COL_VALIDATED_ENTITIES] == {"decisions": []}
@@ -112,16 +116,24 @@ def test_enrich_validation_decisions_ignores_non_dict_validation_payload() -> No
 
 def test_build_validation_skeleton_produces_null_decisions() -> None:
     row: dict[str, Any] = {
-        COL_VALIDATION_CANDIDATES: [
-            {
-                "id": "first_name_0_5",
-                "value": "Alice",
-                "label": "first_name",
-                "context_before": "",
-                "context_after": " works",
-            },
-            {"id": "org_15_19", "value": "Acme", "label": "organization", "context_before": "at ", "context_after": ""},
-        ],
+        COL_VALIDATION_CANDIDATES: {
+            "candidates": [
+                {
+                    "id": "first_name_0_5",
+                    "value": "Alice",
+                    "label": "first_name",
+                    "context_before": "",
+                    "context_after": " works",
+                },
+                {
+                    "id": "org_15_19",
+                    "value": "Acme",
+                    "label": "organization",
+                    "context_before": "at ",
+                    "context_after": "",
+                },
+            ]
+        },
     }
     result = build_validation_skeleton(row)
     skeleton = result[COL_VALIDATION_SKELETON]
@@ -136,11 +148,13 @@ def test_build_validation_skeleton_produces_null_decisions() -> None:
 
 def test_build_validation_skeleton_handles_candidates_with_missing_keys() -> None:
     row: dict[str, Any] = {
-        COL_VALIDATION_CANDIDATES: [
-            {"id": "x"},
-            {"value": "Alice"},
-            {},
-        ],
+        COL_VALIDATION_CANDIDATES: {
+            "candidates": [
+                {"id": "x"},
+                {"value": "Alice"},
+                {},
+            ]
+        },
     }
     result = build_validation_skeleton(row)
     skeleton = result[COL_VALIDATION_SKELETON]

--- a/tests/engine/test_detection_custom_columns.py
+++ b/tests/engine/test_detection_custom_columns.py
@@ -14,7 +14,11 @@ import json
 from typing import Any
 
 from anonymizer.engine.constants import (
+    COL_AUGMENTED_ENTITIES,
+    COL_DETECTED_ENTITIES,
+    COL_ENTITIES_BY_VALUE,
     COL_INITIAL_TAGGED_TEXT,
+    COL_MERGED_ENTITIES,
     COL_RAW_DETECTED,
     COL_SEED_ENTITIES,
     COL_SEED_ENTITIES_JSON,
@@ -26,20 +30,22 @@ from anonymizer.engine.constants import (
     COL_VALIDATION_SKELETON,
 )
 from anonymizer.engine.detection.custom_columns import (
-    _from_dicts,
+    _parse_entity_spans,
+    apply_validation_and_finalize,
     build_validation_skeleton,
     enrich_validation_decisions,
+    merge_and_build_candidates,
     parse_detected_entities,
 )
 
 
-def test_from_dicts_handles_empty_list() -> None:
-    assert _from_dicts([]) == []
+def test_parse_entity_spans_handles_malformed_payload() -> None:
+    assert _parse_entity_spans([]) == []
 
 
-def test_from_dicts_defaults_missing_keys() -> None:
+def test_parse_entity_spans_defaults_missing_keys() -> None:
     """After a parquet round-trip some keys may be absent."""
-    spans = _from_dicts([{"value": "Bob", "label": "first_name"}])
+    spans = _parse_entity_spans({"entities": [{"value": "Bob", "label": "first_name"}]})
     assert spans[0].entity_id == ""
     assert spans[0].start_position == 0
     assert spans[0].score == 0.0
@@ -68,7 +74,33 @@ def test_parse_produces_valid_tagged_text_and_notation() -> None:
     assert "(555) 123-4567" in result[COL_INITIAL_TAGGED_TEXT]
     assert "phone_number" in result[COL_INITIAL_TAGGED_TEXT]
     assert result[COL_TAG_NOTATION] in {"xml", "bracket", "paren", "sentinel"}
-    assert json.loads(result[COL_SEED_ENTITIES_JSON]) == result[COL_SEED_ENTITIES]
+    assert json.loads(result[COL_SEED_ENTITIES_JSON]) == result[COL_SEED_ENTITIES]["entities"]
+
+
+def test_merge_and_build_candidates_writes_schema_shaped_payloads() -> None:
+    row: dict[str, Any] = {
+        COL_TEXT: "Alice works at Acme in Seattle.",
+        COL_SEED_ENTITIES: {
+            "entities": [
+                {
+                    "id": "first_name_0_5",
+                    "value": "Alice",
+                    "label": "first_name",
+                    "start_position": 0,
+                    "end_position": 5,
+                    "score": 0.95,
+                    "source": "detector",
+                }
+            ]
+        },
+        COL_AUGMENTED_ENTITIES: {"entities": []},
+    }
+
+    result = merge_and_build_candidates(row)
+    assert "entities" in result[COL_MERGED_ENTITIES]
+    assert isinstance(result[COL_MERGED_ENTITIES]["entities"], list)
+    assert "candidates" in result[COL_VALIDATION_CANDIDATES]
+    assert isinstance(result[COL_VALIDATION_CANDIDATES]["candidates"], list)
 
 
 def test_enrich_validation_decisions_adds_value_from_candidates() -> None:
@@ -163,3 +195,39 @@ def test_build_validation_skeleton_handles_candidates_with_missing_keys() -> Non
     assert skeleton["decisions"][0]["value"] == ""
     assert skeleton["decisions"][1]["id"] == ""
     assert skeleton["decisions"][1]["value"] == "Alice"
+
+
+def test_apply_validation_and_finalize_writes_schema_shaped_entities_by_value() -> None:
+    row: dict[str, Any] = {
+        COL_TEXT: "Alice works at Acme.",
+        COL_MERGED_ENTITIES: {
+            "entities": [
+                {
+                    "id": "first_name_0_5",
+                    "value": "Alice",
+                    "label": "first_name",
+                    "start_position": 0,
+                    "end_position": 5,
+                    "score": 0.95,
+                    "source": "detector",
+                }
+            ]
+        },
+        COL_VALIDATED_ENTITIES: {"decisions": []},
+    }
+
+    result = apply_validation_and_finalize(row)
+    assert "entities_by_value" in result[COL_ENTITIES_BY_VALUE]
+    assert isinstance(result[COL_ENTITIES_BY_VALUE]["entities_by_value"], list)
+
+
+def test_apply_validation_and_finalize_handles_malformed_merged_entities() -> None:
+    row: dict[str, Any] = {
+        COL_TEXT: "Alice works at Acme.",
+        COL_MERGED_ENTITIES: ["bad-shape"],
+        COL_VALIDATED_ENTITIES: {"decisions": []},
+    }
+
+    result = apply_validation_and_finalize(row)
+    assert result[COL_DETECTED_ENTITIES] == {"entities": []}
+    assert result[COL_ENTITIES_BY_VALUE] == {"entities_by_value": []}

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -43,7 +43,7 @@ def test_run_with_latent_detection_calls_second_workflow(
                 {
                     COL_TEXT: ["Alice works in Seattle"],
                     COL_TAGGED_TEXT: ["<first_name>Alice</first_name> works in <city>Seattle</city>"],
-                    COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                    COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
                 }
             ),
             failed_records=[],
@@ -53,7 +53,7 @@ def test_run_with_latent_detection_calls_second_workflow(
                 {
                     COL_TEXT: ["Alice works in Seattle"],
                     COL_TAGGED_TEXT: ["<first_name>Alice</first_name> works in <city>Seattle</city>"],
-                    COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                    COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
                     COL_LATENT_ENTITIES: [[{"value": "Acme Corp", "label": "organization", "sensitivity": "medium"}]],
                 }
             ),
@@ -112,7 +112,7 @@ def test_run_without_latent_detection_materializes_final_entities(
         dataframe=pd.DataFrame(
             {
                 COL_TEXT: ["Alice works in Seattle"],
-                COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
             }
         ),
         failed_records=[],
@@ -146,8 +146,8 @@ def test_run_compute_grouped_entities_false_drops_grouped_column(
         dataframe=pd.DataFrame(
             {
                 COL_TEXT: ["Alice works in Seattle"],
-                COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
-                COL_ENTITIES_BY_VALUE: [[{"value": "Alice", "labels": ["first_name"]}]],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
+                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
             }
         ),
         failed_records=[],
@@ -174,7 +174,7 @@ def test_run_preserves_original_text_column_attr(
         dataframe=pd.DataFrame(
             {
                 COL_TEXT: ["Alice works in Seattle"],
-                COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
             }
         ),
         failed_records=[],
@@ -203,7 +203,7 @@ def test_run_with_latent_detection_merges_failures_in_order(
             dataframe=pd.DataFrame(
                 {
                     COL_TEXT: ["Alice works in Seattle"],
-                    COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                    COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
                 }
             ),
             failed_records=[FailedRecord(record_id="d1", step="entity-detection", reason="detected failure")],
@@ -212,7 +212,7 @@ def test_run_with_latent_detection_merges_failures_in_order(
             dataframe=pd.DataFrame(
                 {
                     COL_TEXT: ["Alice works in Seattle"],
-                    COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                    COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
                     COL_LATENT_ENTITIES: [[{"value": "Acme Corp", "label": "organization", "sensitivity": "medium"}]],
                 }
             ),
@@ -243,8 +243,8 @@ def test_detect_and_validate_entities_drops_grouped_when_compute_grouped_false(
         dataframe=pd.DataFrame(
             {
                 COL_TEXT: ["Alice works in Seattle"],
-                COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
-                COL_ENTITIES_BY_VALUE: [[{"value": "Alice", "labels": ["first_name"]}]],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
+                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
             }
         ),
         failed_records=[],

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -130,9 +130,11 @@ def test_run_without_latent_detection_materializes_final_entities(
 
     assert adapter.run_workflow.call_count == 1
     assert COL_FINAL_ENTITIES in result.dataframe.columns
-    detected = result.dataframe[COL_DETECTED_ENTITIES].tolist()
-    final = result.dataframe[COL_FINAL_ENTITIES].tolist()
-    assert final == [{"entities": row} for row in detected]
+    final = result.dataframe[COL_FINAL_ENTITIES].iloc[0]
+    assert isinstance(final, dict)
+    assert len(final["entities"]) == 1
+    assert final["entities"][0]["value"] == "Alice"
+    assert final["entities"][0]["label"] == "first_name"
 
 
 def test_run_compute_grouped_entities_false_drops_grouped_column(

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -130,7 +130,9 @@ def test_run_without_latent_detection_materializes_final_entities(
 
     assert adapter.run_workflow.call_count == 1
     assert COL_FINAL_ENTITIES in result.dataframe.columns
-    assert result.dataframe[COL_FINAL_ENTITIES].tolist() == result.dataframe[COL_DETECTED_ENTITIES].tolist()
+    detected = result.dataframe[COL_DETECTED_ENTITIES].tolist()
+    final = result.dataframe[COL_FINAL_ENTITIES].tolist()
+    assert final == [{"entities": row} for row in detected]
 
 
 def test_run_compute_grouped_entities_false_drops_grouped_column(
@@ -349,6 +351,9 @@ def test_validation_prompt_includes_label_examples() -> None:
     assert "Here are all the valid entity classes with examples" in prompt
     assert "- email: derez_lester94@icloud.com" in prompt
     assert "- city: Houston, San Diego, Doha, Lahore" in prompt
+    assert "Copy ids exactly as given; never modify entries" in prompt
+    assert "You MUST fill in a decision for EVERY entry in the template" in prompt
+    assert "Return ONLY the entries from the template" in prompt
 
 
 def test_validation_prompt_includes_data_summary() -> None:

--- a/tests/engine/test_replace_runner.py
+++ b/tests/engine/test_replace_runner.py
@@ -140,6 +140,32 @@ def test_apply_replacement_map_handles_numpy_array_entities() -> None:
     assert output_df[COL_REPLACED_TEXT].iloc[0] == "Maya works at NovaCorp"
 
 
+def test_apply_replacement_map_handles_dict_wrapped_entities() -> None:
+    dataframe = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice works at Acme"],
+            COL_FINAL_ENTITIES: [
+                {
+                    "entities": [
+                        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+                        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+                    ]
+                }
+            ],
+            COL_REPLACEMENT_MAP: [
+                {
+                    "replacements": [
+                        {"original": "Alice", "label": "first_name", "synthetic": "Maya"},
+                        {"original": "Acme", "label": "organization", "synthetic": "NovaCorp"},
+                    ]
+                }
+            ],
+        }
+    )
+    output_df = apply_replacement_map(dataframe)
+    assert output_df[COL_REPLACED_TEXT].iloc[0] == "Maya works at NovaCorp"
+
+
 def test_hash_strategy_executes(
     stub_model_configs: list[ModelConfig],
     stub_replace_model_selection: ReplaceModelSelection,
@@ -237,7 +263,116 @@ def test_filter_entities_preserves_original_column() -> None:
         {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
         {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
     ]
+    input_df = pd.DataFrame({COL_TEXT: ["Alice works at Acme"], COL_FINAL_ENTITIES: [{"entities": entities}]})
+    filtered_df = _filter_entities_by_label(input_df, filter_labels=["first_name"])
+    assert len(filtered_df[COL_FINAL_ENTITIES].iloc[0]["entities"]) == 1
+    assert len(input_df[COL_FINAL_ENTITIES].iloc[0]["entities"]) == 2
+
+
+def test_filter_entities_normalizes_list_to_dict_wrapped() -> None:
+    """Bare list entities are normalized to dict-wrapped format after filtering."""
+    entities = [
+        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+    ]
     input_df = pd.DataFrame({COL_TEXT: ["Alice works at Acme"], COL_FINAL_ENTITIES: [entities]})
     filtered_df = _filter_entities_by_label(input_df, filter_labels=["first_name"])
-    assert len(filtered_df[COL_FINAL_ENTITIES].iloc[0]) == 1
-    assert len(input_df[COL_FINAL_ENTITIES].iloc[0]) == 2
+    result = filtered_df[COL_FINAL_ENTITIES].iloc[0]
+    assert isinstance(result, dict)
+    assert len(result["entities"]) == 1
+
+
+# --- detection → replace integration ---
+
+
+def test_detection_output_flows_through_redact(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    """Smoke test: dict-wrapped final_entities from detection must work with Redact."""
+    detection_output = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice works at Acme"],
+            COL_FINAL_ENTITIES: [
+                {
+                    "entities": [
+                        {
+                            "id": "first_name_0_5",
+                            "value": "Alice",
+                            "label": "first_name",
+                            "start_position": 0,
+                            "end_position": 5,
+                            "score": 1.0,
+                            "source": "detector",
+                        },
+                        {
+                            "id": "org_15_19",
+                            "value": "Acme",
+                            "label": "organization",
+                            "start_position": 15,
+                            "end_position": 19,
+                            "score": 0.9,
+                            "source": "augmenter",
+                        },
+                    ]
+                }
+            ],
+        }
+    )
+    runner = ReplacementWorkflow()
+    result = runner.run(
+        detection_output,
+        replace_method=Redact(),
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+    replaced = result.dataframe[COL_REPLACED_TEXT].iloc[0]
+    assert "Alice" not in replaced
+    assert "Acme" not in replaced
+    assert "[REDACTED_FIRST_NAME]" in replaced
+    assert "[REDACTED_ORGANIZATION]" in replaced
+
+
+def test_detection_output_with_numpy_entities_flows_through_redact(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    """Regression: parquet round-trip produces {"entities": numpy_array}."""
+    detection_output = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice works at Acme"],
+            COL_FINAL_ENTITIES: [
+                {
+                    "entities": np.array(
+                        [
+                            {
+                                "id": "first_name_0_5",
+                                "value": "Alice",
+                                "label": "first_name",
+                                "start_position": 0,
+                                "end_position": 5,
+                            },
+                            {
+                                "id": "org_15_19",
+                                "value": "Acme",
+                                "label": "organization",
+                                "start_position": 15,
+                                "end_position": 19,
+                            },
+                        ],
+                        dtype=object,
+                    )
+                }
+            ],
+        }
+    )
+    runner = ReplacementWorkflow()
+    result = runner.run(
+        detection_output,
+        replace_method=Redact(),
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+    replaced = result.dataframe[COL_REPLACED_TEXT].iloc[0]
+    assert "Alice" not in replaced
+    assert "[REDACTED_FIRST_NAME]" in replaced

--- a/tests/engine/test_replace_runner.py
+++ b/tests/engine/test_replace_runner.py
@@ -62,7 +62,7 @@ def test_substitute_runner_applies_generated_map(
         dataframe=pd.DataFrame(
             {
                 COL_TEXT: ["Alice works at Acme"],
-                COL_FINAL_ENTITIES: [stub_entities],
+                COL_FINAL_ENTITIES: [{"entities": stub_entities}],
                 COL_REPLACEMENT_MAP: [
                     {
                         "replacements": [
@@ -77,7 +77,7 @@ def test_substitute_runner_applies_generated_map(
     )
     runner = ReplacementWorkflow(llm_workflow=llm_workflow)
     result = runner.run(
-        pd.DataFrame({COL_TEXT: ["Alice works at Acme"], COL_FINAL_ENTITIES: [[]]}),
+        pd.DataFrame({COL_TEXT: ["Alice works at Acme"], COL_FINAL_ENTITIES: [{"entities": []}]}),
         replace_method=Substitute(),
         model_configs=stub_model_configs,
         selected_models=stub_replace_model_selection,
@@ -94,7 +94,7 @@ def test_substitute_without_workflow_raises(
     runner = ReplacementWorkflow()
     with pytest.raises(ValueError, match="llm_workflow"):
         runner.run(
-            pd.DataFrame({COL_TEXT: ["Alice"], COL_FINAL_ENTITIES: [[]]}),
+            pd.DataFrame({COL_TEXT: ["Alice"], COL_FINAL_ENTITIES: [{"entities": []}]}),
             replace_method=Substitute(),
             model_configs=stub_model_configs,
             selected_models=stub_replace_model_selection,
@@ -105,7 +105,9 @@ def test_apply_replacement_map_handles_string_map() -> None:
     dataframe = pd.DataFrame(
         {
             COL_TEXT: ["abc Alice xyz"],
-            COL_FINAL_ENTITIES: [[{"value": "Alice", "label": "first_name", "start_position": 4, "end_position": 9}]],
+            COL_FINAL_ENTITIES: [
+                {"entities": [{"value": "Alice", "label": "first_name", "start_position": 4, "end_position": 9}]}
+            ],
             COL_REPLACEMENT_MAP: ['{"replacements":[{"original":"Alice","label":"first_name","synthetic":"Elena"}]}'],
         }
     )
@@ -114,7 +116,7 @@ def test_apply_replacement_map_handles_string_map() -> None:
 
 
 def test_apply_replacement_map_handles_numpy_array_entities() -> None:
-    """Entities may come back as numpy arrays after parquet round-trip through DataDesigner."""
+    """Entities may come back as dict-wrapped numpy arrays after parquet round-trip through DataDesigner."""
     entities = np.array(
         [
             {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
@@ -125,7 +127,7 @@ def test_apply_replacement_map_handles_numpy_array_entities() -> None:
     dataframe = pd.DataFrame(
         {
             COL_TEXT: ["Alice works at Acme"],
-            COL_FINAL_ENTITIES: [entities],
+            COL_FINAL_ENTITIES: [{"entities": entities}],
             COL_REPLACEMENT_MAP: [
                 {
                     "replacements": [
@@ -174,7 +176,9 @@ def test_hash_strategy_executes(
     input_df = pd.DataFrame(
         {
             COL_TEXT: ["Alice"],
-            COL_FINAL_ENTITIES: [[{"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]],
+            COL_FINAL_ENTITIES: [
+                {"entities": [{"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]}
+            ],
         }
     )
     result = runner.run(
@@ -269,8 +273,8 @@ def test_filter_entities_preserves_original_column() -> None:
     assert len(input_df[COL_FINAL_ENTITIES].iloc[0]["entities"]) == 2
 
 
-def test_filter_entities_normalizes_list_to_dict_wrapped() -> None:
-    """Bare list entities are normalized to dict-wrapped format after filtering."""
+def test_filter_entities_bare_list_is_treated_as_empty() -> None:
+    """Bare list payloads are non-canonical and ignored."""
     entities = [
         {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
         {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
@@ -279,7 +283,7 @@ def test_filter_entities_normalizes_list_to_dict_wrapped() -> None:
     filtered_df = _filter_entities_by_label(input_df, filter_labels=["first_name"])
     result = filtered_df[COL_FINAL_ENTITIES].iloc[0]
     assert isinstance(result, dict)
-    assert len(result["entities"]) == 1
+    assert result["entities"] == []
 
 
 # --- detection → replace integration ---

--- a/tests/engine/test_replace_runner.py
+++ b/tests/engine/test_replace_runner.py
@@ -17,6 +17,21 @@ from anonymizer.engine.ndd.adapter import FailedRecord
 from anonymizer.engine.replace.llm_replace_workflow import LlmReplaceResult
 from anonymizer.engine.replace.replace_runner import ReplacementWorkflow, _filter_entities_by_label
 from anonymizer.engine.replace.strategies import apply_replacement_map
+from anonymizer.engine.schemas import EntitiesSchema
+
+
+def _build_entities_payload(payload_kind: str) -> object:
+    entities_list = [
+        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+    ]
+    if payload_kind == "dict_wrapper":
+        return {"entities": entities_list}
+    if payload_kind == "numpy_wrapped_dict_wrapper":
+        return {"entities": np.array(entities_list, dtype=object)}
+    if payload_kind == "entities_schema":
+        return EntitiesSchema(entities=entities_list)
+    raise ValueError(f"Unsupported payload kind: {payload_kind}")
 
 
 def test_local_replace_runner_uses_strategy_directly(
@@ -115,45 +130,15 @@ def test_apply_replacement_map_handles_string_map() -> None:
     assert output_df[COL_REPLACED_TEXT].iloc[0] == "abc Elena xyz"
 
 
-def test_apply_replacement_map_handles_numpy_array_entities() -> None:
-    """Entities may come back as dict-wrapped numpy arrays after parquet round-trip through DataDesigner."""
-    entities = np.array(
-        [
-            {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-            {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
-        ],
-        dtype=object,
-    )
+@pytest.mark.parametrize(
+    "payload_kind",
+    ["dict_wrapper", "numpy_wrapped_dict_wrapper", "entities_schema"],
+)
+def test_apply_replacement_map_handles_entity_payload_shapes(payload_kind: str) -> None:
     dataframe = pd.DataFrame(
         {
             COL_TEXT: ["Alice works at Acme"],
-            COL_FINAL_ENTITIES: [{"entities": entities}],
-            COL_REPLACEMENT_MAP: [
-                {
-                    "replacements": [
-                        {"original": "Alice", "label": "first_name", "synthetic": "Maya"},
-                        {"original": "Acme", "label": "organization", "synthetic": "NovaCorp"},
-                    ]
-                }
-            ],
-        }
-    )
-    output_df = apply_replacement_map(dataframe)
-    assert output_df[COL_REPLACED_TEXT].iloc[0] == "Maya works at NovaCorp"
-
-
-def test_apply_replacement_map_handles_dict_wrapped_entities() -> None:
-    dataframe = pd.DataFrame(
-        {
-            COL_TEXT: ["Alice works at Acme"],
-            COL_FINAL_ENTITIES: [
-                {
-                    "entities": [
-                        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-                        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
-                    ]
-                }
-            ],
+            COL_FINAL_ENTITIES: [_build_entities_payload(payload_kind)],
             COL_REPLACEMENT_MAP: [
                 {
                     "replacements": [

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -79,6 +79,11 @@ def test_entities_payload_from_raw_invalid_returns_empty() -> None:
     assert payload.entities == []
 
 
+def test_entities_payload_from_malformed_list_returns_empty() -> None:
+    payload = EntitiesSchema.from_raw(["not-an-entity"])
+    assert payload.entities == []
+
+
 def test_validation_candidates_payload_from_raw_list() -> None:
     payload = ValidationCandidatesSchema.from_raw(
         [{"id": "city_3_10", "value": "Seattle", "label": "city", "context_before": "in ", "context_after": ", WA"}]
@@ -94,6 +99,11 @@ def test_raw_validation_decisions_payload_from_raw_list() -> None:
     assert len(payload.decisions) == 1
     assert payload.decisions[0].decision is not None
     assert payload.decisions[0].decision.value == "keep"
+
+
+def test_raw_validation_decisions_payload_from_malformed_list_returns_empty() -> None:
+    payload = RawValidationDecisionsSchema.from_raw({"decisions": ["bad-item"]})
+    assert payload.decisions == []
 
 
 def test_validated_decisions_payload_from_raw_list() -> None:

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+
+from anonymizer.engine.schemas import (
+    EntitiesByValueSchema,
+    EntitiesSchema,
+    RawValidationDecisionsSchema,
+    ValidatedDecisionsSchema,
+    ValidationCandidatesSchema,
+    ValidationSkeletonSchema,
+)
+
+
+def test_entities_payload_from_raw_list() -> None:
+    raw = [
+        {
+            "id": "first_name_0_5",
+            "value": "Alice",
+            "label": "first_name",
+            "start_position": 0,
+            "end_position": 5,
+            "score": 0.9,
+            "source": "detector",
+        }
+    ]
+    payload = EntitiesSchema.from_raw(raw)
+    assert len(payload.entities) == 1
+    assert payload.entities[0].value == "Alice"
+
+
+def test_entities_payload_from_raw_dict() -> None:
+    raw = {
+        "entities": [
+            {
+                "id": "org_15_19",
+                "value": "Acme",
+                "label": "organization",
+                "start_position": 15,
+                "end_position": 19,
+                "score": 0.8,
+                "source": "augmenter",
+            }
+        ]
+    }
+    payload = EntitiesSchema.from_raw(raw)
+    assert len(payload.entities) == 1
+    assert payload.entities[0].label == "organization"
+
+
+def test_entities_payload_from_raw_numpy_array() -> None:
+    raw = np.array(
+        [{"id": "city_23_30", "value": "Seattle", "label": "city", "start_position": 23, "end_position": 30}],
+        dtype=object,
+    )
+    payload = EntitiesSchema.from_raw(raw)
+    assert len(payload.entities) == 1
+    assert payload.entities[0].value == "Seattle"
+
+
+def test_entities_payload_from_raw_dict_wrapping_numpy_array() -> None:
+    """Regression: parquet round-trips produce {"entities": numpy_array}."""
+    raw = {
+        "entities": np.array(
+            [{"id": "city_23_30", "value": "Seattle", "label": "city", "start_position": 23, "end_position": 30}],
+            dtype=object,
+        )
+    }
+    payload = EntitiesSchema.from_raw(raw)
+    assert len(payload.entities) == 1
+    assert payload.entities[0].value == "Seattle"
+
+
+def test_entities_payload_from_raw_invalid_returns_empty() -> None:
+    payload = EntitiesSchema.from_raw("not-a-payload")
+    assert payload.entities == []
+
+
+def test_validation_candidates_payload_from_raw_list() -> None:
+    payload = ValidationCandidatesSchema.from_raw(
+        [{"id": "city_3_10", "value": "Seattle", "label": "city", "context_before": "in ", "context_after": ", WA"}]
+    )
+    assert len(payload.candidates) == 1
+    assert payload.candidates[0].label == "city"
+
+
+def test_raw_validation_decisions_payload_from_raw_list() -> None:
+    payload = RawValidationDecisionsSchema.from_raw(
+        [{"id": "city_3_10", "decision": "keep", "proposed_label": "", "reason": "quasi-identifier"}]
+    )
+    assert len(payload.decisions) == 1
+    assert payload.decisions[0].decision is not None
+    assert payload.decisions[0].decision.value == "keep"
+
+
+def test_validated_decisions_payload_from_raw_list() -> None:
+    payload = ValidatedDecisionsSchema.from_raw(
+        [
+            {
+                "id": "city_3_10",
+                "decision": "keep",
+                "proposed_label": "",
+                "reason": "quasi-identifier",
+                "value": "Seattle",
+                "label": "city",
+            }
+        ]
+    )
+    assert len(payload.decisions) == 1
+    assert payload.decisions[0].value == "Seattle"
+
+
+def test_validation_skeleton_payload_from_raw_dict() -> None:
+    payload = ValidationSkeletonSchema.from_raw(
+        {
+            "decisions": [
+                {
+                    "id": "city_3_10",
+                    "value": "Seattle",
+                    "label": "city",
+                    "decision": None,
+                    "proposed_label": None,
+                    "reason": None,
+                }
+            ]
+        }
+    )
+    assert len(payload.decisions) == 1
+    assert payload.decisions[0].decision is None
+
+
+def test_entities_by_value_payload_from_raw_list() -> None:
+    payload = EntitiesByValueSchema.from_raw([{"value": "Seattle", "labels": ["city"]}])
+    assert len(payload.entities_by_value) == 1
+    assert payload.entities_by_value[0].labels == ["city"]

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -53,6 +53,25 @@ def test_entities_payload_from_raw_dict() -> None:
     assert payload.entities[0].label == "organization"
 
 
+def test_entities_payload_from_raw_model_instance() -> None:
+    raw = EntitiesSchema(
+        entities=[
+            {
+                "id": "org_15_19",
+                "value": "Acme",
+                "label": "organization",
+                "start_position": 15,
+                "end_position": 19,
+                "score": 0.8,
+                "source": "augmenter",
+            }
+        ]
+    )
+    payload = EntitiesSchema.from_raw(raw)
+    assert len(payload.entities) == 1
+    assert payload.entities[0].label == "organization"
+
+
 def test_entities_payload_from_raw_numpy_array() -> None:
     raw = {
         "entities": np.array(

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -16,17 +16,19 @@ from anonymizer.engine.schemas import (
 
 
 def test_entities_payload_from_raw_list() -> None:
-    raw = [
-        {
-            "id": "first_name_0_5",
-            "value": "Alice",
-            "label": "first_name",
-            "start_position": 0,
-            "end_position": 5,
-            "score": 0.9,
-            "source": "detector",
-        }
-    ]
+    raw = {
+        "entities": [
+            {
+                "id": "first_name_0_5",
+                "value": "Alice",
+                "label": "first_name",
+                "start_position": 0,
+                "end_position": 5,
+                "score": 0.9,
+                "source": "detector",
+            }
+        ]
+    }
     payload = EntitiesSchema.from_raw(raw)
     assert len(payload.entities) == 1
     assert payload.entities[0].value == "Alice"
@@ -52,10 +54,12 @@ def test_entities_payload_from_raw_dict() -> None:
 
 
 def test_entities_payload_from_raw_numpy_array() -> None:
-    raw = np.array(
-        [{"id": "city_23_30", "value": "Seattle", "label": "city", "start_position": 23, "end_position": 30}],
-        dtype=object,
-    )
+    raw = {
+        "entities": np.array(
+            [{"id": "city_23_30", "value": "Seattle", "label": "city", "start_position": 23, "end_position": 30}],
+            dtype=object,
+        )
+    }
     payload = EntitiesSchema.from_raw(raw)
     assert len(payload.entities) == 1
     assert payload.entities[0].value == "Seattle"
@@ -84,9 +88,26 @@ def test_entities_payload_from_malformed_list_returns_empty() -> None:
     assert payload.entities == []
 
 
+def test_entities_payload_from_bare_list_returns_empty() -> None:
+    payload = EntitiesSchema.from_raw(
+        [{"id": "first_name_0_5", "value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]
+    )
+    assert payload.entities == []
+
+
 def test_validation_candidates_payload_from_raw_list() -> None:
     payload = ValidationCandidatesSchema.from_raw(
-        [{"id": "city_3_10", "value": "Seattle", "label": "city", "context_before": "in ", "context_after": ", WA"}]
+        {
+            "candidates": [
+                {
+                    "id": "city_3_10",
+                    "value": "Seattle",
+                    "label": "city",
+                    "context_before": "in ",
+                    "context_after": ", WA",
+                }
+            ]
+        }
     )
     assert len(payload.candidates) == 1
     assert payload.candidates[0].label == "city"
@@ -94,7 +115,7 @@ def test_validation_candidates_payload_from_raw_list() -> None:
 
 def test_raw_validation_decisions_payload_from_raw_list() -> None:
     payload = RawValidationDecisionsSchema.from_raw(
-        [{"id": "city_3_10", "decision": "keep", "proposed_label": "", "reason": "quasi-identifier"}]
+        {"decisions": [{"id": "city_3_10", "decision": "keep", "proposed_label": "", "reason": "quasi-identifier"}]}
     )
     assert len(payload.decisions) == 1
     assert payload.decisions[0].decision is not None
@@ -108,16 +129,18 @@ def test_raw_validation_decisions_payload_from_malformed_list_returns_empty() ->
 
 def test_validated_decisions_payload_from_raw_list() -> None:
     payload = ValidatedDecisionsSchema.from_raw(
-        [
-            {
-                "id": "city_3_10",
-                "decision": "keep",
-                "proposed_label": "",
-                "reason": "quasi-identifier",
-                "value": "Seattle",
-                "label": "city",
-            }
-        ]
+        {
+            "decisions": [
+                {
+                    "id": "city_3_10",
+                    "decision": "keep",
+                    "proposed_label": "",
+                    "reason": "quasi-identifier",
+                    "value": "Seattle",
+                    "label": "city",
+                }
+            ]
+        }
     )
     assert len(payload.decisions) == 1
     assert payload.decisions[0].value == "Seattle"
@@ -143,6 +166,6 @@ def test_validation_skeleton_payload_from_raw_dict() -> None:
 
 
 def test_entities_by_value_payload_from_raw_list() -> None:
-    payload = EntitiesByValueSchema.from_raw([{"value": "Seattle", "labels": ["city"]}])
+    payload = EntitiesByValueSchema.from_raw({"entities_by_value": [{"value": "Seattle", "labels": ["city"]}]})
     assert len(payload.entities_by_value) == 1
     assert payload.entities_by_value[0].labels == ["city"]

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -38,7 +38,7 @@ def _make_anonymizer(
 ) -> tuple[Anonymizer, Mock, Mock]:
     detection_workflow = Mock(spec=EntityDetectionWorkflow)
     detection_workflow.run.return_value = detection_return or EntityDetectionResult(
-        dataframe=pd.DataFrame({COL_TEXT: ["Alice works at Acme"], COL_FINAL_ENTITIES: [[]]}),
+        dataframe=pd.DataFrame({COL_TEXT: ["Alice works at Acme"], COL_FINAL_ENTITIES: [{"entities": []}]}),
         failed_records=[],
     )
     replace_runner = Mock(spec=ReplacementWorkflow)
@@ -60,7 +60,7 @@ def test_run_merges_failed_records_from_both_stages(
     replace_failures = [FailedRecord(record_id="r2", step="replace", reason="parse error")]
 
     detection_result = EntityDetectionResult(
-        dataframe=pd.DataFrame({COL_TEXT: ["Alice"], COL_FINAL_ENTITIES: [[]]}),
+        dataframe=pd.DataFrame({COL_TEXT: ["Alice"], COL_FINAL_ENTITIES: [{"entities": []}]}),
         failed_records=detection_failures,
     )
     replace_return = ReplacementResult(
@@ -112,7 +112,7 @@ def test_run_exposes_trace_dataframe_and_filters_internal_columns(
                 COL_TEXT: ["Alice"],
                 COL_REPLACED_TEXT: ["[REDACTED]"],
                 COL_TAGGED_TEXT: ["<first_name>Alice</first_name>"],
-                COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
                 COL_REPLACEMENT_MAP: [{"replacements": []}],
             }
         ),
@@ -138,7 +138,7 @@ def test_preview_exposes_trace_dataframe_for_display(
             {
                 COL_TEXT: ["Alice"],
                 COL_REPLACED_TEXT: ["[REDACTED]"],
-                COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
                 COL_REPLACEMENT_MAP: [{"replacements": []}],
             }
         ),
@@ -165,7 +165,7 @@ def test_run_restores_original_text_column_names_for_user_dataframe(
             COL_TEXT: ["Alice bio text"],
             COL_REPLACED_TEXT: ["[REDACTED] bio text"],
             COL_TAGGED_TEXT: ["<first_name>Alice</first_name> bio text"],
-            COL_DETECTED_ENTITIES: [[{"value": "Alice", "label": "first_name"}]],
+            COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
         }
     )
     replace_df.attrs["original_text_column"] = "bio"

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -123,10 +123,12 @@ def test_render_record_html_contains_all_sections() -> None:
         {
             "text": "Alice works at Acme",
             "text_replaced": "[REDACTED_FIRST_NAME] works at [REDACTED_ORGANIZATION]",
-            COL_DETECTED_ENTITIES: [
-                {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-                {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
-            ],
+            COL_DETECTED_ENTITIES: {
+                "entities": [
+                    {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+                    {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+                ]
+            },
             COL_REPLACEMENT_MAP: {
                 "replacements": [
                     {"original": "Alice", "label": "first_name", "synthetic": "[REDACTED_FIRST_NAME]"},
@@ -149,7 +151,7 @@ def test_render_record_html_original_highlights_from_map_when_entities_empty() -
     row = {
         "text": "Alice works at Acme",
         "text_replaced": "Maya works at NovaCorp",
-        COL_DETECTED_ENTITIES: [],
+        COL_DETECTED_ENTITIES: {"entities": []},
         COL_REPLACEMENT_MAP: {
             "replacements": [
                 {"original": "Alice", "label": "first_name", "synthetic": "Maya"},
@@ -169,7 +171,7 @@ def test_render_record_html_replaced_highlights_from_map_when_entities_empty() -
     row = {
         "text": "Alice works at Acme",
         "text_replaced": "Maya works at NovaCorp",
-        COL_DETECTED_ENTITIES: [],
+        COL_DETECTED_ENTITIES: {"entities": []},
         COL_REPLACEMENT_MAP: {
             "replacements": [
                 {"original": "Alice", "label": "first_name", "synthetic": "Maya"},
@@ -188,7 +190,7 @@ def test_render_record_html_without_replacement_map() -> None:
         {
             "text": "Alice works here",
             "text_replaced": "Alice works here",
-            COL_DETECTED_ENTITIES: [],
+            COL_DETECTED_ENTITIES: {"entities": []},
             COL_REPLACEMENT_MAP: {},
         }
     )
@@ -201,7 +203,7 @@ def _make_preview(rows: int = 2) -> PreviewResult:
         {
             "text": ["Alice", "Bob"][:rows],
             "text_replaced": ["[R]", "[R]"][:rows],
-            COL_DETECTED_ENTITIES: [[] for _ in range(rows)],
+            COL_DETECTED_ENTITIES: [{"entities": []} for _ in range(rows)],
             COL_REPLACEMENT_MAP: [{} for _ in range(rows)],
         }
     )
@@ -215,10 +217,12 @@ def test_render_record_html_uses_detected_entities_over_map_scan() -> None:
         {
             "text": "She works at the Lantern in Austin",
             "text_replaced": "She works at [REDACTED_COMPANY] in [REDACTED_CITY]",
-            COL_DETECTED_ENTITIES: [
-                {"value": "The Lantern", "label": "company_name", "start_position": 13, "end_position": 24},
-                {"value": "Austin", "label": "city", "start_position": 28, "end_position": 34},
-            ],
+            COL_DETECTED_ENTITIES: {
+                "entities": [
+                    {"value": "The Lantern", "label": "company_name", "start_position": 13, "end_position": 24},
+                    {"value": "Austin", "label": "city", "start_position": 28, "end_position": 34},
+                ]
+            },
             COL_REPLACEMENT_MAP: {
                 "replacements": [
                     {"original": "The Lantern", "label": "company_name", "synthetic": "[REDACTED_COMPANY]"},
@@ -240,11 +244,13 @@ def test_render_record_html_replaced_tags_positioned_correctly_with_case_mismatc
         {
             "text": "Hi Mara at the Lantern in Austin TX",
             "text_replaced": "Hi [REDACTED_NAME] at [REDACTED_COMPANY] in [REDACTED_CITY] TX",
-            COL_DETECTED_ENTITIES: [
-                {"value": "Mara", "label": "first_name", "start_position": 3, "end_position": 7},
-                {"value": "The Lantern", "label": "company_name", "start_position": 11, "end_position": 22},
-                {"value": "Austin", "label": "city", "start_position": 26, "end_position": 32},
-            ],
+            COL_DETECTED_ENTITIES: {
+                "entities": [
+                    {"value": "Mara", "label": "first_name", "start_position": 3, "end_position": 7},
+                    {"value": "The Lantern", "label": "company_name", "start_position": 11, "end_position": 22},
+                    {"value": "Austin", "label": "city", "start_position": 26, "end_position": 32},
+                ]
+            },
             COL_REPLACEMENT_MAP: {
                 "replacements": [
                     {"original": "Mara", "label": "first_name", "synthetic": "[REDACTED_NAME]"},
@@ -266,10 +272,12 @@ def test_render_record_html_mask_strategy_labels_are_distinct() -> None:
         {
             "text": "Mara in Austin",
             "text_replaced": "***** in *****",
-            COL_DETECTED_ENTITIES: [
-                {"value": "Mara", "label": "first_name", "start_position": 0, "end_position": 4},
-                {"value": "Austin", "label": "city", "start_position": 8, "end_position": 14},
-            ],
+            COL_DETECTED_ENTITIES: {
+                "entities": [
+                    {"value": "Mara", "label": "first_name", "start_position": 0, "end_position": 4},
+                    {"value": "Austin", "label": "city", "start_position": 8, "end_position": 14},
+                ]
+            },
             COL_REPLACEMENT_MAP: {
                 "replacements": [
                     {"original": "Mara", "label": "first_name", "synthetic": "*****"},

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_REPLACEMENT_MAP
+from anonymizer.engine.schemas import EntitySchema
 from anonymizer.interface.display import (
     _build_replaced_entities,
     _normalize_replacement_map,
@@ -16,8 +17,12 @@ from anonymizer.interface.display import (
 from anonymizer.interface.results import PreviewResult
 
 
+def _entity(value: str, label: str, start: int, end: int) -> EntitySchema:
+    return EntitySchema(value=value, label=label, start_position=start, end_position=end)
+
+
 def test_highlighted_text_wraps_entity_in_styled_span() -> None:
-    entities = [{"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]
+    entities = [_entity("Alice", "first_name", 0, 5)]
     result = _render_highlighted_text("Alice works here", entities)
     assert "Alice" in result
     assert "first_name" in result
@@ -25,15 +30,15 @@ def test_highlighted_text_wraps_entity_in_styled_span() -> None:
 
 
 def test_highlighted_text_escapes_html_in_plain_text() -> None:
-    entities = [{"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]
+    entities = [_entity("Alice", "first_name", 0, 5)]
     result = _render_highlighted_text("Alice <b>works</b> here", entities)
     assert "&lt;b&gt;" in result
 
 
 def test_highlighted_text_preserves_text_between_entities() -> None:
     entities = [
-        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+        _entity("Alice", "first_name", 0, 5),
+        _entity("Acme", "organization", 15, 19),
     ]
     result = _render_highlighted_text("Alice works at Acme", entities)
     assert " works at " in result
@@ -46,8 +51,8 @@ def test_highlighted_text_no_entities_returns_escaped_text() -> None:
 
 def test_highlighted_text_skips_overlapping_entity() -> None:
     entities = [
-        {"value": "John Doe", "label": "full_name", "start_position": 0, "end_position": 8},
-        {"value": "Doe", "label": "last_name", "start_position": 5, "end_position": 8},
+        _entity("John Doe", "full_name", 0, 8),
+        _entity("Doe", "last_name", 5, 8),
     ]
     result = _render_highlighted_text("John Doe went home", entities)
     assert "full_name" in result
@@ -56,8 +61,8 @@ def test_highlighted_text_skips_overlapping_entity() -> None:
 
 def test_highlighted_text_consistent_color_per_label() -> None:
     entities = [
-        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-        {"value": "Bob", "label": "first_name", "start_position": 10, "end_position": 13},
+        _entity("Alice", "first_name", 0, 5),
+        _entity("Bob", "first_name", 10, 13),
     ]
     result = _render_highlighted_text("Alice met Bob here", entities)
     border_colors = [
@@ -69,29 +74,27 @@ def test_highlighted_text_consistent_color_per_label() -> None:
 
 def test_replaced_entities_tracks_shifted_positions() -> None:
     original_entities = [
-        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+        _entity("Alice", "first_name", 0, 5),
+        _entity("Acme", "organization", 15, 19),
     ]
     replacement_map = [
         {"original": "Alice", "label": "first_name", "synthetic": "Maya"},
         {"original": "Acme", "label": "organization", "synthetic": "NovaCorp"},
     ]
-    replaced_text = "Maya works at NovaCorp"
-
-    result = _build_replaced_entities(original_entities, replacement_map, "Alice works at Acme", replaced_text)
+    result = _build_replaced_entities(original_entities, replacement_map, "Alice works at Acme")
     assert len(result) == 2
-    assert result[0]["value"] == "Maya"
-    assert result[0]["start_position"] == 0
-    assert result[0]["end_position"] == 4
-    assert result[1]["value"] == "NovaCorp"
-    assert result[1]["start_position"] == 14
+    assert result[0].value == "Maya"
+    assert result[0].start_position == 0
+    assert result[0].end_position == 4
+    assert result[1].value == "NovaCorp"
+    assert result[1].start_position == 14
 
 
 def test_replaced_entities_empty_map_uses_original_values() -> None:
-    original_entities = [{"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]
-    result = _build_replaced_entities(original_entities, [], "Alice works", "Alice works")
+    original_entities = [_entity("Alice", "first_name", 0, 5)]
+    result = _build_replaced_entities(original_entities, [], "Alice works")
     assert len(result) == 1
-    assert result[0]["value"] == "Alice"
+    assert result[0].value == "Alice"
 
 
 def test_normalize_replacement_map_from_dict() -> None:
@@ -232,12 +235,7 @@ def test_render_record_html_uses_detected_entities_over_map_scan() -> None:
 
 
 def test_render_record_html_replaced_tags_positioned_correctly_with_case_mismatch() -> None:
-    """Tags in replaced text must not drift when entity value case differs from actual text.
-
-    Regression: when _detected_entities was discarded in favor of map-based scanning,
-    "The Lantern" (case-sensitive find) missed "the Lantern" in the text.  The gap-based
-    position tracking then drifted, placing tags inside replacement tokens.
-    """
+    """Tags in replaced text must not drift when entity value case differs from actual text."""
     row = pd.Series(
         {
             "text": "Hi Mara at the Lantern in Austin TX",
@@ -293,8 +291,8 @@ def test_build_original_entities_from_map_case_insensitive() -> None:
     text = "She works at the Lantern daily"
     result = _build_original_entities_from_map(replacement_map, text)
     assert len(result) == 1
-    assert result[0]["value"] == "the Lantern"
-    assert result[0]["start_position"] == 13
+    assert result[0].value == "the Lantern"
+    assert result[0].start_position == 13
 
 
 def test_display_record_cycles_on_repeated_calls() -> None:

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_REPLACEMENT_MAP
-from anonymizer.engine.schemas import EntitySchema
+from anonymizer.engine.schemas import EntitiesSchema, EntitySchema
 from anonymizer.interface.display import (
     _build_replaced_entities,
     _normalize_replacement_map,
@@ -19,6 +20,20 @@ from anonymizer.interface.results import PreviewResult
 
 def _entity(value: str, label: str, start: int, end: int) -> EntitySchema:
     return EntitySchema(value=value, label=label, start_position=start, end_position=end)
+
+
+def _build_detected_entities_payload(payload_kind: str) -> object:
+    entities_list = [
+        {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+        {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
+    ]
+    if payload_kind == "dict_wrapper":
+        return {"entities": entities_list}
+    if payload_kind == "numpy_wrapped_dict_wrapper":
+        return {"entities": np.array(entities_list, dtype=object)}
+    if payload_kind == "entities_schema":
+        return EntitiesSchema(entities=entities_list)
+    raise ValueError(f"Unsupported payload kind: {payload_kind}")
 
 
 def test_highlighted_text_wraps_entity_in_styled_span() -> None:
@@ -123,17 +138,16 @@ def test_normalize_replacement_map_non_dict_returns_empty() -> None:
     assert _normalize_replacement_map([1, 2, 3]) == []
 
 
-def test_render_record_html_contains_all_sections() -> None:
+@pytest.mark.parametrize(
+    "payload_kind",
+    ["dict_wrapper", "numpy_wrapped_dict_wrapper", "entities_schema"],
+)
+def test_render_record_html_contains_all_sections(payload_kind: str) -> None:
     row = pd.Series(
         {
             "text": "Alice works at Acme",
             "text_replaced": "[REDACTED_FIRST_NAME] works at [REDACTED_ORGANIZATION]",
-            COL_DETECTED_ENTITIES: {
-                "entities": [
-                    {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
-                    {"value": "Acme", "label": "organization", "start_position": 15, "end_position": 19},
-                ]
-            },
+            COL_DETECTED_ENTITIES: _build_detected_entities_payload(payload_kind),
             COL_REPLACEMENT_MAP: {
                 "replacements": [
                     {"original": "Alice", "label": "first_name", "synthetic": "[REDACTED_FIRST_NAME]"},


### PR DESCRIPTION
## Summary
Issue #8 asked for validation decision traces to include entity values. While implementing that, I found a deeper reliability issue: validator IDs were not consistently aligning with candidate IDs, so some validation decisions could be silently ignored.

To make traces both readable and trustworthy, this PR goes beyond value enrichment and hardens the full validation path.

### What changed
- Added post-validation enrichment so `_validated_entities.decisions[*]` include `value` (Issue #8 objective).
- Introduced template-guided validation input via `_validation_skeleton` so the model fills predefined decision rows instead of inventing structure. I think this still aligns better with a `LLMStructuredColumn` vs. `LLMTextColumn`. 
- Added `_validation_decisions` as explicit intermediate output; `_validated_entities` remains canonical post-processed output.
- Switched entity IDs from opaque hash fragments to deterministic readable span IDs (`{label}_{start}_{end}`) to improve copy fidelity and debugging.
- Added a filter on validator decisions to limit to known candidate IDs before finalization.
- Updated tests and prompt assertions to lock in these behaviors.
- Added two minor prompt improvements (one in replacement map generation and one when validating entities) for context-fit quality.

### Why this is broader than #8
A value-only trace enhancement is not sufficient if decision IDs do not reliably map to candidates. Without ID alignment, decisions can be dropped or ignored, which reduces correctness.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes

## Related Issues
Closes #8