### PR TITLE
fix: tighten substitute replacement-map generation

### DIFF
--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -42,7 +42,7 @@ class LlmReplaceWorkflow:
         replace_alias = resolve_model_alias("replacement_generator", selected_models)
 
         working_df = dataframe.copy()
-        working_df["_row_order"] = range(len(working_df))
+        working_df["_anonymizer_row_order"] = range(len(working_df))
 
         # Parse the per-row entity payload once, then reuse it for prompt inputs.
         parsed_entities = working_df[entities_column].apply(EntitiesByValueSchema.from_raw)
@@ -57,14 +57,17 @@ class LlmReplaceWorkflow:
         passthrough_rows = working_df[~has_entities_mask].copy()
         passthrough_rows[COL_REPLACEMENT_MAP] = [{"replacements": []} for _ in range(len(passthrough_rows))]
 
-        # Only rows with actual entities are sent to the LLM.
-        entity_rows = working_df[has_entities_mask].copy()
-        if entity_rows.empty:
+        if not has_entities_mask.any():
             passthrough_rows = (
-                passthrough_rows.sort_values("_row_order").drop(columns="_row_order").reset_index(drop=True)
+                passthrough_rows.sort_values("_anonymizer_row_order")
+                .drop(columns="_anonymizer_row_order")
+                .reset_index(drop=True)
             )
             passthrough_rows.attrs = {**dataframe.attrs}
             return LlmReplaceResult(dataframe=passthrough_rows, failed_records=[])
