### PR TITLE
fix: drop age duration tags and first_name initials in validation prompt

### DIFF
--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -342,6 +342,7 @@ What to DROP:
 - Generic time references that are not specific dates (e.g., "today", "now", "soon")
 - Kinship and family-role terms used as relationship descriptors are not quasi-identifiers.
 - Filenames that are system executables or binaries (e.g., ending in .exe, .dll, .sys).
+- If a single abbreviated letter (e.g. "A.") is tagged as a first_name but is not followed by a last_name, drop it.
 
 PARTIAL-TOKEN RULE (HARD DROP):
 - If the tagged value is only a substring of a larger contiguous token (letters, digits, underscore with no whitespace boundary), DROP it.
@@ -368,6 +369,13 @@ PARTIAL-TOKEN RULE (HARD DROP):
     "<<SENSITIVE:political_view>>dem<</SENSITIVE:political_view>>eanor" → drop, because "dem" is inside "demeanor"
     {%- endif -%}
 - Apply this even if the substring itself looks privacy-relevant.
+
+AGE RULE:
+- Keep "age" only when the number clearly refers to a person's age (e.g., "35 years old", "35-year-old", "aged 35", "John, 35, ...")
+- Patterns like "X years", "X months", or "X days" describing how long something happened indicate duration, not age.
+- If the number refers to time, duration, counts, prices, measurements, codes, or dates — it is NOT age.
+- If unclear, drop the tag.
+
 
 Additional rules:
 - Check context matches label (not just format)

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -361,7 +361,7 @@ def test_format_label_examples_handles_custom_labels_without_examples() -> None:
 
 
 def test_validation_prompt_includes_label_examples() -> None:
-    prompt = _get_validation_prompt(data_summary=None, labels=["email", "city", "sexuality"])
+    prompt = _get_validation_prompt(data_summary=None, labels=["email", "city", "sexuality", "age", "first_name"])
     assert "Here are all the valid entity classes with examples" in prompt
     assert "- email: derez_lester94@icloud.com" in prompt
     assert "- city: Houston, San Diego, Doha, Lahore" in prompt
@@ -372,6 +372,9 @@ def test_validation_prompt_includes_label_examples() -> None:
     assert "PARTIAL-TOKEN RULE (HARD DROP):" in prompt
     assert '"((SENSITIVE:political_view|dem))eanor" → drop, because "dem" is inside "demeanor"' in prompt
     assert 'The entity label "occupation" refers only to a specific paid job title or profession' in prompt
+    assert "AGE RULE:" in prompt
+    assert "indicate duration, not age" in prompt
+    assert "tagged as a first_name but is not followed by a last_name, drop it" in prompt
 
 
 def test_validation_prompt_includes_data_summary() -> None:


### PR DESCRIPTION
## Summary
  Adds two drop rules to `_get_validation_prompt`:
  - age rule
  - first_name initial rule


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally