### PR TITLE
feat: add QA generation workflow for rewrite pipeline

### DIFF
--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -145,6 +145,11 @@ DEFAULT_ENTITY_LABELS: list[str] = list(ENTITY_LABEL_EXAMPLES.keys())
 # ---------------------------------------------------------------------------
 
 
-def _jinja(col: str) -> str:
-    """Wrap a column name in Jinja2 template syntax for use in NDD prompts."""
-    return "{{ " + col + " }}"
+def _jinja(col: str, *, key: str | None = None) -> str:
+    """Wrap a column name in Jinja2 template syntax for use in NDD prompts.
+
+    When *key* is given the expression becomes ``{{ col['key'] }}``,
+    providing a single grep-able call site for nested schema access.
+    """
+    expr = col if key is None else f"{col}['{key}']"
+    return "{{ " + expr + " }}"

--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -53,8 +53,11 @@ COL_FINAL_ENTITIES = "final_entities"
 
 COL_DOMAIN = "_domain"
 COL_DOMAIN_CONFIDENCE = "_domain_confidence"
+COL_DOMAIN_SUPPLEMENT = "_domain_supplement"
 COL_SENSITIVITY_DISPOSITION = "_sensitivity_disposition"
+COL_SENSITIVITY_DISPOSITION_BLOCK = "_sensitivity_disposition_block"
 COL_MEANING_UNITS = "_meaning_units"
+COL_MEANING_UNITS_SERIALIZED = "_meaning_units_serialized"
 COL_QUALITY_QA = "_quality_qa"
 COL_PRIVACY_QA = "_privacy_qa"
 COL_REWRITTEN_TEXT = "_rewritten_text"  # pre-repair intermediate; renamed to {text_col}_rewritten in user output

