### PR TITLE
fix: enforce entity_labels scope on augmented entities in detection output

### DIFF
--- a/src/anonymizer/engine/detection/custom_columns.py
+++ b/src/anonymizer/engine/detection/custom_columns.py
@@ -19,7 +19,6 @@ from data_designer.config import custom_column_generator
 from anonymizer.engine.constants import (
     COL_AUGMENTED_ENTITIES,
     COL_DETECTED_ENTITIES,
-    COL_ENTITIES_BY_VALUE,
     COL_INITIAL_TAGGED_TEXT,
     COL_MERGED_ENTITIES,
     COL_MERGED_TAGGED_TEXT,
@@ -42,11 +41,9 @@ from anonymizer.engine.detection.postprocess import (
     build_validation_candidates,
     expand_entity_occurrences,
     get_tag_notation,
-    group_entities_by_value,
     parse_raw_entities,
 )
 from anonymizer.engine.schemas import (
-    EntitiesByValueSchema,
     EntitiesSchema,
     RawValidationDecisionsSchema,
     ValidatedDecisionSchema,
@@ -181,7 +178,7 @@ def enrich_validation_decisions(row: dict[str, Any]) -> dict[str, Any]:
 
 @custom_column_generator(
     required_columns=[COL_TEXT, COL_MERGED_ENTITIES, COL_VALIDATED_ENTITIES],
-    side_effect_columns=[COL_TAGGED_TEXT, COL_ENTITIES_BY_VALUE],
+    side_effect_columns=[COL_TAGGED_TEXT],
 )
 def apply_validation_and_finalize(row: dict[str, Any]) -> dict[str, Any]:
     """Apply keep/reclass/drop decisions, expand to all occurrences, and produce final outputs."""
@@ -196,9 +193,6 @@ def apply_validation_and_finalize(row: dict[str, Any]) -> dict[str, Any]:
         mode="json"
     )
     row[COL_TAGGED_TEXT] = build_tagged_text(text=text, entities=expanded)
-    row[COL_ENTITIES_BY_VALUE] = EntitiesByValueSchema(
-        entities_by_value=group_entities_by_value(entities=expanded)
-    ).model_dump(mode="json")
     return row
 
 

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -45,10 +45,12 @@ from anonymizer.engine.detection.custom_columns import (
     parse_detected_entities,
     prepare_validation_inputs,
 )
+from anonymizer.engine.detection.postprocess import EntitySpan, group_entities_by_value
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
 from anonymizer.engine.schemas import (
     AugmentedEntitiesSchema,
+    EntitiesByValueSchema,
     EntitiesSchema,
     LatentEntitiesSchema,
     ValidationDecisionsSchema,
@@ -78,7 +80,6 @@ class EntityDetectionWorkflow:
         gliner_detection_threshold: float,
         entity_labels: list[str] | None = None,
         data_summary: str | None = None,
-        compute_grouped: bool = True,
         preview_num_records: int | None = None,
     ) -> EntityDetectionResult:
         """Run the core detection pipeline: GLiNER NER, LLM validation, LLM augmentation, and finalization.
@@ -162,8 +163,6 @@ class EntityDetectionWorkflow:
             preview_num_records=preview_num_records,
         )
         detected_df = detection_result.dataframe.copy()
-        if not compute_grouped and COL_ENTITIES_BY_VALUE in detected_df.columns:
-            detected_df = detected_df.drop(columns=[COL_ENTITIES_BY_VALUE])
         return EntityDetectionResult(dataframe=detected_df, failed_records=detection_result.failed_records)
 
     def identify_latent_entities(
@@ -241,7 +240,6 @@ class EntityDetectionWorkflow:
             gliner_detection_threshold=gliner_detection_threshold,
             entity_labels=entity_labels,
             data_summary=data_summary,
-            compute_grouped=compute_grouped,
             preview_num_records=preview_num_records,
         )
 
@@ -271,6 +269,8 @@ class EntityDetectionWorkflow:
             final_df[COL_FINAL_ENTITIES] = final_df.apply(
                 lambda row: _materialize_final_entities(row, allowed_labels=allowed), axis=1
             )
+            if compute_grouped:
+                final_df[COL_ENTITIES_BY_VALUE] = final_df[COL_FINAL_ENTITIES].apply(_build_entities_by_value)
         if "original_text_column" in dataframe.attrs:
             final_df.attrs["original_text_column"] = dataframe.attrs["original_text_column"]
         return EntityDetectionResult(
@@ -314,6 +314,24 @@ def _materialize_final_entities(row: pd.Series, *, allowed_labels: set[str] | No
         return parsed.model_dump()
     kept = [e for e in parsed.entities if e.label in allowed_labels]
     return EntitiesSchema(entities=[e.model_dump() for e in kept]).model_dump()
+
+
+def _build_entities_by_value(final_entities_raw: object) -> dict:
+    """Derive COL_ENTITIES_BY_VALUE from COL_FINAL_ENTITIES."""
+    parsed = EntitiesSchema.from_raw(final_entities_raw)
+    spans = [
+        EntitySpan(
+            entity_id=e.id,
+            value=e.value,
+            label=e.label,
+            start_position=e.start_position,
+            end_position=e.end_position,
+            score=e.score,
+            source=e.source,
+        )
+        for e in parsed.entities
+    ]
+    return EntitiesByValueSchema(entities_by_value=group_entities_by_value(entities=spans)).model_dump(mode="json")
 
 
 def _format_label_examples(labels: list[str]) -> str:

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -309,7 +309,7 @@ def _resolve_detection_labels(entity_labels: list[str] | None) -> list[str]:
 
 def _materialize_final_entities(row: pd.Series, *, allowed_labels: set[str] | None) -> dict:
     """Build COL_FINAL_ENTITIES, optionally filtering to *allowed_labels*."""
-    parsed = EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, {}))
+    parsed = EntitiesSchema.from_raw(row[COL_DETECTED_ENTITIES])
     if allowed_labels is None:
         return parsed.model_dump()
     kept = [e for e in parsed.entities if e.label in allowed_labels]

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -458,14 +458,39 @@ def _get_augment_prompt(*, data_summary: str | None, labels: list[str], strict_l
             "<<VALID_CLASSES>>\n\n"
             "Do not create new labels. If an entity does not fit any label in the list, skip it."
         )
-        strict_example_note = "\nfirst_name, last_name, and city are all in the allowed label list."
+        example_block = """\
+Example (allowed labels: first_name, last_name, city — note that employment_status is NOT in the allowed list):
+{%- if <<TAG_NOTATION>> == "xml" -%}
+Input text: Jane Doe lives in <city>Santa Clara</city>. She works full-time.
+{%- elif <<TAG_NOTATION>> == "bracket" -%}
+Input text: Jane Doe lives in [[Santa Clara|city]]. She works full-time.
+{%- elif <<TAG_NOTATION>> == "paren" -%}
+Input text: Jane Doe lives in ((SENSITIVE:city|Santa Clara)). She works full-time.
+{%- else -%}
+Input text: Jane Doe lives in <<SENSITIVE:city>>Santa Clara<</SENSITIVE:city>>. She works full-time.
+{%- endif -%}
+Already-detected entities: [{"value": "Santa Clara", "label": "city"}]
+Output: {"entities": [{"value": "Jane", "label": "first_name", "reason": "first name"}, {"value": "Doe", "label": "last_name", "reason": "last name"}]}"""
+
     else:
         label_block = (
             "Here are the known entity classes. Strongly prefer labels from this list when they fit:\n"
             "<<VALID_CLASSES>>\n\n"
             "If no known label fits, create a concise snake_case label (e.g., clinic_name, server_name, transaction_id)."
         )
-        strict_example_note = ""
+        example_block = """\
+Example:
+{%- if <<TAG_NOTATION>> == "xml" -%}
+Input text: Jane Doe lives in <city>Santa Clara</city>. She works full-time.
+{%- elif <<TAG_NOTATION>> == "bracket" -%}
+Input text: Jane Doe lives in [[Santa Clara|city]]. She works full-time.
+{%- elif <<TAG_NOTATION>> == "paren" -%}
+Input text: Jane Doe lives in ((SENSITIVE:city|Santa Clara)). She works full-time.
+{%- else -%}
+Input text: Jane Doe lives in <<SENSITIVE:city>>Santa Clara<</SENSITIVE:city>>. She works full-time.
+{%- endif -%}
+Already-detected entities: [{"value": "Santa Clara", "label": "city"}]
+Output: {"entities": [{"value": "Jane", "label": "first_name", "reason": "first name"}, {"value": "Doe", "label": "last_name", "reason": "last name"}, {"value": "full-time", "label": "employment_status", "reason": "employment status"}]}"""
 
     prompt = """Task: Find untagged sensitive entities in text (ignore already tagged entities). Focus on:
 - Direct identifiers: Uniquely identify entities (names, emails, IDs), records (transaction IDs, case numbers), resources (file paths, URLs), or instances (server names, hostnames)
@@ -490,18 +515,7 @@ Other information:
 - Filename Exclusions: The "filename" label should be reserved for user-created documents or data exports (e.g., .pdf, .xlsx, .csv, .txt).
 - Executable Distinction: Do not tag executable binaries (ending in .exe, .dll, or .sys) as filename. Treat these extensions as non-sensitive system identifiers.
 
-Example:<<STRICT_EXAMPLE_NOTE>>
-{%- if <<TAG_NOTATION>> == "xml" -%}
-Input text: Jane Doe lives in <city>Santa Clara</city>.
-{%- elif <<TAG_NOTATION>> == "bracket" -%}
-Input text: Jane Doe lives in [[Santa Clara|city]].
-{%- elif <<TAG_NOTATION>> == "paren" -%}
-Input text: Jane Doe lives in ((SENSITIVE:city|Santa Clara)).
-{%- else -%}
-Input text: Jane Doe lives in <<SENSITIVE:city>>Santa Clara<</SENSITIVE:city>>.
-{%- endif -%}
-Already-detected entities: [{"value": "Santa Clara", "label": "city"}]
-Output: {"entities": [{"value": "Jane", "label": "first_name", "reason": "first name"}, {"value": "Doe", "label": "last_name", "reason": "last name"}]}
+<<EXAMPLE_BLOCK>>
 
 ---
 Input text: <<TAGGED_TEXT>>
@@ -509,7 +523,7 @@ Already-detected entities: <<SEED_ENTITIES>>
 """
     prompt = (
         prompt.replace("<<LABEL_BLOCK>>", label_block)
-        .replace("<<STRICT_EXAMPLE_NOTE>>", strict_example_note)
+        .replace("<<EXAMPLE_BLOCK>>", example_block)
         .replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
         .replace("<<TAGGED_TEXT>>", _jinja(COL_INITIAL_TAGGED_TEXT))
         .replace("<<SEED_ENTITIES>>", _jinja(COL_SEED_ENTITIES_JSON))

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -450,12 +450,14 @@ def _get_augment_prompt(*, data_summary: str | None, labels: list[str], strict_l
             "<<VALID_CLASSES>>\n\n"
             "Do not create new labels. If an entity does not fit any label in the list, skip it."
         )
+        strict_example_note = "\nfirst_name, last_name, and city are all in the allowed label list."
     else:
         label_block = (
             "Here are the known entity classes. Strongly prefer labels from this list when they fit:\n"
             "<<VALID_CLASSES>>\n\n"
             "If no known label fits, create a concise snake_case label (e.g., clinic_name, server_name, transaction_id)."
         )
+        strict_example_note = ""
 
     prompt = """Task: Find untagged sensitive entities in text (ignore already tagged entities). Focus on:
 - Direct identifiers: Uniquely identify entities (names, emails, IDs), records (transaction IDs, case numbers), resources (file paths, URLs), or instances (server names, hostnames)
@@ -480,28 +482,29 @@ Other information:
 - Filename Exclusions: The "filename" label should be reserved for user-created documents or data exports (e.g., .pdf, .xlsx, .csv, .txt).
 - Executable Distinction: Do not tag executable binaries (ending in .exe, .dll, or .sys) as filename. Treat these extensions as non-sensitive system identifiers.
 
-Example:
+Example:<<STRICT_EXAMPLE_NOTE>>
 {%- if <<TAG_NOTATION>> == "xml" -%}
-Input text: My name is Amy Steier in <city>San Diego</city>.
+Input text: Jane Doe lives in <city>Santa Clara</city>.
 {%- elif <<TAG_NOTATION>> == "bracket" -%}
-Input text: My name is Amy Steier in [[San Diego|city]].
+Input text: Jane Doe lives in [[Santa Clara|city]].
 {%- elif <<TAG_NOTATION>> == "paren" -%}
-Input text: My name is Amy Steier in ((SENSITIVE:city|San Diego)).
+Input text: Jane Doe lives in ((SENSITIVE:city|Santa Clara)).
 {%- else -%}
-Input text: My name is Amy Steier in <<SENSITIVE:city>>San Diego<</SENSITIVE:city>>.
+Input text: Jane Doe lives in <<SENSITIVE:city>>Santa Clara<</SENSITIVE:city>>.
 {%- endif -%}
-Already-detected entities: [{"value": "San Diego", "label": "city"}]
-Output: {"entities": [{"value": "Amy", "label": "first_name", "reason": "first name"}, {"value": "Steier", "label": "last_name", "reason": "last name"}]}
+Already-detected entities: [{"value": "Santa Clara", "label": "city"}]
+Output: {"entities": [{"value": "Jane", "label": "first_name", "reason": "first name"}, {"value": "Doe", "label": "last_name", "reason": "last name"}]}
 
 ---
 Input text: <<TAGGED_TEXT>>
 Already-detected entities: <<SEED_ENTITIES>>
 """
     prompt = (
-        prompt.replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
+        prompt.replace("<<LABEL_BLOCK>>", label_block)
+        .replace("<<STRICT_EXAMPLE_NOTE>>", strict_example_note)
+        .replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
         .replace("<<TAGGED_TEXT>>", _jinja(COL_INITIAL_TAGGED_TEXT))
         .replace("<<SEED_ENTITIES>>", _jinja(COL_SEED_ENTITIES_JSON))
-        .replace("<<LABEL_BLOCK>>", label_block)
         .replace("<<VALID_CLASSES>>", ", ".join(labels))
     )
     context_section = data_summary if data_summary else "Not provided"

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -266,8 +266,8 @@ class EntityDetectionWorkflow:
         # TODO(docs): document this None-vs-explicit contract in user-facing docs.
         if COL_DETECTED_ENTITIES in final_df.columns:
             allowed = set(entity_labels) if entity_labels is not None else None
-            final_df[COL_FINAL_ENTITIES] = final_df.apply(
-                lambda row: _materialize_final_entities(row, allowed_labels=allowed), axis=1
+            final_df[COL_FINAL_ENTITIES] = final_df[COL_DETECTED_ENTITIES].apply(
+                lambda raw: _materialize_final_entities(raw, allowed_labels=allowed)
             )
             if compute_grouped:
                 final_df[COL_ENTITIES_BY_VALUE] = final_df[COL_FINAL_ENTITIES].apply(_build_entities_by_value)
@@ -307,13 +307,13 @@ def _resolve_detection_labels(entity_labels: list[str] | None) -> list[str]:
     return list(entity_labels)
 
 
-def _materialize_final_entities(row: pd.Series, *, allowed_labels: set[str] | None) -> dict:
+def _materialize_final_entities(raw: object, *, allowed_labels: set[str] | None) -> dict:
     """Build COL_FINAL_ENTITIES, optionally filtering to *allowed_labels*."""
-    parsed = EntitiesSchema.from_raw(row[COL_DETECTED_ENTITIES])
+    parsed = EntitiesSchema.from_raw(raw)
     if allowed_labels is None:
         return parsed.model_dump()
     kept = [e for e in parsed.entities if e.label in allowed_labels]
-    return EntitiesSchema(entities=[e.model_dump() for e in kept]).model_dump()
+    return EntitiesSchema(entities=kept).model_dump()
 
 
 def _build_entities_by_value(final_entities_raw: object) -> dict:

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -143,7 +143,9 @@ class EntityDetectionWorkflow:
                 ),
                 LLMStructuredColumnConfig(
                     name=COL_AUGMENTED_ENTITIES,
-                    prompt=_get_augment_prompt(data_summary=data_summary, labels=labels),
+                    prompt=_get_augment_prompt(
+                        data_summary=data_summary, labels=labels, strict_labels=entity_labels is not None
+                    ),
                     model_alias=augmenter_alias,
                     output_format=AugmentedEntitiesSchema,
                 ),
@@ -260,9 +262,14 @@ class EntityDetectionWorkflow:
             final_df = detected_result.dataframe.copy()
             final_failures = detected_result.failed_records
 
+        # When entity_labels is explicitly provided (even if it matches DEFAULT_ENTITY_LABELS),
+        # the augmenter is strict and out-of-scope labels are filtered.
+        # entity_labels=None is the only way to get permissive augmentation.
+        # TODO(docs): document this None-vs-explicit contract in user-facing docs.
         if COL_DETECTED_ENTITIES in final_df.columns:
-            final_df[COL_FINAL_ENTITIES] = final_df[COL_DETECTED_ENTITIES].apply(
-                lambda x: EntitiesSchema.from_raw(x).model_dump()
+            allowed = set(entity_labels) if entity_labels is not None else None
+            final_df[COL_FINAL_ENTITIES] = final_df.apply(
+                lambda row: _materialize_final_entities(row, allowed_labels=allowed), axis=1
             )
         if "original_text_column" in dataframe.attrs:
             final_df.attrs["original_text_column"] = dataframe.attrs["original_text_column"]
@@ -298,6 +305,15 @@ def _resolve_detection_labels(entity_labels: list[str] | None) -> list[str]:
     if entity_labels is None:
         return list(DEFAULT_ENTITY_LABELS)
     return list(entity_labels)
+
+
+def _materialize_final_entities(row: pd.Series, *, allowed_labels: set[str] | None) -> dict:
+    """Build COL_FINAL_ENTITIES, optionally filtering to *allowed_labels*."""
+    parsed = EntitiesSchema.from_raw(row.get(COL_DETECTED_ENTITIES, {}))
+    if allowed_labels is None:
+        return parsed.model_dump()
+    kept = [e for e in parsed.entities if e.label in allowed_labels]
+    return EntitiesSchema(entities=[e.model_dump() for e in kept]).model_dump()
 
 
 def _format_label_examples(labels: list[str]) -> str:
@@ -409,7 +425,20 @@ Template: <<VALIDATION_SKELETON>>
     return prompt.replace("<<DATA_SUMMARY>>", context_section)
 
 
-def _get_augment_prompt(*, data_summary: str | None, labels: list[str]) -> str:
+def _get_augment_prompt(*, data_summary: str | None, labels: list[str], strict_labels: bool = False) -> str:
+    if strict_labels:
+        label_block = (
+            "Here are the allowed entity classes. Use ONLY labels from this list:\n"
+            "<<VALID_CLASSES>>\n\n"
+            "Do not create new labels. If an entity does not fit any label in the list, skip it."
+        )
+    else:
+        label_block = (
+            "Here are the known entity classes. Strongly prefer labels from this list when they fit:\n"
+            "<<VALID_CLASSES>>\n\n"
+            "If no known label fits, create a concise snake_case label (e.g., clinic_name, server_name, transaction_id)."
+        )
+
     prompt = """Task: Find untagged sensitive entities in text (ignore already tagged entities). Focus on:
 - Direct identifiers: Uniquely identify entities (names, emails, IDs), records (transaction IDs, case numbers), resources (file paths, URLs), or instances (server names, hostnames)
 - Quasi-identifiers: Attributes that combine to narrow specificity (age, location, job title, timestamps, technical specs)
@@ -417,10 +446,7 @@ def _get_augment_prompt(*, data_summary: str | None, labels: list[str]) -> str:
 
 We have the following type of data: <<DATA_SUMMARY>>
 
-Here are the known entity classes. Strongly prefer labels from this list when they fit:
-<<VALID_CLASSES>>
-
-If no known label fits, create a concise snake_case label (e.g., clinic_name, server_name, transaction_id).
+<<LABEL_BLOCK>>
 
 Rules:
 - Tag actual values, not placeholders
@@ -457,6 +483,7 @@ Already-detected entities: <<SEED_ENTITIES>>
         prompt.replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
         .replace("<<TAGGED_TEXT>>", _jinja(COL_INITIAL_TAGGED_TEXT))
         .replace("<<SEED_ENTITIES>>", _jinja(COL_SEED_ENTITIES_JSON))
+        .replace("<<LABEL_BLOCK>>", label_block)
         .replace("<<VALID_CLASSES>>", ", ".join(labels))
     )
     context_section = data_summary if data_summary else "Not provided"

