### PR TITLE
fix: cap preview_num_records to entity row count in replace workflow

### DIFF
--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -69,6 +69,9 @@ class LlmReplaceWorkflow:
         # Only rows with actual entities are sent to the LLM.
         entity_rows = working_df[has_entities_mask].copy()
 
+        effective_preview_num_records = (
+            min(preview_num_records, len(entity_rows)) if preview_num_records is not None else None
+        )
         run_result = self._adapter.run_workflow(
             entity_rows,
             model_configs=model_configs,
@@ -84,7 +87,7 @@ class LlmReplaceWorkflow:
                 )
             ],
             workflow_name="replace-map-generation",
-            preview_num_records=preview_num_records,
+            preview_num_records=effective_preview_num_records,
         )
         output_df = run_result.dataframe.copy()
         # Drop any LLM-returned replacements that were not requested for this row.


### PR DESCRIPTION
## Summary

When `preview()` is called with `Substitute` replacement, `llm_replace_workflow.py` filters the input down to only entity-bearing rows before passing to the adapter. Previously it passed the original `preview_num_records` (total dataset size) unchanged, causing Data Designer's seed generator to wrap around and produce duplicate rows.

The fix caps `preview_num_records` to `len(entity_rows)` before the adapter call.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [ ] Added/updated tests for changes

The fix is a one-liner capping a value passed to a mocked dependency. A unit test would only assert that `min()` works, not that duplicates are actually prevented — the real invariant lives at the Data Designer seed wrap-around boundary which requires a live NIM endpoint to exercise.

## Related Issues
Closes #58 