--- a/src/anonymizer/engine/rewrite/qa_generation.py
+++ b/src/anonymizer/engine/rewrite/qa_generation.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from data_designer.config import custom_column_generator
+from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+from data_designer.config.column_types import ColumnConfigT
+
+from anonymizer.config.models import RewriteModelSelection
+from anonymizer.engine.constants import (
+    COL_DOMAIN,
+    COL_DOMAIN_SUPPLEMENT,
+    COL_MEANING_UNITS,
+    COL_MEANING_UNITS_SERIALIZED,
+    COL_PRIVACY_QA,
+    COL_QUALITY_QA,
+    COL_SENSITIVITY_DISPOSITION,
+    COL_SENSITIVITY_DISPOSITION_BLOCK,
+    COL_TEXT,
+    _jinja,
+)
+from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.schemas import (
+    EntityCategory,
+    MeaningUnitsSchema,
+    PrivacyQAPairsSchema,
+    PrivacyQuestionSchema,
+    QualityQAPairsSchema,
+    SensitivityDispositionSchema,
+    SensitivityLevel,
+)
+
+# ---------------------------------------------------------------------------
+# Stage 1 pre-step: format disposition → disposition block
+# ---------------------------------------------------------------------------
+
+
+@custom_column_generator(required_columns=[COL_SENSITIVITY_DISPOSITION])
+def _format_disposition_block(row: dict[str, Any]) -> dict[str, Any]:
+    """Serialize sensitivity disposition into a JSON block for the meaning unit extraction prompt."""
+    disposition: SensitivityDispositionSchema = row[COL_SENSITIVITY_DISPOSITION]
+    block = [
+        {
+            "entity_value": e.entity_value,
+            "needs_protection": e.needs_protection,
+            "protection_method": e.protection_method_suggestion,
+            "category": e.category,
+        }
+        for e in disposition.sensitivity_disposition
+    ]
+    row[COL_SENSITIVITY_DISPOSITION_BLOCK] = json.dumps(block, ensure_ascii=False)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 prompt: meaning unit extraction
+# ---------------------------------------------------------------------------
+
+
+def _get_meaning_unit_extraction_prompt() -> str:
+    prompt = """You are extracting IMPORTANT MEANING UNITS from a text to evaluate anonymization quality.
+The original text may contain sensitive entities; a separate system will rewrite it.
+Your job is to capture the core informational content that MUST be preserved for the text to remain
+useful, while avoiding unsafe disclosure of identifying details.
+
+<entity_protection_rules>
+You are given an ENTITY PROTECTION BLOCK — a JSON array where each entity has an "entity_value" string
+(e.g., a name, address, occupation, city, diagnosis). Treat every entity_value where needs_protection=true
+as a BANNED SURFACE FORM:
+
+- None of these entity_value strings may appear anywhere in any "unit".
+- If a unit would require using one of these exact strings, you MUST either:
+  - rewrite it in more abstract terms that do NOT contain that value, OR
+  - DROP that unit if it cannot be expressed safely.
+
+Apply this by type:
+
+1. DIRECT IDENTIFIERS (names, exact addresses, exact ages, record numbers)
+   - NEVER include them.
+   - Keep only abstract roles or relations (e.g., "the individual",
+     "a close family member", "a colleague").
+   - If the idea is only interesting because of the specific identity,
+     drop it.
+
+2. QUASI-IDENTIFIERS (occupation, city, school, degree, event names, etc.)
+   - Keep the KIND of information, but generalize so the original value
+     is not recoverable.
+   - DO NOT repeat the exact value text from the sensitive block.
+   - Use broader or paraphrased categories (e.g., "a medical specialist",
+     "a higher-education program", "a local community event", "a city").
+
+3. LATENT / HIGHLY SENSITIVE ATTRIBUTES (medical_condition, family_death,
+   religion, etc.)
+   - If not essential to the meaning, DROP them.
+   - If essential (e.g., motivation, history), describe them in softened,
+     high-level form (e.g., "a health difficulty", "a personal loss")
+     and NEVER use the exact value string.
+
+4. GENERALIZATION AND SAFETY
+   - Prefer abstract phrases like "the individual", "a family member",
+     "a local area", "a professional setting", "a long-term challenge".
+   - Avoid precise times, counts, and locations when they combine with
+     other details to make someone easy to identify.
+   - When in doubt, DROP the detail rather than risk leaking a sensitive value.
+</entity_protection_rules>
+
+<importance_criteria>
+KEEP a detail if removing it would significantly weaken understanding of:
+- The main roles or functions of the key actors.
+- Core processes, workflows, decisions, or events.
+- Key outputs, products, or creative/technical results.
+- Important relationships, obligations, or dependencies.
+- Central values, beliefs, or motivations that clearly drive behavior.
+- Critical contextual constraints (e.g., high-level timelines, key conditions).
+
+DROP details that are:
+- Purely decorative, anecdotal, or atmospheric.
+- Redundant restatements of a previously captured unit.
+- Hyper-local or overly specific identifiers that don't affect the underlying logic or meaning.
+
+Each meaning unit must contain only the information required to support a single quality-check question.
+</importance_criteria>
+
+<segmentation_rules>
+- Each meaning unit must express ONE coherent idea.
+- If a sentence encodes multiple important ideas, split them into separate units.
+- If two sentences form a single coherent idea that cannot be separated without losing meaning,
+  merge them into one unit.
+</segmentation_rules>
+
+<domain_context>
+Primary domain: <<DOMAIN>>
+
+Domain-specific guidance:
+---
+<<DOMAIN_SUPPLEMENT>>
+---
+</domain_context>
+
+<input>
+Entity protection block:
+---
+<<ENTITY_PROTECTION_BLOCK>>
+---
+
+Original text:
+---
+<<TEXT>>
+---
+</input>"""
+    return (
+        prompt.replace("<<ENTITY_PROTECTION_BLOCK>>", _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK))
+        .replace("<<DOMAIN>>", _jinja(COL_DOMAIN + "['domain']"))
+        .replace("<<DOMAIN_SUPPLEMENT>>", _jinja(COL_DOMAIN_SUPPLEMENT))
+        .replace("<<TEXT>>", _jinja(COL_TEXT))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 pre-step: serialize meaning units → JSON string
+# ---------------------------------------------------------------------------
+
+
+@custom_column_generator(required_columns=[COL_MEANING_UNITS])
+def _serialize_meaning_units(row: dict[str, Any]) -> dict[str, Any]:
+    """Serialize MeaningUnitsSchema to a JSON string for injection into the QA generation prompt."""
+    meaning_units: MeaningUnitsSchema = row[COL_MEANING_UNITS]
+    row[COL_MEANING_UNITS_SERIALIZED] = json.dumps([u.model_dump() for u in meaning_units.units], ensure_ascii=False)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 prompt: quality QA generation from meaning units
+# ---------------------------------------------------------------------------
+
+
+def _get_quality_qa_prompt() -> str:
+    prompt = """You are creating QUALITY-CHECK QUESTIONS for anonymized text.
+
+You will be given a JSON array of MEANING UNITS that are already abstracted and PII-safe.
+Each meaning unit has:
+- "id": an integer identifier
+- "aspect": a label describing the type of information
+- "unit": a short sentence or clause capturing one important idea
+
+Your task is to generate, for EACH meaning unit:
+- ONE open-ended question that checks whether that unit is still true in an anonymized version of the text.
+- ONE concise reference answer that matches the meaning unit.
+
+<constraints>
+1. Base questions and answers ONLY on the information present in the meaning units.
+   Do NOT invent or recall any extra details not explicitly in the "unit" field.
+
+2. Do NOT introduce any specific identifiers not present in the unit itself, including:
+   - Personal names, family member names, or character names.
+   - Street names, cities, regions, or institutions.
+   - Program names, event names, branded titles, or other unique labels.
+   If a unit uses abstract phrasing (e.g., "the individual", "a family member"), keep the
+   same level of abstraction in the question and answer.
+
+3. Questions should be specific enough to verify the meaning unit is preserved, but open-ended.
+   - Avoid yes/no questions.
+   - Start with: "what", "how", "why", "when", "where", or "in what way".
+
+4. The reference answer should:
+   - Be short and factual.
+   - Align directly with the "unit" text at the same abstraction level.
+   - NOT add new information beyond what is in the unit.
+</constraints>
+
+<input>
+Meaning units:
+---
+<<MEANING_UNITS_SERIALIZED>>
+---
+</input>"""
+    return prompt.replace("<<MEANING_UNITS_SERIALIZED>>", _jinja(COL_MEANING_UNITS_SERIALIZED))
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: privacy QA generation (pure Python, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def generate_privacy_qa_from_disposition(
+    disposition: SensitivityDispositionSchema,
+) -> PrivacyQAPairsSchema:
+    """Generate privacy QA questions from sensitivity disposition without an LLM call.
+
+    Produces one question per entity that needs protection:
+        "Can the {entity_label} '{entity_value}' be deduced from the rewritten text?"
+    All questions expect the answer "no" — a "yes" answer indicates a privacy leak.
+    """
+    questions = []
+    for idx, entity in enumerate(disposition.protected_entities, start=1):
+        questions.append(
+            PrivacyQuestionSchema(
+                id=idx,
+                question=f"Can the {entity.entity_label} '{entity.entity_value}' be deduced from the rewritten text?",
+                sensitivity=SensitivityLevel(entity.sensitivity),
+                entity_label=entity.entity_label,
+                entity_value=entity.entity_value,
+                category=EntityCategory(entity.category),
+            )
+        )
+    return PrivacyQAPairsSchema(items=questions)
+
+
+@custom_column_generator(required_columns=[COL_SENSITIVITY_DISPOSITION])
+def _generate_privacy_qa_column(row: dict[str, Any]) -> dict[str, Any]:
+    """Generate privacy QA questions from sensitivity disposition without an LLM call."""
+    disposition: SensitivityDispositionSchema = row[COL_SENSITIVITY_DISPOSITION]
+    row[COL_PRIVACY_QA] = generate_privacy_qa_from_disposition(disposition)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+
+
+class QAGenerationWorkflow:
+    def columns(
+        self,
+        *,
+        selected_models: RewriteModelSelection,
+    ) -> list[ColumnConfigT]:
+        meaning_extractor_alias = resolve_model_alias("meaning_extractor", selected_models)
+        qa_generator_alias = resolve_model_alias("qa_generator", selected_models)
+        return [
+            CustomColumnConfig(
+                name=COL_SENSITIVITY_DISPOSITION_BLOCK,
+                generator_function=_format_disposition_block,
+            ),
+            LLMStructuredColumnConfig(
+                name=COL_MEANING_UNITS,
+                prompt=_get_meaning_unit_extraction_prompt(),
+                model_alias=meaning_extractor_alias,
+                output_format=MeaningUnitsSchema,
+            ),
+            CustomColumnConfig(
+                name=COL_MEANING_UNITS_SERIALIZED,
+                generator_function=_serialize_meaning_units,
+            ),
+            LLMStructuredColumnConfig(
+                name=COL_QUALITY_QA,
+                prompt=_get_quality_qa_prompt(),
+                model_alias=qa_generator_alias,
+                output_format=QualityQAPairsSchema,
+            ),
+            CustomColumnConfig(
+                name=COL_PRIVACY_QA,
+                generator_function=_generate_privacy_qa_column,
+            ),
+        ]

--- a/src/anonymizer/engine/rewrite/qa_generation.py
+++ b/src/anonymizer/engine/rewrite/qa_generation.py
@@ -47,7 +47,7 @@ _DOMAIN_KEY = next(name for name, info in DomainClassificationSchema.model_field
 @custom_column_generator(required_columns=[COL_SENSITIVITY_DISPOSITION])
 def _format_disposition_block(row: dict[str, Any]) -> dict[str, Any]:
     """Serialize sensitivity disposition into a JSON block for the meaning unit extraction prompt."""
-    disposition: SensitivityDispositionSchema = row[COL_SENSITIVITY_DISPOSITION]
+    disposition = SensitivityDispositionSchema.model_validate(row.get(COL_SENSITIVITY_DISPOSITION, {}))
     block = [
         {
             "entity_value": e.entity_value,
@@ -173,7 +173,7 @@ Original text:
 @custom_column_generator(required_columns=[COL_MEANING_UNITS])
 def _serialize_meaning_units(row: dict[str, Any]) -> dict[str, Any]:
     """Serialize MeaningUnitsSchema to a JSON string for injection into the QA generation prompt."""
-    meaning_units: MeaningUnitsSchema = row[COL_MEANING_UNITS]
+    meaning_units = MeaningUnitsSchema.model_validate(row.get(COL_MEANING_UNITS, {}))
     row[COL_MEANING_UNITS_SERIALIZED] = json.dumps([u.model_dump() for u in meaning_units.units], ensure_ascii=False)
     return row
 
@@ -258,7 +258,7 @@ def generate_privacy_qa_from_disposition(
 @custom_column_generator(required_columns=[COL_SENSITIVITY_DISPOSITION])
 def _generate_privacy_qa_column(row: dict[str, Any]) -> dict[str, Any]:
     """Generate privacy QA questions from sensitivity disposition without an LLM call."""
-    disposition: SensitivityDispositionSchema = row[COL_SENSITIVITY_DISPOSITION]
+    disposition = SensitivityDispositionSchema.model_validate(row.get(COL_SENSITIVITY_DISPOSITION, {}))
     row[COL_PRIVACY_QA] = generate_privacy_qa_from_disposition(disposition)
     return row
 

--- a/src/anonymizer/engine/rewrite/qa_generation.py
+++ b/src/anonymizer/engine/rewrite/qa_generation.py
@@ -37,7 +37,12 @@ from anonymizer.engine.schemas import (
 )
 
 # Derived from the schema so the Jinja key stays in sync with the field name.
-_DOMAIN_KEY = next(name for name, info in DomainClassificationSchema.model_fields.items() if info.annotation is Domain)
+_DOMAIN_KEY = next(
+    (name for name, info in DomainClassificationSchema.model_fields.items() if info.annotation is Domain),
+    None,
+)
+if _DOMAIN_KEY is None:
+    raise RuntimeError("DomainClassificationSchema must define a field annotated with Domain")
 
 # ---------------------------------------------------------------------------
 # Stage 1 pre-step: format disposition → disposition block
@@ -51,8 +56,8 @@ def _format_disposition_block(row: dict[str, Any]) -> dict[str, Any]:
     block = [
         {
             "entity_value": e.entity_value,
-            "needs_protection": e.needs_protection,
-            "protection_method": e.protection_method_suggestion,  # shortened key for prompt brevity
+            "does_need_protection": e.needs_protection,
+            "protection_method_suggestion": e.protection_method_suggestion,
             "category": e.category,
         }
         for e in disposition.sensitivity_disposition
@@ -69,52 +74,68 @@ def _format_disposition_block(row: dict[str, Any]) -> dict[str, Any]:
 def _get_meaning_unit_extraction_prompt() -> str:
     prompt = """You are extracting IMPORTANT MEANING UNITS from a text to evaluate anonymization quality.
 The original text may contain sensitive entities; a separate system will rewrite it.
-Your job is to capture the core informational content that MUST be preserved for the text to remain
-useful, while avoiding unsafe disclosure of identifying details.
+Your job is to capture the core informational content that MUST be preserved for the text to remain useful,
+while avoiding unsafe disclosure of identifying details.
+
+You are given:
+- The ORIGINAL TEXT.
+- A SENSITIVITY DISPOSITION BLOCK (entities with protection decisions).
+- A PRIMARY DOMAIN and DOMAIN-SPECIFIC GUIDANCE.
+
+Your output will be a JSON array of meaning units. Each unit is a short statement
+that captures ONE important fact, process, value, or relationship that should
+remain true after anonymization.
 
 <entity_protection_rules>
-You are given an ENTITY PROTECTION BLOCK — a JSON array where each entity has an "entity_value" string
-(e.g., a name, address, occupation, city, diagnosis). Treat every entity_value where needs_protection=true
-as a BANNED SURFACE FORM:
+You are given a SENSITIVITY DISPOSITION BLOCK, which contains entries like:
+- entity_value (surface form from the original text)
+- does_need_protection (True/False)
+- protection_method_suggestion (replace/remove/generalize/paraphrase/left_as_is)
+- category (direct_identifier/quasi_identifier/sensitive_attribute/latent_identifier/etc.)
 
-- None of these entity_value strings may appear anywhere in any "unit".
-- If a unit would require using one of these exact strings, you MUST either:
-  - rewrite it in more abstract terms that do NOT contain that value, OR
-  - DROP that unit if it cannot be expressed safely.
+Use it as follows:
 
-Apply this by type:
+A) HARD BANS (must not appear in meaning units)
+If an entry has:
+  - does_need_protection = True
+  AND protection_method_suggestion is "replace" OR "remove"
+Then treat its entity_value as a BANNED SURFACE FORM:
+  - Do NOT include that exact string anywhere in any unit.
+  - Also do NOT include near-verbatim variants that obviously preserve the same identifier.
+  - If the underlying fact is important, express it WITHOUT that value using abstraction
+    (roles, relationships, high-level descriptions).
+  - If it cannot be expressed safely without carrying identifying detail, DROP the unit.
 
-1. DIRECT IDENTIFIERS (names, exact addresses, exact ages, record numbers)
-   - NEVER include them.
-   - Keep only abstract roles or relations (e.g., "the individual",
-     "a close family member", "a colleague").
-   - If the idea is only interesting because of the specific identity,
-     drop it.
+B) TRANSFORM-ALLOWED (allowed only if generalized/paraphrased)
+If an entry has:
+  - does_need_protection = True
+  AND protection_method_suggestion is "generalize" OR "paraphrase"
+Then you MAY still capture the meaning, BUT you must NOT use the entity_value itself.
+Instead: preserve the semantic role while moving to a broader, less identifying level of abstraction.
+This may include:
 
-2. QUASI-IDENTIFIERS (occupation, city, school, degree, event names, etc.)
-   - Keep the KIND of information, but generalize so the original value
-     is not recoverable.
-   - DO NOT repeat the exact value text from the sensitive block.
-   - Use broader or paraphrased categories (e.g., "a medical specialist",
-     "a higher-education program", "a local community event", "a city").
+  • Geographic hierarchy: city → state → region → country
+  • Institutional hierarchy: named organization → organization type
+  • Role hierarchy: specific specialty → broader profession
+  • Temporal abstraction: exact date → approximate period
+  • Quantitative abstraction: exact number → rough scale
+  • Named program/product → generic descriptive category
 
-3. LATENT / HIGHLY SENSITIVE ATTRIBUTES (medical_condition, family_death,
-   religion, etc.)
-   - If not essential to the meaning, DROP them.
-   - If essential (e.g., motivation, history), describe them in softened,
-     high-level form (e.g., "a health difficulty", "a personal loss")
-     and NEVER use the exact value string.
+The generalized phrasing must prevent recovery or lookup of the original entity_value while
+still preserving the meaning needed for usefulness.
 
-4. GENERALIZATION AND SAFETY
-   - Prefer abstract phrases like "the individual", "a family member",
-     "a local area", "a professional setting", "a long-term challenge".
-   - Avoid precise times, counts, and locations when they combine with
-     other details to make someone easy to identify.
-   - When in doubt, DROP the detail rather than risk leaking a sensitive value.
+C) SAFE / LEFT-AS-IS (no special avoidance required)
+If an entry has:
+  - does_need_protection = False
+Then you do NOT need to avoid it for privacy reasons in meaning units.
+However:
+  - still prefer concise phrasing and avoid unnecessary precision
+  - avoid adding extra identifying detail beyond what is needed for meaning
 </entity_protection_rules>
 
 <importance_criteria>
-KEEP a detail if removing it would significantly weaken understanding of:
+KEEP a detail as a meaning unit if removing it would significantly weaken
+understanding of:
 - The main roles or functions of the key actors.
 - Core processes, workflows, decisions, or events.
 - Key outputs, products, or creative/technical results.
@@ -140,22 +161,29 @@ Each meaning unit must contain only the information required to support a single
 <domain_context>
 Primary domain: <<DOMAIN>>
 
-Domain-specific guidance:
----
+DOMAIN-SPECIFIC GUIDANCE (CONTEXT):
+
 <<DOMAIN_SUPPLEMENT>>
----
+
+Use this guidance to decide what is "important" versus "nice-to-have" in this text.
+For example:
+- In LEGAL/POLICY, obligations, conditions, exceptions, and remedies are critical.
+- In CLINICAL/EHR, symptoms, diagnoses, interventions, and timelines of care are critical.
+- In TECHNICAL, inputs/outputs, requirements, constraints, and failure modes are critical.
+- In CHAT/EMAIL/CSAT, the problem, key actions, decisions, and resolutions are critical.
+But always apply this in context of the actual text, not blindly.
 </domain_context>
 
 <input>
-Entity protection block:
----
-<<ENTITY_PROTECTION_BLOCK>>
----
-
 Original text:
----
+<<<
 <<TEXT>>
----
+>>>
+
+Sensitivity disposition:
+<<<
+<<ENTITY_PROTECTION_BLOCK>>
+>>>
 </input>"""
     return (
         prompt.replace("<<ENTITY_PROTECTION_BLOCK>>", _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK))

--- a/src/anonymizer/engine/rewrite/qa_generation.py
+++ b/src/anonymizer/engine/rewrite/qa_generation.py
@@ -25,6 +25,8 @@ from anonymizer.engine.constants import (
 )
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
 from anonymizer.engine.schemas import (
+    Domain,
+    DomainClassificationSchema,
     EntityCategory,
     MeaningUnitsSchema,
     PrivacyQAPairsSchema,
@@ -33,6 +35,9 @@ from anonymizer.engine.schemas import (
     SensitivityDispositionSchema,
     SensitivityLevel,
 )
+
+# Derived from the schema so the Jinja key stays in sync with the field name.
+_DOMAIN_KEY = next(name for name, info in DomainClassificationSchema.model_fields.items() if info.annotation is Domain)
 
 # ---------------------------------------------------------------------------
 # Stage 1 pre-step: format disposition → disposition block
@@ -47,7 +52,7 @@ def _format_disposition_block(row: dict[str, Any]) -> dict[str, Any]:
         {
             "entity_value": e.entity_value,
             "needs_protection": e.needs_protection,
-            "protection_method": e.protection_method_suggestion,
+            "protection_method": e.protection_method_suggestion,  # shortened key for prompt brevity
             "category": e.category,
         }
         for e in disposition.sensitivity_disposition
@@ -154,7 +159,7 @@ Original text:
 </input>"""
     return (
         prompt.replace("<<ENTITY_PROTECTION_BLOCK>>", _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK))
-        .replace("<<DOMAIN>>", _jinja(COL_DOMAIN + "['domain']"))
+        .replace("<<DOMAIN>>", _jinja(COL_DOMAIN, key=_DOMAIN_KEY))
         .replace("<<DOMAIN_SUPPLEMENT>>", _jinja(COL_DOMAIN_SUPPLEMENT))
         .replace("<<TEXT>>", _jinja(COL_TEXT))
     )

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -41,7 +41,6 @@ Utility: generate_privacy_qa_from_disposition — template-based, no LLM require
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -357,36 +356,3 @@ class JudgeEvaluationSchema(BaseModel):
     privacy: JudgeScoreSchema
     quality: JudgeScoreSchema
     naturalness: JudgeScoreSchema
-
-
-# ---------------------------------------------------------------------------
-# Utility: template-based privacy QA generation (no LLM required)
-# TODO(#32): move to engine/rewrite/qa_generation.py once that workflow owns it
-# ---------------------------------------------------------------------------
-
-
-def generate_privacy_qa_from_disposition(
-    sensitivity_disposition: SensitivityDispositionSchema | dict[str, Any],
-) -> PrivacyQAPairsSchema:
-    """Generate privacy QA questions from sensitivity disposition without an LLM call.
-
-    Produces one question per entity that needs protection:
-        "Can the {entity_label} '{entity_value}' be deduced from the rewritten text?"
-    All questions expect the answer "no" — a "yes" answer indicates a privacy leak.
-    """
-    if isinstance(sensitivity_disposition, dict):
-        sensitivity_disposition = SensitivityDispositionSchema.model_validate(sensitivity_disposition)
-
-    questions = []
-    for idx, entity in enumerate(sensitivity_disposition.protected_entities, start=1):
-        questions.append(
-            PrivacyQuestionSchema(
-                id=idx,
-                question=f"Can the {entity.entity_label} '{entity.entity_value}' be deduced from the rewritten text?",
-                sensitivity=SensitivityLevel(entity.sensitivity),
-                entity_label=entity.entity_label,
-                entity_value=entity.entity_value,
-                category=EntityCategory(entity.category),
-            )
-        )
-    return PrivacyQAPairsSchema(items=questions)

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -159,6 +159,10 @@ class SensitivityDispositionSchema(BaseModel):
 
     Validates that entity IDs are sequential from 1 and that each entity's
     ``needs_protection`` flag is consistent with its ``protection_method_suggestion``.
+
+    ``sensitivity_disposition`` requires at least one entry (``min_length=1``).
+    The orchestrator short-circuits before this step when detection finds no
+    entities, so an empty list here indicates a pipeline bug.
     """
 
     # Non-empty by design: the rewrite workflow only runs when entities were detected.

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -34,8 +34,6 @@ Each schema group corresponds to one pipeline step:
 
 Supporting enums: Domain, EntitySource, EntityCategory, SensitivityLevel,
                   ProtectionMethod, CombinedRiskLevel, MeaningUnitAspect, PrivacyAnswer
-
-Utility: generate_privacy_qa_from_disposition — template-based, no LLM required.
 """
 
 from __future__ import annotations

--- a/tests/engine/test_qa_generation.py
+++ b/tests/engine/test_qa_generation.py
@@ -117,10 +117,10 @@ def test_format_disposition_block_produces_valid_json() -> None:
     block = json.loads(result[COL_SENSITIVITY_DISPOSITION_BLOCK])
     assert len(block) == 2
     assert block[0]["entity_value"] == "Alice"
-    assert block[0]["needs_protection"] is True
-    assert block[0]["protection_method"] == "replace"
+    assert block[0]["does_need_protection"] is True
+    assert block[0]["protection_method_suggestion"] == "replace"
     assert block[1]["entity_value"] == "Portland"
-    assert block[1]["needs_protection"] is False
+    assert block[1]["does_need_protection"] is False
 
 
 def test_format_disposition_block_accepts_dict_payload() -> None:
@@ -258,6 +258,23 @@ def test_meaning_unit_prompt_references_required_columns() -> None:
     assert _jinja(COL_DOMAIN, key=_DOMAIN_KEY) in prompt
     assert _jinja(COL_DOMAIN_SUPPLEMENT) in prompt
     assert _jinja(COL_TEXT) in prompt
+
+
+def test_meaning_unit_prompt_preserves_gitlab_protection_branches() -> None:
+    prompt = _get_meaning_unit_extraction_prompt()
+    assert "does_need_protection = True" in prompt
+    assert 'protection_method_suggestion is "replace" OR "remove"' in prompt
+    assert 'protection_method_suggestion is "generalize" OR "paraphrase"' in prompt
+    assert "does_need_protection = False" in prompt
+
+
+def test_meaning_unit_prompt_keeps_xml_style_blocks() -> None:
+    prompt = _get_meaning_unit_extraction_prompt()
+    assert "<entity_protection_rules>" in prompt
+    assert "<importance_criteria>" in prompt
+    assert "<segmentation_rules>" in prompt
+    assert "<domain_context>" in prompt
+    assert "<input>" in prompt
 
 
 def test_quality_qa_prompt_references_meaning_units_serialized() -> None:

--- a/tests/engine/test_qa_generation.py
+++ b/tests/engine/test_qa_generation.py
@@ -9,6 +9,7 @@ from data_designer.config.column_configs import CustomColumnConfig, LLMStructure
 
 from anonymizer.config.models import RewriteModelSelection
 from anonymizer.engine.constants import (
+    COL_DOMAIN,
     COL_DOMAIN_SUPPLEMENT,
     COL_MEANING_UNITS,
     COL_MEANING_UNITS_SERIALIZED,
@@ -20,6 +21,7 @@ from anonymizer.engine.constants import (
     _jinja,
 )
 from anonymizer.engine.rewrite.qa_generation import (
+    _DOMAIN_KEY,
     QAGenerationWorkflow,
     _format_disposition_block,
     _generate_privacy_qa_column,
@@ -229,6 +231,7 @@ def test_generate_privacy_qa_from_disposition_ids_are_sequential() -> None:
 def test_meaning_unit_prompt_references_required_columns() -> None:
     prompt = _get_meaning_unit_extraction_prompt()
     assert _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK) in prompt
+    assert _jinja(COL_DOMAIN, key=_DOMAIN_KEY) in prompt
     assert _jinja(COL_DOMAIN_SUPPLEMENT) in prompt
     assert _jinja(COL_TEXT) in prompt
 

--- a/tests/engine/test_qa_generation.py
+++ b/tests/engine/test_qa_generation.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+
+from anonymizer.config.models import RewriteModelSelection
+from anonymizer.engine.constants import (
+    COL_DOMAIN_SUPPLEMENT,
+    COL_MEANING_UNITS,
+    COL_MEANING_UNITS_SERIALIZED,
+    COL_PRIVACY_QA,
+    COL_QUALITY_QA,
+    COL_SENSITIVITY_DISPOSITION,
+    COL_SENSITIVITY_DISPOSITION_BLOCK,
+    COL_TEXT,
+    _jinja,
+)
+from anonymizer.engine.rewrite.qa_generation import (
+    QAGenerationWorkflow,
+    _format_disposition_block,
+    _generate_privacy_qa_column,
+    _get_meaning_unit_extraction_prompt,
+    _get_quality_qa_prompt,
+    _serialize_meaning_units,
+    generate_privacy_qa_from_disposition,
+)
+from anonymizer.engine.schemas import (
+    EntityCategory,
+    EntityDispositionSchema,
+    EntitySource,
+    MeaningUnitAspect,
+    MeaningUnitSchema,
+    MeaningUnitsSchema,
+    PrivacyQAPairsSchema,
+    ProtectionMethod,
+    SensitivityDispositionSchema,
+    SensitivityLevel,
+)
+
+_STUB_DISPOSITION = SensitivityDispositionSchema(
+    sensitivity_disposition=[
+        EntityDispositionSchema(
+            id=1,
+            source=EntitySource.tagged,
+            category=EntityCategory.direct_identifier,
+            sensitivity=SensitivityLevel.high,
+            entity_label="first_name",
+            entity_value="Alice",
+            needs_protection=True,
+            protection_reason="Full name directly identifies the individual.",
+            protection_method_suggestion=ProtectionMethod.replace,
+            combined_risk_level="high",
+        ),
+        EntityDispositionSchema(
+            id=2,
+            source=EntitySource.tagged,
+            category=EntityCategory.quasi_identifier,
+            sensitivity=SensitivityLevel.low,
+            entity_label="city",
+            entity_value="Portland",
+            needs_protection=False,
+            protection_reason="City alone does not create meaningful re-identification risk here.",
+            protection_method_suggestion=ProtectionMethod.left_as_is,
+            combined_risk_level="low",
+        ),
+    ]
+)
+
+_STUB_MEANING_UNITS = MeaningUnitsSchema(
+    units=[
+        MeaningUnitSchema(id=1, aspect=MeaningUnitAspect.ROLE, unit="An individual works as a software engineer."),
+        MeaningUnitSchema(id=2, aspect=MeaningUnitAspect.ENVIRONMENT, unit="The individual works remotely."),
+    ]
+)
+
+
+def test_columns_returns_exactly_five_in_order(
+    stub_rewrite_model_selection: RewriteModelSelection,
+) -> None:
+    cols = QAGenerationWorkflow().columns(selected_models=stub_rewrite_model_selection)
+    assert len(cols) == 5
+    assert isinstance(cols[0], CustomColumnConfig)
+    assert isinstance(cols[1], LLMStructuredColumnConfig)
+    assert isinstance(cols[2], CustomColumnConfig)
+    assert isinstance(cols[3], LLMStructuredColumnConfig)
+    assert isinstance(cols[4], CustomColumnConfig)
+    assert cols[0].name == COL_SENSITIVITY_DISPOSITION_BLOCK
+    assert cols[1].name == COL_MEANING_UNITS
+    assert cols[2].name == COL_MEANING_UNITS_SERIALIZED
+    assert cols[3].name == COL_QUALITY_QA
+    assert cols[4].name == COL_PRIVACY_QA
+
+
+def test_meaning_extractor_alias_used(
+    stub_rewrite_model_selection: RewriteModelSelection,
+) -> None:
+    cols = QAGenerationWorkflow().columns(selected_models=stub_rewrite_model_selection)
+    assert cols[1].model_alias == stub_rewrite_model_selection.meaning_extractor
+
+
+def test_qa_generator_alias_used(
+    stub_rewrite_model_selection: RewriteModelSelection,
+) -> None:
+    cols = QAGenerationWorkflow().columns(selected_models=stub_rewrite_model_selection)
+    assert cols[3].model_alias == stub_rewrite_model_selection.qa_generator
+
+
+def test_format_disposition_block_produces_valid_json() -> None:
+    row = {COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION}
+    result = _format_disposition_block(row)
+    block = json.loads(result[COL_SENSITIVITY_DISPOSITION_BLOCK])
+    assert len(block) == 2
+    assert block[0]["entity_value"] == "Alice"
+    assert block[0]["needs_protection"] is True
+    assert block[0]["protection_method"] == "replace"
+    assert block[1]["entity_value"] == "Portland"
+    assert block[1]["needs_protection"] is False
+
+
+def test_serialize_meaning_units_produces_valid_json() -> None:
+    row = {COL_MEANING_UNITS: _STUB_MEANING_UNITS}
+    result = _serialize_meaning_units(row)
+    serialized = json.loads(result[COL_MEANING_UNITS_SERIALIZED])
+    assert len(serialized) == 2
+    assert serialized[0]["id"] == 1
+    assert serialized[0]["aspect"] == "role"
+    assert "software engineer" in serialized[0]["unit"]
+
+
+def test_generate_privacy_qa_column_only_protected_entities() -> None:
+    row = {COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION}
+    result = _generate_privacy_qa_column(row)
+    qa: PrivacyQAPairsSchema = result[COL_PRIVACY_QA]
+    # Only Alice needs protection; Portland does not
+    assert len(qa.items) == 1
+    assert "Alice" in qa.items[0].question
+    assert qa.items[0].entity_label == "first_name"
+    assert qa.items[0].sensitivity == SensitivityLevel.high
+
+
+def test_generate_privacy_qa_column_no_protected_entities() -> None:
+    disposition = SensitivityDispositionSchema(
+        sensitivity_disposition=[
+            EntityDispositionSchema(
+                id=1,
+                source=EntitySource.tagged,
+                category=EntityCategory.quasi_identifier,
+                sensitivity=SensitivityLevel.low,
+                entity_label="city",
+                entity_value="Portland",
+                needs_protection=False,
+                protection_reason="City alone does not create meaningful re-identification risk.",
+                protection_method_suggestion=ProtectionMethod.left_as_is,
+                combined_risk_level="low",
+            )
+        ]
+    )
+    row = {COL_SENSITIVITY_DISPOSITION: disposition}
+    result = _generate_privacy_qa_column(row)
+    qa: PrivacyQAPairsSchema = result[COL_PRIVACY_QA]
+    assert len(qa.items) == 0
+
+
+def test_generate_privacy_qa_from_disposition_only_protected_entities() -> None:
+    qa = generate_privacy_qa_from_disposition(_STUB_DISPOSITION)
+    assert len(qa.items) == 1
+    assert "Alice" in qa.items[0].question
+    assert qa.items[0].entity_label == "first_name"
+    assert qa.items[0].sensitivity == SensitivityLevel.high
+
+
+def test_generate_privacy_qa_from_disposition_empty_when_nothing_to_protect() -> None:
+    disposition = SensitivityDispositionSchema(
+        sensitivity_disposition=[
+            EntityDispositionSchema(
+                id=1,
+                source=EntitySource.tagged,
+                category=EntityCategory.quasi_identifier,
+                sensitivity=SensitivityLevel.low,
+                entity_label="city",
+                entity_value="Portland",
+                needs_protection=False,
+                protection_reason="City alone does not create meaningful re-identification risk.",
+                protection_method_suggestion=ProtectionMethod.left_as_is,
+                combined_risk_level="low",
+            )
+        ]
+    )
+    assert generate_privacy_qa_from_disposition(disposition).items == []
+
+
+def test_generate_privacy_qa_from_disposition_ids_are_sequential() -> None:
+    disposition = SensitivityDispositionSchema(
+        sensitivity_disposition=[
+            EntityDispositionSchema(
+                id=1,
+                source=EntitySource.tagged,
+                category=EntityCategory.direct_identifier,
+                sensitivity=SensitivityLevel.high,
+                entity_label="first_name",
+                entity_value="Alice",
+                needs_protection=True,
+                protection_reason="Direct identifier.",
+                protection_method_suggestion=ProtectionMethod.replace,
+                combined_risk_level="high",
+            ),
+            EntityDispositionSchema(
+                id=2,
+                source=EntitySource.tagged,
+                category=EntityCategory.direct_identifier,
+                sensitivity=SensitivityLevel.high,
+                entity_label="last_name",
+                entity_value="Smith",
+                needs_protection=True,
+                protection_reason="Direct identifier.",
+                protection_method_suggestion=ProtectionMethod.replace,
+                combined_risk_level="high",
+            ),
+        ]
+    )
+    qa = generate_privacy_qa_from_disposition(disposition)
+    assert [item.id for item in qa.items] == [1, 2]
+
+
+def test_meaning_unit_prompt_references_required_columns() -> None:
+    prompt = _get_meaning_unit_extraction_prompt()
+    assert _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK) in prompt
+    assert _jinja(COL_DOMAIN_SUPPLEMENT) in prompt
+    assert _jinja(COL_TEXT) in prompt
+
+
+def test_quality_qa_prompt_references_meaning_units_serialized() -> None:
+    prompt = _get_quality_qa_prompt()
+    assert _jinja(COL_MEANING_UNITS_SERIALIZED) in prompt

--- a/tests/engine/test_qa_generation.py
+++ b/tests/engine/test_qa_generation.py
@@ -123,6 +123,14 @@ def test_format_disposition_block_produces_valid_json() -> None:
     assert block[1]["needs_protection"] is False
 
 
+def test_format_disposition_block_accepts_dict_payload() -> None:
+    row = {COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION.model_dump(mode="python")}
+    result = _format_disposition_block(row)
+    block = json.loads(result[COL_SENSITIVITY_DISPOSITION_BLOCK])
+    assert len(block) == 2
+    assert block[0]["entity_value"] == "Alice"
+
+
 def test_serialize_meaning_units_produces_valid_json() -> None:
     row = {COL_MEANING_UNITS: _STUB_MEANING_UNITS}
     result = _serialize_meaning_units(row)
@@ -131,6 +139,14 @@ def test_serialize_meaning_units_produces_valid_json() -> None:
     assert serialized[0]["id"] == 1
     assert serialized[0]["aspect"] == "role"
     assert "software engineer" in serialized[0]["unit"]
+
+
+def test_serialize_meaning_units_accepts_dict_payload() -> None:
+    row = {COL_MEANING_UNITS: _STUB_MEANING_UNITS.model_dump(mode="python")}
+    result = _serialize_meaning_units(row)
+    serialized = json.loads(result[COL_MEANING_UNITS_SERIALIZED])
+    assert len(serialized) == 2
+    assert serialized[1]["id"] == 2
 
 
 def test_generate_privacy_qa_column_only_protected_entities() -> None:
@@ -142,6 +158,14 @@ def test_generate_privacy_qa_column_only_protected_entities() -> None:
     assert "Alice" in qa.items[0].question
     assert qa.items[0].entity_label == "first_name"
     assert qa.items[0].sensitivity == SensitivityLevel.high
+
+
+def test_generate_privacy_qa_column_accepts_dict_payload() -> None:
+    row = {COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION.model_dump(mode="python")}
+    result = _generate_privacy_qa_column(row)
+    qa: PrivacyQAPairsSchema = result[COL_PRIVACY_QA]
+    assert len(qa.items) == 1
+    assert qa.items[0].entity_value == "Alice"
 
 
 def test_generate_privacy_qa_column_no_protected_entities() -> None:

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -298,7 +298,6 @@ def test_sensitivity_disposition_format_for_rewrite_context_empty_when_all_low()
     assert schema.format_for_rewrite_context() == "No medium or high sensitivity entities identified."
 
 
-
 def test_quality_answers_use_integer_ids() -> None:
     answers = QualityAnswersSchema.model_validate({"answers": [{"id": 1, "answer": "A concise answer"}]})
     assert answers.answers[0].id == 1

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -21,7 +21,7 @@ from anonymizer.engine.schemas import (
     ValidationCandidatesSchema,
     ValidationSkeletonSchema,
 )
-from anonymizer.engine.schemas.rewrite import EntityDispositionSchema, generate_privacy_qa_from_disposition
+from anonymizer.engine.schemas.rewrite import EntityDispositionSchema
 
 
 def test_entities_payload_from_raw_dict() -> None:
@@ -297,53 +297,6 @@ def test_sensitivity_disposition_format_for_rewrite_context_empty_when_all_low()
     )
     assert schema.format_for_rewrite_context() == "No medium or high sensitivity entities identified."
 
-
-# generate_privacy_qa_from_disposition
-
-
-def test_generate_privacy_qa_from_schema_only_protected_entities(
-    mixed_disposition: SensitivityDispositionSchema,
-) -> None:
-    qa = generate_privacy_qa_from_disposition(mixed_disposition)
-    assert len(qa.items) == 1
-    assert "Alice" in qa.items[0].question
-
-
-def test_generate_privacy_qa_from_dict_input(mixed_disposition: SensitivityDispositionSchema) -> None:
-    qa = generate_privacy_qa_from_disposition(mixed_disposition.model_dump())
-    assert len(qa.items) == 1
-    assert "Alice" in qa.items[0].question
-
-
-def test_generate_privacy_qa_from_invalid_dict_raises_validation_error() -> None:
-    bad_entity = _make_entity()
-    del bad_entity["entity_label"]
-    with pytest.raises(ValidationError):
-        generate_privacy_qa_from_disposition({"sensitivity_disposition": [bad_entity]})
-
-
-def test_generate_privacy_qa_empty_when_nothing_to_protect() -> None:
-    schema = SensitivityDispositionSchema.model_validate(
-        {
-            "sensitivity_disposition": [
-                _make_entity(id=1, needs_protection=False, protection_method_suggestion="left_as_is")
-            ]
-        }
-    )
-    assert generate_privacy_qa_from_disposition(schema).items == []
-
-
-def test_generate_privacy_qa_ids_are_sequential() -> None:
-    schema = SensitivityDispositionSchema.model_validate(
-        {
-            "sensitivity_disposition": [
-                _make_entity(id=1),
-                _make_entity(id=2, entity_label="last_name", entity_value="Smith"),
-            ],
-        }
-    )
-    qa = generate_privacy_qa_from_disposition(schema)
-    assert [item.id for item in qa.items] == [1, 2]
 
 
 def test_quality_answers_use_integer_ids() -> None:


### PR DESCRIPTION
  ## Summary
Implements `QAGenerationWorkflow` for the rewrite pipeline. This stage runs after sensitivity disposition and produces the QA artifacts used downstream to evaluate rewrite quality and privacy leakage.

  - Adds `src/anonymizer/engine/rewrite/qa_generation.py`
  - `QAGenerationWorkflow.columns()`
  - `_format_disposition_block()` for prompt-safe disposition serialization
  - `_serialize_meaning_units()` for quality-QA prompt injection
  - `generate_privacy_qa_from_disposition()` and `_generate_privacy_qa_column()` for template-based privacy QA
  - Meaning unit extraction runs through `LLMStructuredColumnConfig` using the `meaning_extractor` alias
  - Quality QA generation runs through `LLMStructuredColumnConfig` using the `qa_generator` alias
  - Privacy QA is generated without an LLM call from protected entities in `SensitivityDispositionSchema`

  ## Design Decisions

Structured cross-column payloads are normalized at the custom-column boundary with `model_validate(...)` rather than assuming live schema instances. Prompt sections use the same XML-style layout introduced in #45 

  ## Dependencies

Depends on #45 for domain classification and sensitivity disposition.

  ## Testing

Tests pass locally and cover column ordering, model alias wiring, disposition/meaning-unit serialization, privacy-QA generation, and prompt column references.

  ## Related Issues

Closes #32