+
+        # Only rows with actual entities are sent to the LLM.
+        entity_rows = working_df[has_entities_mask].copy()
 
         run_result = self._adapter.run_workflow(
             entity_rows,
@@ -96,8 +99,8 @@ class LlmReplaceWorkflow:
         # Recombine LLM-processed rows with passthrough rows in original order.
         output_df = (
             pd.concat([output_df, passthrough_rows], axis=0)
-            .sort_values("_row_order")
-            .drop(columns="_row_order")
+            .sort_values("_anonymizer_row_order")
+            .drop(columns="_anonymizer_row_order")
             .reset_index(drop=True)
         )
         # Carry pipeline metadata (e.g. original_text_column) through to downstream steps.
@@ -136,10 +139,7 @@ def _filter_replacement_map_to_input_entities(
     if not isinstance(raw_map, dict):
         return {"replacements": []}
 
-    try:
-        parsed_map = EntityReplacementMapSchema.model_validate(raw_map)
-    except Exception:
-        return {"replacements": []}
+    parsed_map = EntityReplacementMapSchema.model_validate(raw_map)
 
     allowed_pairs = {
         (entity.value, label)

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -42,18 +42,32 @@ class LlmReplaceWorkflow:
         replace_alias = resolve_model_alias("replacement_generator", selected_models)
 
         working_df = dataframe.copy()
-        working_df["_entity_examples"] = working_df.apply(
-            lambda row: _create_entity_examples(EntitiesByValueSchema.from_raw(row.get(entities_column, {}))),
-            axis=1,
-        )
-        working_df["_entities_for_replace"] = working_df.apply(
-            lambda row: _enrich_entities_for_template(EntitiesByValueSchema.from_raw(row.get(entities_column, {}))),
-            axis=1,
-        )
+        working_df["_row_order"] = range(len(working_df))
+
+        # Parse the per-row entity payload once, then reuse it for prompt inputs.
+        parsed_entities = working_df[entities_column].apply(EntitiesByValueSchema.from_raw)
+        working_df["_entity_examples"] = parsed_entities.apply(_create_entity_examples)
+        working_df["_entities_for_replace"] = parsed_entities.apply(_enrich_entities_for_template)
         working_df["_entities_for_replace_json"] = working_df["_entities_for_replace"].apply(json.dumps)
 
+        # Rows with an empty entity list should bypass replacement-map generation.
+        has_entities_mask = working_df["_entities_for_replace"].apply(bool)
+
+        # Passthrough rows get an empty replacement map immediately.
+        passthrough_rows = working_df[~has_entities_mask].copy()
+        passthrough_rows[COL_REPLACEMENT_MAP] = [{"replacements": []} for _ in range(len(passthrough_rows))]
+
+        # Only rows with actual entities are sent to the LLM.
+        entity_rows = working_df[has_entities_mask].copy()
+        if entity_rows.empty:
+            passthrough_rows = (
+                passthrough_rows.sort_values("_row_order").drop(columns="_row_order").reset_index(drop=True)
+            )
+            passthrough_rows.attrs = {**dataframe.attrs}
+            return LlmReplaceResult(dataframe=passthrough_rows, failed_records=[])
+
         run_result = self._adapter.run_workflow(
-            working_df,
+            entity_rows,
             model_configs=model_configs,
             columns=[
                 LLMStructuredColumnConfig(
@@ -70,6 +84,22 @@ class LlmReplaceWorkflow:
             preview_num_records=preview_num_records,
         )
         output_df = run_result.dataframe.copy()
+        # Drop any LLM-returned replacements that were not requested for this row.
+        output_df[COL_REPLACEMENT_MAP] = output_df.apply(
+            lambda row: _filter_replacement_map_to_input_entities(
+                raw_map=row.get(COL_REPLACEMENT_MAP, {"replacements": []}),
+                parsed_entities=EntitiesByValueSchema.from_raw(row.get(entities_column, {})),
+            ),
+            axis=1,
+        )
+
+        # Recombine LLM-processed rows with passthrough rows in original order.
+        output_df = (
+            pd.concat([output_df, passthrough_rows], axis=0)
+            .sort_values("_row_order")
+            .drop(columns="_row_order")
+            .reset_index(drop=True)
+        )
         # Carry pipeline metadata (e.g. original_text_column) through to downstream steps.
         # pandas .attrs is experimental and not preserved through merge/concat/groupby,
         # but is preserved through copy which is all we do here.
@@ -93,6 +123,39 @@ def _create_entity_examples(parsed: EntitiesByValueSchema) -> str:
         label: _EXAMPLE_LOOKUP.get(label, "(generate realistic synthetic replacement)") for label in sorted(labels)
     }
     return json.dumps(examples, ensure_ascii=True)
+
+
+def _filter_replacement_map_to_input_entities(
+    *,
+    raw_map: object,
+    parsed_entities: EntitiesByValueSchema,
+) -> dict[str, list[dict[str, str]]]:
+    """Keep only replacement entries that correspond to actual requested entities."""
+    if hasattr(raw_map, "model_dump"):
+        raw_map = raw_map.model_dump(mode="python")
+    if not isinstance(raw_map, dict):
+        return {"replacements": []}
+
+    try:
+        parsed_map = EntityReplacementMapSchema.model_validate(raw_map)
+    except Exception:
+        return {"replacements": []}
+
+    allowed_pairs = {
+        (entity.value, label)
+        for entity in parsed_entities.entities_by_value
+        for label in entity.labels
+        if entity.value and label
+    }
+    filtered: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for replacement in parsed_map.replacements:
+        key = (replacement.original, replacement.label)
+        if key not in allowed_pairs or key in seen:
+            continue
+        seen.add(key)
+        filtered.append(replacement.model_dump())
+    return {"replacements": filtered}
 
 
 def _get_replacement_mapping_prompt(*, entities_column: str, instructions: str | None = None) -> str:

--- a/tests/engine/test_llm_replace_workflow.py
+++ b/tests/engine/test_llm_replace_workflow.py
@@ -9,7 +9,7 @@ import pandas as pd
 from data_designer.config.models import ModelConfig
 
 from anonymizer.config.models import ReplaceModelSelection
-from anonymizer.engine.constants import COL_REPLACEMENT_MAP
+from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, COL_TEXT
 from anonymizer.engine.ndd.adapter import WorkflowRunResult
 from anonymizer.engine.replace.llm_replace_workflow import LlmReplaceWorkflow
 
@@ -46,3 +46,123 @@ def test_generate_map_only_preserves_input_attrs(
     )
 
     assert result.dataframe.attrs["original_text_column"] == "bio"
+
+
+def test_generate_map_only_skips_llm_for_rows_without_entities(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    adapter = Mock()
+    workflow = LlmReplaceWorkflow(adapter=adapter)
+
+    input_df = pd.DataFrame(
+        {
+            COL_TEXT: ["CT guided biopsy revealed a fatty mass which was diagnosed as lipoma."],
+            COL_ENTITIES_BY_VALUE: [{"entities_by_value": []}],
+            "tagged_text": ["CT guided biopsy revealed a fatty mass which was diagnosed as lipoma."],
+        }
+    )
+
+    result = workflow.generate_map_only(
+        input_df,
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+
+    adapter.run_workflow.assert_not_called()
+    assert result.dataframe[COL_REPLACEMENT_MAP].iloc[0] == {"replacements": []}
+
+
+def test_generate_map_only_filters_hallucinated_replacements(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Alice works at Acme"],
+                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
+                "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
+                COL_REPLACEMENT_MAP: [
+                    {
+                        "replacements": [
+                            {"original": "Alice", "label": "first_name", "synthetic": "Maya"},
+                            {"original": "Acme", "label": "organization", "synthetic": "NovaCorp"},
+                        ]
+                    }
+                ],
+            }
+        ),
+        failed_records=[],
+    )
+    workflow = LlmReplaceWorkflow(adapter=adapter)
+
+    input_df = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice works at Acme"],
+            COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
+            "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
+        }
+    )
+
+    result = workflow.generate_map_only(
+        input_df,
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+
+    assert result.dataframe[COL_REPLACEMENT_MAP].iloc[0] == {
+        "replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]
+    }
+
+
+def test_generate_map_only_preserves_original_row_order_with_mixed_rows(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Alice works at Acme"],
+                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
+                "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
+                "_row_order": [1],
+                COL_REPLACEMENT_MAP: [
+                    {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]}
+                ],
+            }
+        ),
+        failed_records=[],
+    )
+    workflow = LlmReplaceWorkflow(adapter=adapter)
+
+    input_df = pd.DataFrame(
+        {
+            COL_TEXT: ["No entities here", "Alice works at Acme", "Still no entities"],
+            COL_ENTITIES_BY_VALUE: [
+                {"entities_by_value": []},
+                {"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]},
+                {"entities_by_value": []},
+            ],
+            "tagged_text": [
+                "No entities here",
+                "<<PII:first_name>>Alice<</PII:first_name>> works at Acme",
+                "Still no entities",
+            ],
+        }
+    )
+
+    result = workflow.generate_map_only(
+        input_df,
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+
+    assert result.dataframe[COL_TEXT].tolist() == ["No entities here", "Alice works at Acme", "Still no entities"]
+    assert result.dataframe[COL_REPLACEMENT_MAP].tolist() == [
+        {"replacements": []},
+        {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]},
+        {"replacements": []},
+    ]

--- a/tests/engine/test_llm_replace_workflow.py
+++ b/tests/engine/test_llm_replace_workflow.py
@@ -24,6 +24,7 @@ def test_generate_map_only_preserves_input_attrs(
             {
                 "text": ["Alice works at Acme"],
                 COL_REPLACEMENT_MAP: [{"replacements": []}],
+                "_anonymizer_row_order": [0],
             }
         ),
         failed_records=[],
@@ -84,6 +85,7 @@ def test_generate_map_only_filters_hallucinated_replacements(
                 COL_TEXT: ["Alice works at Acme"],
                 COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
                 "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
+                "_anonymizer_row_order": [0],
                 COL_REPLACEMENT_MAP: [
                     {
                         "replacements": [
@@ -117,7 +119,7 @@ def test_generate_map_only_filters_hallucinated_replacements(
     }
 
 
-def test_generate_map_only_preserves_original_row_order_with_mixed_rows(
+def test_generate_map_only_preserves_original_anonymizer_row_order_with_mixed_rows(
     stub_model_configs: list[ModelConfig],
     stub_replace_model_selection: ReplaceModelSelection,
 ) -> None:
@@ -128,7 +130,7 @@ def test_generate_map_only_preserves_original_row_order_with_mixed_rows(
                 COL_TEXT: ["Alice works at Acme"],
                 COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
                 "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
-                "_row_order": [1],
+                "_anonymizer_row_order": [1],
                 COL_REPLACEMENT_MAP: [
                     {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]}
                 ],


### PR DESCRIPTION
## Summary

This fixes a `substitute()` inconsistency where rows could show unchanged replaced text alongside a hallucinated non-empty replacement map. We tighten the `substitute()` workflow so replacement maps are only generated for rows with actual entities to replace. This prevents bogus replacement-map entries from appearing when `_entities_by_value` is empty and keeps substitute output consistent with the detected entity set.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes