### PR TITLE
chore: remove unnecessary skip_health_check for GLiNER

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ make install
 By default, Anonymizer uses models hosted on [build.nvidia.com](https://build.nvidia.com) — NemotronPII for entity detection and a text LLM for augmentation/validation. You can also bring your own models via custom provider configs. See [model configuration docs](docs/concepts/models/model-provider-config.md) for details.
 
 ```bash
-export NIM_API_KEY="your-nvidia-api-key"
+export NVIDIA_API_KEY="your-nvidia-api-key"
 ```
 
 ### 3. Anonymize text
@@ -38,7 +38,7 @@ export NIM_API_KEY="your-nvidia-api-key"
 ```python
 from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, RedactReplace
 
-# Uses default model providers (build.nvidia.com) via NIM_API_KEY env var
+# Uses default model providers (build.nvidia.com) via NVIDIA_API_KEY env var
 anonymizer = Anonymizer()
 
 config = AnonymizerConfig(replace=RedactReplace())

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make install
 
 ### 2. Set up model providers
 
-By default, Anonymizer uses models hosted on [build.nvidia.com](https://build.nvidia.com) — NemotronPII for entity detection and a text LLM for augmentation/validation. You can also bring your own models via custom provider configs. See [model configuration docs](docs/concepts/models/model-provider-config.md) for details.
+By default, Anonymizer uses models hosted on [build.nvidia.com](https://build.nvidia.com/models) — NemotronPII for entity detection and a text LLM for augmentation/validation. You can also bring your own models via custom provider configs.
 
 ```bash
 export NVIDIA_API_KEY="your-nvidia-api-key"

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ export NVIDIA_API_KEY="your-nvidia-api-key"
 ### 3. Anonymize text
 
 ```python
-from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, RedactReplace
+from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Redact
 
 # Uses default model providers (build.nvidia.com) via NVIDIA_API_KEY env var
 anonymizer = Anonymizer()
 
-config = AnonymizerConfig(replace=RedactReplace())
+config = AnonymizerConfig(replace=Redact())
 
 preview = anonymizer.preview(
     config=config,

--- a/src/anonymizer/config/default_model_configs/models.yaml
+++ b/src/anonymizer/config/default_model_configs/models.yaml
@@ -2,7 +2,6 @@ model_configs:
   - alias: gliner-pii-detector
     model: nvidia/gliner-pii
     provider: nvidia
-    skip_health_check: true
     inference_parameters:
       max_parallel_requests: 16
       timeout: 120


### PR DESCRIPTION
## Summary

- Remove `skip_health_check: true` from the GLiNER model config — health check passes now that unsupported params were removed in #24
- Fix README: correct env var from `NIM_API_KEY` to `NVIDIA_API_KEY`

## Test plan

- [x] Health check passes without `skip_health_check`
- [x] Full pipeline runs end-to-end with default nvidia provider