### PR TITLE
fix: correct GLiNER model name and skip health check

### DIFF
--- a/src/anonymizer/config/default_model_configs/models.yaml
+++ b/src/anonymizer/config/default_model_configs/models.yaml
@@ -1,12 +1,10 @@
 model_configs:
   - alias: gliner-pii-detector
-    model: nvidia/nemotron-pii
+    model: nvidia/gliner-pii
     provider: nvidia
+    skip_health_check: true
     inference_parameters:
       max_parallel_requests: 16
-      temperature: 0.0
-      top_p: 1.0
-      max_tokens: 1024
       timeout: 120
 
   - alias: gpt-oss-120b


### PR DESCRIPTION
## Summary

- Rename `nvidia/nemotron-pii` to `nvidia/gliner-pii` (correct model name on build.nvidia.com)
- Add `skip_health_check: true` — GLiNER's health check fails because DD sends standard chat params (`temperature`, `top_p`) that GLiNER rejects
- Remove `temperature`/`top_p`/`max_tokens` from GLiNER inference parameters — these are unsupported by the GLiNER API and cause 422 errors

## Test plan

- [x] Verified `nvidia/gliner-pii` responds correctly on `integrate.api.nvidia.com`
- [x] Full pipeline (detection + replacement) runs end-to-end with default nvidia provider