--- a/tests/engine/test_detection_custom_columns.py
+++ b/tests/engine/test_detection_custom_columns.py
@@ -16,7 +16,6 @@ from typing import Any
 from anonymizer.engine.constants import (
     COL_AUGMENTED_ENTITIES,
     COL_DETECTED_ENTITIES,
-    COL_ENTITIES_BY_VALUE,
     COL_INITIAL_TAGGED_TEXT,
     COL_MERGED_ENTITIES,
     COL_RAW_DETECTED,
@@ -197,30 +196,6 @@ def test_build_validation_skeleton_handles_candidates_with_missing_keys() -> Non
     assert skeleton["decisions"][1]["value"] == "Alice"
 
 
-def test_apply_validation_and_finalize_writes_schema_shaped_entities_by_value() -> None:
-    row: dict[str, Any] = {
-        COL_TEXT: "Alice works at Acme.",
-        COL_MERGED_ENTITIES: {
-            "entities": [
-                {
-                    "id": "first_name_0_5",
-                    "value": "Alice",
-                    "label": "first_name",
-                    "start_position": 0,
-                    "end_position": 5,
-                    "score": 0.95,
-                    "source": "detector",
-                }
-            ]
-        },
-        COL_VALIDATED_ENTITIES: {"decisions": []},
-    }
-
-    result = apply_validation_and_finalize(row)
-    assert "entities_by_value" in result[COL_ENTITIES_BY_VALUE]
-    assert isinstance(result[COL_ENTITIES_BY_VALUE]["entities_by_value"], list)
-
-
 def test_apply_validation_and_finalize_handles_malformed_merged_entities() -> None:
     row: dict[str, Any] = {
         COL_TEXT: "Alice works at Acme.",
@@ -230,4 +205,3 @@ def test_apply_validation_and_finalize_handles_malformed_merged_entities() -> No
 
     result = apply_validation_and_finalize(row)
     assert result[COL_DETECTED_ENTITIES] == {"entities": []}
-    assert result[COL_ENTITIES_BY_VALUE] == {"entities_by_value": []}

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -182,7 +182,6 @@ def test_run_compute_grouped_entities_false_drops_grouped_column(
             {
                 COL_TEXT: ["Alice works in Seattle"],
                 COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
-                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
             }
         ),
         failed_records=[],
@@ -194,7 +193,6 @@ def test_run_compute_grouped_entities_false_drops_grouped_column(
         selected_models=stub_detection_model_selection,
         gliner_detection_threshold=0.5,
         tag_latent_entities=False,
-        privacy_goal=None,
         compute_grouped_entities=False,
     )
     assert COL_ENTITIES_BY_VALUE not in result.dataframe.columns
@@ -267,32 +265,6 @@ def test_run_with_latent_detection_merges_failures_in_order(
         ),
     )
     assert [item.record_id for item in result.failed_records] == ["d1", "l1"]
-
-
-def test_detect_and_validate_entities_drops_grouped_when_compute_grouped_false(
-    stub_detector_model_configs: list[ModelConfig],
-    stub_detection_model_selection: DetectionModelSelection,
-) -> None:
-    adapter = Mock()
-    adapter.run_workflow.return_value = WorkflowRunResult(
-        dataframe=pd.DataFrame(
-            {
-                COL_TEXT: ["Alice works in Seattle"],
-                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
-                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
-            }
-        ),
-        failed_records=[],
-    )
-    workflow = EntityDetectionWorkflow(adapter=adapter)
-    result = workflow.detect_and_validate_entities(
-        pd.DataFrame({COL_TEXT: ["Alice works in Seattle"]}),
-        model_configs=stub_detector_model_configs,
-        selected_models=stub_detection_model_selection,
-        gliner_detection_threshold=0.5,
-        compute_grouped=False,
-    )
-    assert COL_ENTITIES_BY_VALUE not in result.dataframe.columns
 
 
 def test_run_requires_privacy_goal_for_latent_path(
@@ -451,6 +423,10 @@ def test_custom_entity_labels_filters_out_of_scope_augmented_entities(
     final_labels = {e.label for e in final.entities}
     assert final_labels == {"hostname", "ipv4"}
     assert "server_name" not in final_labels
+
+    ebv = result.dataframe[COL_ENTITIES_BY_VALUE].iloc[0]
+    ebv_values = {e["value"] for e in ebv["entities_by_value"]}
+    assert "srv01" not in ebv_values
 
     detected = EntitiesSchema.from_raw(result.dataframe[COL_DETECTED_ENTITIES].iloc[0])
     assert "server_name" in {e.label for e in detected.entities}

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -31,6 +31,40 @@ from anonymizer.engine.detection.detection_workflow import (
 )
 from anonymizer.engine.ndd.adapter import FailedRecord, WorkflowRunResult
 from anonymizer.engine.ndd.model_loader import load_default_model_selection, resolve_model_alias
+from anonymizer.engine.schemas import EntitiesSchema
+
+
+@pytest.fixture
+def _detection_with_novel_augmented_label(
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> tuple[EntityDetectionWorkflow, pd.DataFrame, list[ModelConfig], DetectionModelSelection]:
+    """Workflow whose detector returns an entity with a label (server_name) outside the user's list."""
+    input_df = pd.DataFrame({COL_TEXT: ["Connect to srv01.internal on 10.0.0.5"]})
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Connect to srv01.internal on 10.0.0.5"],
+                COL_DETECTED_ENTITIES: [
+                    {
+                        "entities": [
+                            {"value": "srv01.internal", "label": "hostname", "start_position": 11, "end_position": 25},
+                            {"value": "10.0.0.5", "label": "ipv4", "start_position": 29, "end_position": 37},
+                            {"value": "srv01", "label": "server_name", "start_position": 11, "end_position": 16},
+                        ]
+                    }
+                ],
+            }
+        ),
+        failed_records=[],
+    )
+    return (
+        EntityDetectionWorkflow(adapter=adapter),
+        input_df,
+        stub_detector_model_configs,
+        stub_detection_model_selection,
+    )
 
 
 def test_run_with_latent_detection_calls_second_workflow(
@@ -379,8 +413,66 @@ def test_validation_prompt_includes_data_summary() -> None:
     assert "Data context: Medical records" in prompt
 
 
-def test_augment_prompt_includes_label_names() -> None:
-    prompt = _get_augment_prompt(data_summary=None, labels=["phone_number", "age"])
-    assert "Here are the known entity classes" in prompt
+def test_augment_prompt_permissive_when_using_defaults() -> None:
+    """In practice strict_labels=False only fires with DEFAULT_ENTITY_LABELS (entity_labels=None).
+    We pass a small list here to verify the permissive prompt text in isolation."""
+    prompt = _get_augment_prompt(data_summary=None, labels=["phone_number", "age"], strict_labels=False)
+    assert "Strongly prefer labels from this list when they fit" in prompt
     assert "phone_number, age" in prompt
     assert "If no known label fits, create a concise snake_case label" in prompt
+
+
+def test_augment_prompt_strict_when_custom_labels_provided() -> None:
+    prompt = _get_augment_prompt(data_summary=None, labels=["hostname", "ipv4"], strict_labels=True)
+    assert "Use ONLY labels from this list" in prompt
+    assert "hostname, ipv4" in prompt
+    assert "Do not create new labels" in prompt
+    assert "Strongly prefer" not in prompt
+    assert "create a concise snake_case label" not in prompt
+
+
+def test_custom_entity_labels_filters_out_of_scope_augmented_entities(
+    _detection_with_novel_augmented_label: tuple[
+        EntityDetectionWorkflow, pd.DataFrame, list[ModelConfig], DetectionModelSelection
+    ],
+) -> None:
+    """Augmented entities with labels outside entity_labels must be stripped from final_entities."""
+    workflow, input_df, model_configs, selected_models = _detection_with_novel_augmented_label
+    result = workflow.run(
+        input_df,
+        model_configs=model_configs,
+        selected_models=selected_models,
+        gliner_detection_threshold=0.5,
+        entity_labels=["hostname", "ipv4"],
+        tag_latent_entities=False,
+    )
+
+    final = EntitiesSchema.from_raw(result.dataframe[COL_FINAL_ENTITIES].iloc[0])
+    final_labels = {e.label for e in final.entities}
+    assert final_labels == {"hostname", "ipv4"}
+    assert "server_name" not in final_labels
+
+    detected = EntitiesSchema.from_raw(result.dataframe[COL_DETECTED_ENTITIES].iloc[0])
+    assert "server_name" in {e.label for e in detected.entities}
+
+
+def test_default_entity_labels_preserves_novel_augmented_entities(
+    _detection_with_novel_augmented_label: tuple[
+        EntityDetectionWorkflow, pd.DataFrame, list[ModelConfig], DetectionModelSelection
+    ],
+) -> None:
+    """When entity_labels=None, augmented entities with novel labels must be preserved."""
+    workflow, input_df, model_configs, selected_models = _detection_with_novel_augmented_label
+    result = workflow.run(
+        input_df,
+        model_configs=model_configs,
+        selected_models=selected_models,
+        gliner_detection_threshold=0.5,
+        tag_latent_entities=False,
+    )
+
+    final = EntitiesSchema.from_raw(result.dataframe[COL_FINAL_ENTITIES].iloc[0])
+    final_labels = {e.label for e in final.entities}
+    assert "server_name" in final_labels
+    assert "hostname" in final_labels
+    assert "ipv4" in final_labels

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -395,6 +395,7 @@ def test_augment_prompt_permissive_when_using_defaults() -> None:
     assert "Strongly prefer labels from this list when they fit" in prompt
     assert "phone_number, age" in prompt
     assert "If no known label fits, create a concise snake_case label" in prompt
+    assert "employment_status" in prompt
 
 
 def test_augment_prompt_strict_when_custom_labels_provided() -> None:
@@ -404,9 +405,10 @@ def test_augment_prompt_strict_when_custom_labels_provided() -> None:
     assert "Do not create new labels" in prompt
     assert "Strongly prefer" not in prompt
     assert "create a concise snake_case label" not in prompt
-    assert "all in the allowed label list" in prompt
+    assert "employment_status is NOT in the allowed list" in prompt
+    assert "employment_status" not in prompt.split("Output:")[1]
 
-
+å
 def test_custom_entity_labels_filters_out_of_scope_augmented_entities(
     _detection_with_novel_augmented_label: tuple[
         EntityDetectionWorkflow, pd.DataFrame, list[ModelConfig], DetectionModelSelection

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -408,7 +408,7 @@ def test_augment_prompt_strict_when_custom_labels_provided() -> None:
     assert "employment_status is NOT in the allowed list" in prompt
     assert "employment_status" not in prompt.split("Output:")[1]
 
-å
+
 def test_custom_entity_labels_filters_out_of_scope_augmented_entities(
     _detection_with_novel_augmented_label: tuple[
         EntityDetectionWorkflow, pd.DataFrame, list[ModelConfig], DetectionModelSelection

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -401,6 +401,7 @@ def test_augment_prompt_strict_when_custom_labels_provided() -> None:
     assert "Do not create new labels" in prompt
     assert "Strongly prefer" not in prompt
     assert "create a concise snake_case label" not in prompt
+    assert "all in the allowed label list" in prompt
 
 
 def test_custom_entity_labels_filters_out_of_scope_augmented_entities(


### PR DESCRIPTION
## Summary
This PR addresses a regression in behavior that was inadvertently introduced by #44, and fortifies the implementation.

When a user provides an explicit `Detect(entity_labels=[...])`, the LLM augmentation step should not introduce entities with labels outside that list. To enforce this, we add two layers:
1. **Prompt (soft enforcement):** `_get_augment_prompt` accepts a `strict_labels` flag — strict ("Use ONLY labels from this list") when `entity_labels` is explicitly provided, permissive when using defaults.
2. **Post-processing (hard enforcement):** `_materialize_final_entities` filters `COL_FINAL_ENTITIES` to only include entities whose label is in the user's list. This runs during the existing `.apply()` pass in `run()` — no extra loop. `COL_DETECTED_ENTITIES` retains the full unfiltered trace for debugging. Only applied when `entity_labels is not None`; defaults pass through unfiltered.

**Note:** When `entity_labels` is explicitly provided — even if it matches `DEFAULT_ENTITY_LABELS` — strict mode and filtering apply. `entity_labels=None` is the only way to get permissive augmentation. This is tracked for documentation in a follow-up (`TODO(docs)` in code).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Notebooks run end-to-end with expected behavior
<img width="354" height="205" alt="image" src="https://github.com/user-attachments/assets/1fec3898-05a6-4e56-aade-47094c60e7b0" />
<img width="975" height="851" alt="image" src="https://github.com/user-attachments/assets/552a25ec-d751-4520-97ce-a07f523a4ad4" />
<img width="850" height="279" alt="image" src="https://github.com/user-attachments/assets/925fffdb-6fbe-4d0e-9ecc-8271f0af1623" />

## Related Issues 
Closes #56 