### PR TITLE
fix: filtered-label preview mismatch in replace mode

### DIFF
--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 import pandas as pd
 
-from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_REPLACEMENT_MAP
+from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_FINAL_ENTITIES, COL_REPLACEMENT_MAP
 from anonymizer.engine.schemas import EntitiesSchema, EntitySchema
 
 ENTITY_COLORS: list[str] = [
@@ -68,7 +68,7 @@ def render_record_html(row: pd.Series, record_index: int | None = None, original
     text_col = original_text_column or "text"
     text = str(row.get(text_col, ""))
     replaced_text = str(row.get(f"{text_col}_replaced", ""))
-    entities = EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, {})).entities
+    entities = _resolve_display_entities(row)
     replacement_map = _normalize_replacement_map(row.get(COL_REPLACEMENT_MAP, {}))
 
     if not entities and replacement_map:
@@ -90,6 +90,14 @@ def render_record_html(row: pd.Series, record_index: int | None = None, original
         replaced_html=replaced_html,
         table_html=table_html,
     )
+
+
+def _resolve_display_entities(row: pd.Series) -> list[EntitySchema]:
+    """Prefer the final entity set so preview matches replacement behavior."""
+    final_entities = EntitiesSchema.from_raw(row.get(COL_FINAL_ENTITIES, {})).entities
+    if final_entities:
+        return final_entities
+    return EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, {})).entities
 
 
 def _render_highlighted_text(text: str, entities: list[EntitySchema]) -> str:

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_REPLACEMENT_MAP
+from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_FINAL_ENTITIES, COL_REPLACEMENT_MAP
 from anonymizer.engine.schemas import EntitiesSchema, EntitySchema
 from anonymizer.interface.display import (
     _build_replaced_entities,
@@ -255,6 +255,38 @@ def test_render_record_html_uses_detected_entities_over_map_scan() -> None:
     assert "city" in result
     assert "[REDACTED_COMPANY]" in result
     assert "[REDACTED_CITY]" in result
+
+
+def test_render_record_html_prefers_final_entities_for_filtered_replace_preview() -> None:
+    row = pd.Series(
+        {
+            "text": "Mara Delgado works in Austin",
+            "text_replaced": "[REDACTED_FIRST_NAME] Delgado works in Austin",
+            COL_DETECTED_ENTITIES: {
+                "entities": [
+                    {"value": "Mara", "label": "first_name", "start_position": 0, "end_position": 4},
+                    {"value": "Delgado", "label": "last_name", "start_position": 5, "end_position": 12},
+                    {"value": "Austin", "label": "city", "start_position": 22, "end_position": 28},
+                ]
+            },
+            COL_FINAL_ENTITIES: {
+                "entities": [
+                    {"value": "Mara", "label": "first_name", "start_position": 0, "end_position": 4},
+                ]
+            },
+            COL_REPLACEMENT_MAP: {
+                "replacements": [
+                    {"original": "Mara", "label": "first_name", "synthetic": "[REDACTED_FIRST_NAME]"},
+                ]
+            },
+        }
+    )
+
+    result = render_record_html(row)
+
+    assert "first_name" in result
+    assert "| last_name" not in result
+    assert "| city" not in result
 
 
 def test_render_record_html_replaced_tags_positioned_correctly_with_case_mismatch() -> None:


### PR DESCRIPTION
## Summary
- Make replace-mode preview/rendering use the filtered entity set instead of the full detected set
- Ensure `display_record()` matches the entities actually used for replacement when `filter_labels` is set
- Add a regression test covering filtered preview behavior

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes