### PR TITLE
feat: add evaluate and repair workflows

### DIFF
--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -69,6 +69,8 @@ COL_QUALITY_QA_REANSWER = "_quality_qa_reanswer"
 COL_QUALITY_QA_COMPARE = "_quality_qa_compare"
 COL_PRIVACY_QA_REANSWER = "_privacy_qa_reanswer"
 COL_NEEDS_REPAIR = "_needs_repair"
+COL_LEAKED_PRIVACY_ITEMS = "_leaked_privacy_items"
+COL_REWRITTEN_TEXT_NEXT = COL_REWRITTEN_TEXT + "__next"
 COL_REPAIR_ITERATIONS = "_repair_iterations"
 COL_JUDGE_EVALUATION = "_judge_evaluation"
 

--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -68,6 +68,7 @@ COL_REWRITTEN_TEXT = "_rewritten_text"  # pre-repair intermediate; renamed to {t
 COL_QUALITY_QA_REANSWER = "_quality_qa_reanswer"
 COL_QUALITY_QA_COMPARE = "_quality_qa_compare"
 COL_PRIVACY_QA_REANSWER = "_privacy_qa_reanswer"
+COL_NEEDS_REPAIR = "_needs_repair"
 COL_REPAIR_ITERATIONS = "_repair_iterations"
 COL_JUDGE_EVALUATION = "_judge_evaluation"
 

--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -48,8 +48,10 @@ COL_LATENT_ENTITIES = "_latent_entities"
 COL_FINAL_ENTITIES = "final_entities"
 
 # ---------------------------------------------------------------------------
-# Rewrite pipeline — internal columns (prefixed with _)
+# Rewrite pipeline
 # ---------------------------------------------------------------------------
+
+# Internal columns (prefixed with _)
 
 COL_DOMAIN = "_domain"
 COL_DOMAIN_SUPPLEMENT = "_domain_supplement"
@@ -66,9 +68,10 @@ COL_REWRITTEN_TEXT = "_rewritten_text"  # pre-repair intermediate; renamed to {t
 COL_QUALITY_QA_REANSWER = "_quality_qa_reanswer"
 COL_QUALITY_QA_COMPARE = "_quality_qa_compare"
 COL_PRIVACY_QA_REANSWER = "_privacy_qa_reanswer"
+COL_REPAIR_ITERATIONS = "_repair_iterations"
 COL_JUDGE_EVALUATION = "_judge_evaluation"
 
-# Rewrite pipeline — user-facing output columns
+# User-facing output columns
 COL_UTILITY_SCORE = "utility_score"
 COL_LEAKAGE_MASS = "leakage_mass"
 COL_ANY_HIGH_LEAKED = "any_high_leaked"

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from data_designer.config import custom_column_generator
-from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.column_types import ColumnConfigT
+from data_designer.engine.models.recipes.response_recipes import PydanticResponseRecipe
 from pydantic import BaseModel
 
 from anonymizer.config.models import RewriteModelSelection
@@ -15,6 +17,7 @@ from anonymizer.config.rewrite import EvaluationCriteria
 from anonymizer.engine.constants import (
     COL_ANY_HIGH_LEAKED,
     COL_LEAKAGE_MASS,
+    COL_NEEDS_REPAIR,
     COL_PRIVACY_QA,
     COL_PRIVACY_QA_REANSWER,
     COL_QUALITY_QA,
@@ -25,37 +28,22 @@ from anonymizer.engine.constants import (
 )
 from anonymizer.engine.ndd.adapter import NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.rewrite.parsers import (
+    parse_privacy_answers,
+    parse_privacy_qa,
+    parse_quality_answers,
+    parse_quality_compare,
+    parse_quality_qa,
+)
 from anonymizer.engine.schemas.rewrite import (
     PrivacyAnswer,
     PrivacyAnswerItemSchema,
     PrivacyAnswersSchema,
     PrivacyQAPairsSchema,
     QACompareResultsSchema,
-    QualityAnswerSchema,
     QualityAnswersSchema,
-    QualityQAItemSchema,
-    QualityQAPairsSchema,
     SensitivityLevel,
 )
-
-_COL_NEEDS_REPAIR = "_needs_repair"
-_COL_QA_COMPARISON_BLOCK = "_qa_comparison_block"
-
-
-# Schema field names validated at import time.
-def _field(model: type, name: str) -> str:
-    if name not in model.model_fields:
-        raise KeyError(f"{model.__name__} has no field '{name}'")
-    return name
-
-
-_F_ITEMS = _field(QualityQAPairsSchema, "items")
-_F_ANSWERS = _field(QualityAnswersSchema, "answers")
-_F_ID = _field(QualityQAItemSchema, "id")
-_F_QUESTION = _field(QualityQAItemSchema, "question")
-_F_ANSWER = _field(QualityAnswerSchema, "answer")
-_F_REFERENCE_ANSWER = _field(QualityQAItemSchema, "reference_answer")
-
 
 # ---------------------------------------------------------------------------
 # Generator params
@@ -73,63 +61,85 @@ class RepairNeedsParams(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Prompts (Jinja2 templates resolved by NDD)
+# Python-rendered prompts
 # ---------------------------------------------------------------------------
 
 
-def _quality_reanswer_prompt() -> str:
+def _render_quality_reanswer_prompt(row: dict[str, Any]) -> str:
+    qa = parse_quality_qa(row.get(COL_QUALITY_QA, {}))
+    skeleton = [{"id": item.id, "question": item.question, "answer": ""} for item in qa.items]
+
     prompt = """You are taking a reading comprehension exam. You will answer each question about the text.
 
 <rules>
 - If the text does not state the answer, use "unknown"
 - Keep answers concise and factual
 - Do not invent details
+- You MUST provide an answer for EVERY item in the template below
 </rules>
 
 <text>
-{{ <<COL_REWRITTEN_TEXT>> }}
+<<REWRITTEN_TEXT>>
 </text>
 
-<questions>
-{% for it in <<COL_QUALITY_QA>>['<<F_ITEMS>>'] %}- {{ it['<<F_ID>>'] }}: {{ it['<<F_QUESTION>>'] }}
-{% endfor %}</questions>
+<task>
+Fill in the "answer" field for each item. Do not add or remove items.
+</task>
+<answer_template>
+<<SKELETON>>
+</answer_template>
 """
-    return (
-        prompt.replace("<<COL_REWRITTEN_TEXT>>", COL_REWRITTEN_TEXT)
-        .replace("<<COL_QUALITY_QA>>", COL_QUALITY_QA)
-        .replace("<<F_ITEMS>>", _F_ITEMS)
-        .replace("<<F_ID>>", _F_ID)
-        .replace("<<F_QUESTION>>", _F_QUESTION)
+    return prompt.replace("<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))).replace(
+        "<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)
     )
 
 
-def _privacy_reanswer_prompt() -> str:
+def _render_privacy_reanswer_prompt(row: dict[str, Any]) -> str:
+    qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
+    skeleton = [{"id": item.id, "question": item.question, "answer": ""} for item in qa.items]
+
     prompt = """You are a privacy auditor. Read the text and answer each question with "yes" or "no".
 
 <rules>
-- Answer "yes" if the specific entity value can be identified or reasonably inferred from the text.
-- Answer "no" if it cannot be answered from the text.
+- Answer "yes" if the specific entity value can be identified or reasonably inferred from the text
+- Answer "no" if it cannot
 - You must commit to "yes" or "no". Do not hedge.
+- You MUST provide an answer for EVERY item in the template below
 </rules>
 
 <text>
-{{ <<COL_REWRITTEN_TEXT>> }}
+<<REWRITTEN_TEXT>>
 </text>
 
-<questions>
-{% for it in <<COL_PRIVACY_QA>>['<<F_ITEMS>>'] %}- {{ it['<<F_ID>>'] }}: {{ it['<<F_QUESTION>>'] }}
-{% endfor %}</questions>
+<task>
+Fill in the "answer" field for each item with "yes" or "no". Do not add or remove items.
+</task>
+<answer_template>
+<<SKELETON>>
+</answer_template>
 """
-    return (
-        prompt.replace("<<COL_REWRITTEN_TEXT>>", COL_REWRITTEN_TEXT)
-        .replace("<<COL_PRIVACY_QA>>", COL_PRIVACY_QA)
-        .replace("<<F_ITEMS>>", _F_ITEMS)
-        .replace("<<F_ID>>", _F_ID)
-        .replace("<<F_QUESTION>>", _F_QUESTION)
+    return prompt.replace("<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))).replace(
+        "<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)
     )
 
 
-def _quality_compare_prompt() -> str:
+def _render_quality_compare_prompt(row: dict[str, Any]) -> str:
+    qa = parse_quality_qa(row.get(COL_QUALITY_QA, {}))
+    reanswer = parse_quality_answers(row.get(COL_QUALITY_QA_REANSWER))
+    answer_lookup: dict[int, str] = {a.id: a.answer for a in reanswer}
+
+    skeleton = [
+        {
+            "id": item.id,
+            "question": item.question,
+            "expected_answer": item.reference_answer,
+            "student_answer": answer_lookup.get(item.id, "(no answer)"),
+            "score": "",
+            "reason": "",
+        }
+        for item in qa.items
+    ]
+
     prompt = """A student took a reading comprehension exam.
 
 <scoring_rubric>
@@ -148,57 +158,61 @@ Compare the student's answer to the reference answer and grade each on a 0.0-1.0
 * "unknown" answers get 0.0 score
 </grading_rules>
 
-<qa_pairs>
-{{ <<COL_QA_COMPARISON_BLOCK>> }}
-</qa_pairs>
+<task>
+Fill in the "score" (0.0-1.0) and "reason" fields for each item. Do not add or remove items.
+</task>
+<answer_template>
+<<SKELETON>>
+</answer_template>
 """
-    return prompt.replace("<<COL_QA_COMPARISON_BLOCK>>", _COL_QA_COMPARISON_BLOCK)
+    return prompt.replace("<<SKELETON>>", json.dumps({"per_item": skeleton}, indent=2))
 
 
 # ---------------------------------------------------------------------------
-# Parse helpers
+# Custom parser builders (closure captures expected_ids per row)
 # ---------------------------------------------------------------------------
 
 
-def _parse_privacy_answers(raw: Any) -> list[PrivacyAnswerItemSchema]:
-    if isinstance(raw, PrivacyAnswersSchema):
-        return raw.answers
-    if isinstance(raw, dict):
-        return PrivacyAnswersSchema.model_validate(raw).answers
-    raise TypeError(f"Expected PrivacyAnswersSchema or dict, got {type(raw).__name__}")
+def _make_quality_answer_parser(
+    recipe: PydanticResponseRecipe,
+    expected_ids: list[int],
+) -> Any:
+    def parser(response: str) -> QualityAnswersSchema:
+        obj = recipe.parse(response)
+        return QualityAnswersSchema.model_validate(
+            obj.model_dump() if hasattr(obj, "model_dump") else obj,
+            context={"expected_ids": expected_ids},
+        )
+
+    return parser
 
 
-def _parse_quality_qa(raw: Any) -> QualityQAPairsSchema:
-    if isinstance(raw, QualityQAPairsSchema):
-        return raw
-    if isinstance(raw, dict):
-        return QualityQAPairsSchema.model_validate(raw)
-    raise TypeError(f"Expected QualityQAPairsSchema or dict, got {type(raw).__name__}")
+def _make_privacy_answer_parser(
+    recipe: PydanticResponseRecipe,
+    expected_ids: list[int],
+) -> Any:
+    def parser(response: str) -> PrivacyAnswersSchema:
+        obj = recipe.parse(response)
+        return PrivacyAnswersSchema.model_validate(
+            obj.model_dump() if hasattr(obj, "model_dump") else obj,
+            context={"expected_ids": expected_ids},
+        )
+
+    return parser
 
 
-def _parse_quality_answers(raw: Any) -> list[QualityAnswerSchema]:
-    if isinstance(raw, QualityAnswersSchema):
-        return raw.answers
-    if isinstance(raw, dict):
-        return QualityAnswersSchema.model_validate(raw).answers
-    raise TypeError(f"Expected QualityAnswersSchema or dict, got {type(raw).__name__}")
+def _make_qa_compare_parser(
+    recipe: PydanticResponseRecipe,
+    expected_ids: list[int],
+) -> Any:
+    def parser(response: str) -> QACompareResultsSchema:
+        obj = recipe.parse(response)
+        return QACompareResultsSchema.model_validate(
+            obj.model_dump() if hasattr(obj, "model_dump") else obj,
+            context={"expected_ids": expected_ids},
+        )
 
-
-def _parse_quality_compare(raw: Any) -> list[float]:
-    if isinstance(raw, QACompareResultsSchema):
-        return [item.score for item in raw.per_item]
-    if isinstance(raw, dict):
-        parsed = QACompareResultsSchema.model_validate(raw)
-        return [item.score for item in parsed.per_item]
-    raise TypeError(f"Expected QACompareResultsSchema or dict, got {type(raw).__name__}")
-
-
-def _parse_privacy_qa(raw: Any) -> PrivacyQAPairsSchema:
-    if isinstance(raw, PrivacyQAPairsSchema):
-        return raw
-    if isinstance(raw, dict):
-        return PrivacyQAPairsSchema.model_validate(raw)
-    raise TypeError(f"Expected PrivacyQAPairsSchema or dict, got {type(raw).__name__}")
+    return parser
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +221,11 @@ def _parse_privacy_qa(raw: Any) -> PrivacyQAPairsSchema:
 
 
 def compute_utility_score(compare_scores: list[float]) -> float:
-    """Mean of per-item QA comparison scores, or 0.0 if empty."""
+    """Mean of per-item QA comparison scores.
+
+    Answer coverage is enforced upstream by the context-validated parser
+    on QACompareResultsSchema, so all expected IDs are guaranteed present.
+    """
     if not compare_scores:
         return 0.0
     return sum(compare_scores) / len(compare_scores)
@@ -221,15 +239,17 @@ def compute_leakage_mass(
     """Weighted sum of leaked entities.
 
     An entity is "leaked" when the privacy re-answer is ``yes``.
-    The weight comes from ``sensitivity_weights[entity.sensitivity]``.
+    Answer coverage is enforced upstream by the context-validated parser
+    on PrivacyAnswersSchema, so all expected IDs are guaranteed present.
     """
     qa_lookup: dict[int, str] = {item.id: item.sensitivity for item in privacy_qa.items}
     total = 0.0
     for answer in privacy_answers:
         if answer.answer == PrivacyAnswer.yes:
-            sensitivity = qa_lookup.get(answer.id, SensitivityLevel.low)
-            weight = sensitivity_weights[sensitivity]
-            total += weight
+            sensitivity = qa_lookup.get(answer.id)
+            if sensitivity is None:
+                continue
+            total += sensitivity_weights[sensitivity]
     return total
 
 
@@ -262,39 +282,81 @@ def determine_repair_needs(
 
 
 # ---------------------------------------------------------------------------
-# Custom column generators
+# Custom column generator factories
 # ---------------------------------------------------------------------------
 
 
-@custom_column_generator(required_columns=[COL_QUALITY_QA, COL_QUALITY_QA_REANSWER])
-def _pair_qa_for_comparison(row: dict[str, Any]) -> dict[str, Any]:
-    """Match quality QA items with their reanswered counterparts by ID for the compare prompt."""
-    qa = _parse_quality_qa(row.get(COL_QUALITY_QA, {}))
-    reanswer = _parse_quality_answers(row.get(COL_QUALITY_QA_REANSWER))
-    answer_lookup: dict[int, str] = {a.id: a.answer for a in reanswer}
+def _make_quality_reanswer_column(evaluator_alias: str) -> Any:
+    @custom_column_generator(
+        required_columns=[COL_QUALITY_QA, COL_REWRITTEN_TEXT],
+        model_aliases=[evaluator_alias],
+    )
+    def _quality_reanswer(row: dict[str, Any], generator_params: None, models: dict) -> dict[str, Any]:
+        qa = parse_quality_qa(row.get(COL_QUALITY_QA, {}))
+        expected_ids = [item.id for item in qa.items]
 
-    lines = []
-    for item in qa.items:
-        student = answer_lookup.get(item.id, "(no answer)")
-        lines.append(
-            f"- question ID: {item.id}\n"
-            f"  question: {item.question}\n"
-            f"  expected answer: {item.reference_answer}\n"
-            f"  student answer: {student}"
-        )
-    row[_COL_QA_COMPARISON_BLOCK] = "\n".join(lines)
-    return row
+        recipe = PydanticResponseRecipe(data_type=QualityAnswersSchema)
+        prompt = recipe.apply_recipe_to_user_prompt(_render_quality_reanswer_prompt(row))
+        parser = _make_quality_answer_parser(recipe, expected_ids)
+        result, _ = models[evaluator_alias].generate(prompt=prompt, parser=parser, max_correction_steps=3)
+        row[COL_QUALITY_QA_REANSWER] = result
+        return row
+
+    return _quality_reanswer
+
+
+def _make_privacy_reanswer_column(evaluator_alias: str) -> Any:
+    @custom_column_generator(
+        required_columns=[COL_PRIVACY_QA, COL_REWRITTEN_TEXT],
+        model_aliases=[evaluator_alias],
+    )
+    def _privacy_reanswer(row: dict[str, Any], generator_params: None, models: dict) -> dict[str, Any]:
+        qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
+        expected_ids = [item.id for item in qa.items]
+
+        recipe = PydanticResponseRecipe(data_type=PrivacyAnswersSchema)
+        prompt = recipe.apply_recipe_to_user_prompt(_render_privacy_reanswer_prompt(row))
+        parser = _make_privacy_answer_parser(recipe, expected_ids)
+        result, _ = models[evaluator_alias].generate(prompt=prompt, parser=parser, max_correction_steps=3)
+        row[COL_PRIVACY_QA_REANSWER] = result
+        return row
+
+    return _privacy_reanswer
+
+
+def _make_quality_compare_column(evaluator_alias: str) -> Any:
+    @custom_column_generator(
+        required_columns=[COL_QUALITY_QA, COL_QUALITY_QA_REANSWER],
+        model_aliases=[evaluator_alias],
+    )
+    def _quality_compare(row: dict[str, Any], generator_params: None, models: dict) -> dict[str, Any]:
+        qa = parse_quality_qa(row.get(COL_QUALITY_QA, {}))
+        expected_ids = [item.id for item in qa.items]
+
+        recipe = PydanticResponseRecipe(data_type=QACompareResultsSchema)
+        prompt = recipe.apply_recipe_to_user_prompt(_render_quality_compare_prompt(row))
+        parser = _make_qa_compare_parser(recipe, expected_ids)
+        result, _ = models[evaluator_alias].generate(prompt=prompt, parser=parser, max_correction_steps=3)
+        row[COL_QUALITY_QA_COMPARE] = result
+        return row
+
+    return _quality_compare
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python custom column generators
+# ---------------------------------------------------------------------------
 
 
 @custom_column_generator(
-    required_columns=[COL_QUALITY_QA_COMPARE, COL_PRIVACY_QA_REANSWER, COL_PRIVACY_QA],
+    required_columns=[COL_QUALITY_QA_COMPARE, COL_PRIVACY_QA_REANSWER, COL_PRIVACY_QA, COL_QUALITY_QA],
     side_effect_columns=[COL_LEAKAGE_MASS, COL_ANY_HIGH_LEAKED],
 )
 def _compute_metrics_columns(row: dict[str, Any], generator_params: MetricsParams) -> dict[str, Any]:
     """Compute utility_score, leakage_mass, and any_high_leaked from evaluation outputs."""
-    compare_scores = _parse_quality_compare(row.get(COL_QUALITY_QA_COMPARE))
-    privacy_answers = _parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
-    privacy_qa = _parse_privacy_qa(row.get(COL_PRIVACY_QA))
+    _, compare_scores = parse_quality_compare(row.get(COL_QUALITY_QA_COMPARE))
+    privacy_answers = parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
+    privacy_qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
 
     row[COL_UTILITY_SCORE] = compute_utility_score(compare_scores)
     row[COL_LEAKAGE_MASS] = compute_leakage_mass(privacy_answers, privacy_qa, generator_params.sensitivity_weights)
@@ -305,7 +367,7 @@ def _compute_metrics_columns(row: dict[str, Any], generator_params: MetricsParam
 @custom_column_generator(required_columns=[COL_ANY_HIGH_LEAKED, COL_LEAKAGE_MASS])
 def _determine_repair_needs_column(row: dict[str, Any], generator_params: RepairNeedsParams) -> dict[str, Any]:
     """Set _needs_repair flag based on evaluation criteria."""
-    row[_COL_NEEDS_REPAIR] = determine_repair_needs(
+    row[COL_NEEDS_REPAIR] = determine_repair_needs(
         any_high_leaked=bool(row.get(COL_ANY_HIGH_LEAKED, False)),
         leakage_mass=float(row.get(COL_LEAKAGE_MASS, 0.0)),
         auto_repair_privacy=generator_params.auto_repair_privacy,
@@ -323,9 +385,15 @@ def _determine_repair_needs_column(row: dict[str, Any], generator_params: Repair
 class EvaluateWorkflow:
     """Evaluate rewritten text for quality preservation and privacy leakage.
 
-    Produces metric columns (utility_score, leakage_mass, any_high_leaked)
-    and a _needs_repair flag. The orchestrator uses these to decide whether
-    to run RepairWorkflow on failing rows and whether to iterate.
+    LLM calls use custom columns (not LLMStructuredColumnConfig) so we can
+    build a per-row parser that passes ``context={"expected_ids": [...]}`` to
+    Pydantic's ``model_validate``. This enforces that the LLM answers every
+    question ID -- DD's correction loop retries with the exact missing IDs
+    if the LLM skips any. LLMStructuredColumnConfig does not support passing
+    Pydantic validation context, which is why custom columns are required.
+
+    The orchestrator uses the output metrics and COL_NEEDS_REPAIR flag to
+    decide whether to run RepairWorkflow on failing rows.
     """
 
     def __init__(self, adapter: NddAdapter) -> None:
@@ -342,41 +410,30 @@ class EvaluateWorkflow:
         effective_threshold = evaluation.get_effective_threshold(domain)
 
         return [
-            # Step 1 -- Quality re-answer (LLM)
-            LLMStructuredColumnConfig(
-                name=COL_QUALITY_QA_REANSWER,
-                prompt=_quality_reanswer_prompt(),
-                model_alias=evaluator_alias,
-                output_format=QualityAnswersSchema,
-            ),
-            # Step 2 -- Privacy re-answer (LLM)
-            LLMStructuredColumnConfig(
-                name=COL_PRIVACY_QA_REANSWER,
-                prompt=_privacy_reanswer_prompt(),
-                model_alias=evaluator_alias,
-                output_format=PrivacyAnswersSchema,
-            ),
-            # Step 3 -- Pair QA items by ID for comparison (pure Python)
+            # Step 1 -- Quality re-answer (LLM with context-validated parser)
             CustomColumnConfig(
-                name=_COL_QA_COMPARISON_BLOCK,
-                generator_function=_pair_qa_for_comparison,
+                name=COL_QUALITY_QA_REANSWER,
+                generator_function=_make_quality_reanswer_column(evaluator_alias),
             ),
-            # Step 4 -- Quality comparison (LLM)
-            LLMStructuredColumnConfig(
+            # Step 2 -- Privacy re-answer (LLM with context-validated parser)
+            CustomColumnConfig(
+                name=COL_PRIVACY_QA_REANSWER,
+                generator_function=_make_privacy_reanswer_column(evaluator_alias),
+            ),
+            # Step 3 -- Quality comparison (LLM with context-validated parser)
+            CustomColumnConfig(
                 name=COL_QUALITY_QA_COMPARE,
-                prompt=_quality_compare_prompt(),
-                model_alias=evaluator_alias,
-                output_format=QACompareResultsSchema,
+                generator_function=_make_quality_compare_column(evaluator_alias),
             ),
-            # Step 5 -- Compute metrics (pure Python)
+            # Step 4 -- Compute metrics (pure Python)
             CustomColumnConfig(
                 name=COL_UTILITY_SCORE,
                 generator_function=_compute_metrics_columns,
                 generator_params=MetricsParams(sensitivity_weights=evaluation.sensitivity_weights),
             ),
-            # Step 6 -- Determine repair needs (pure Python)
+            # Step 5 -- Determine repair needs (pure Python)
             CustomColumnConfig(
-                name=_COL_NEEDS_REPAIR,
+                name=COL_NEEDS_REPAIR,
                 generator_function=_determine_repair_needs_column,
                 generator_params=RepairNeedsParams(
                     auto_repair_privacy=evaluation.auto_repair_privacy,

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -313,7 +313,7 @@ def _make_quality_reanswer_column(evaluator_alias: str) -> Any:
         prompt = recipe.apply_recipe_to_user_prompt(_render_quality_reanswer_prompt(row))
         parser = _make_quality_answer_parser(recipe, expected_ids)
         result, _ = models[evaluator_alias].generate(prompt=prompt, parser=parser, max_correction_steps=3)
-        row[COL_QUALITY_QA_REANSWER] = result
+        row[COL_QUALITY_QA_REANSWER] = result.model_dump()
         return row
 
     return _quality_reanswer
@@ -332,7 +332,7 @@ def _make_privacy_reanswer_column(evaluator_alias: str) -> Any:
         prompt = recipe.apply_recipe_to_user_prompt(_render_privacy_reanswer_prompt(row))
         parser = _make_privacy_answer_parser(recipe, expected_ids)
         result, _ = models[evaluator_alias].generate(prompt=prompt, parser=parser, max_correction_steps=3)
-        row[COL_PRIVACY_QA_REANSWER] = result
+        row[COL_PRIVACY_QA_REANSWER] = result.model_dump()
         return row
 
     return _privacy_reanswer
@@ -351,7 +351,7 @@ def _make_quality_compare_column(evaluator_alias: str) -> Any:
         prompt = recipe.apply_recipe_to_user_prompt(_render_quality_compare_prompt(row))
         parser = _make_qa_compare_parser(recipe, expected_ids)
         result, _ = models[evaluator_alias].generate(prompt=prompt, parser=parser, max_correction_steps=3)
-        row[COL_QUALITY_QA_COMPARE] = result
+        row[COL_QUALITY_QA_COMPARE] = result.model_dump()
         return row
 
     return _quality_compare

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -34,6 +34,7 @@ from anonymizer.engine.rewrite.parsers import (
     parse_quality_answers,
     parse_quality_compare,
     parse_quality_qa,
+    render_template,
 )
 from anonymizer.engine.schemas.rewrite import (
     PrivacyAnswer,
@@ -89,8 +90,12 @@ Fill in the "answer" field for each item. Do not add or remove items.
 <<SKELETON>>
 </answer_template>
 """
-    return prompt.replace("<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)).replace(
-        "<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))
+    return render_template(
+        prompt,
+        {
+            "<<SKELETON>>": json.dumps({"answers": skeleton}, indent=2),
+            "<<REWRITTEN_TEXT>>": str(row.get(COL_REWRITTEN_TEXT, "")),
+        },
     )
 
 
@@ -118,8 +123,12 @@ Fill in the "answer" field for each item with "yes" or "no". Do not add or remov
 <<SKELETON>>
 </answer_template>
 """
-    return prompt.replace("<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)).replace(
-        "<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))
+    return render_template(
+        prompt,
+        {
+            "<<SKELETON>>": json.dumps({"answers": skeleton}, indent=2),
+            "<<REWRITTEN_TEXT>>": str(row.get(COL_REWRITTEN_TEXT, "")),
+        },
     )
 
 
@@ -165,7 +174,12 @@ Fill in the "score" (0.0-1.0) and "reason" fields for each item. Do not add or r
 <<SKELETON>>
 </answer_template>
 """
-    return prompt.replace("<<SKELETON>>", json.dumps({"per_item": skeleton}, indent=2))
+    return render_template(
+        prompt,
+        {
+            "<<SKELETON>>": json.dumps({"per_item": skeleton}, indent=2),
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -89,8 +89,8 @@ Fill in the "answer" field for each item. Do not add or remove items.
 <<SKELETON>>
 </answer_template>
 """
-    return prompt.replace("<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))).replace(
-        "<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)
+    return prompt.replace("<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)).replace(
+        "<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))
     )
 
 
@@ -118,8 +118,8 @@ Fill in the "answer" field for each item with "yes" or "no". Do not add or remov
 <<SKELETON>>
 </answer_template>
 """
-    return prompt.replace("<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))).replace(
-        "<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)
+    return prompt.replace("<<SKELETON>>", json.dumps({"answers": skeleton}, indent=2)).replace(
+        "<<REWRITTEN_TEXT>>", str(row.get(COL_REWRITTEN_TEXT, ""))
     )
 
 
@@ -278,7 +278,7 @@ def determine_repair_needs(
         return False
     if repair_any_high_leak and any_high_leaked:
         return True
-    return leakage_mass >= effective_threshold
+    return leakage_mass > effective_threshold
 
 
 # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from data_designer.config import custom_column_generator
+from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+from data_designer.config.column_types import ColumnConfigT
+from pydantic import BaseModel
+
+from anonymizer.config.models import RewriteModelSelection
+from anonymizer.config.rewrite import EvaluationCriteria
+from anonymizer.engine.constants import (
+    COL_ANY_HIGH_LEAKED,
+    COL_LEAKAGE_MASS,
+    COL_PRIVACY_QA,
+    COL_PRIVACY_QA_REANSWER,
+    COL_QUALITY_QA,
+    COL_QUALITY_QA_COMPARE,
+    COL_QUALITY_QA_REANSWER,
+    COL_REWRITTEN_TEXT,
+    COL_UTILITY_SCORE,
+)
+from anonymizer.engine.ndd.adapter import NddAdapter
+from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.schemas.rewrite import (
+    PrivacyAnswer,
+    PrivacyAnswerItemSchema,
+    PrivacyAnswersSchema,
+    PrivacyQAPairsSchema,
+    QACompareResultsSchema,
+    QualityAnswerSchema,
+    QualityAnswersSchema,
+    QualityQAItemSchema,
+    QualityQAPairsSchema,
+    SensitivityLevel,
+)
+
+_COL_NEEDS_REPAIR = "_needs_repair"
+_COL_QA_COMPARISON_BLOCK = "_qa_comparison_block"
+
+
+# Schema field names validated at import time.
+def _field(model: type, name: str) -> str:
+    if name not in model.model_fields:
+        raise KeyError(f"{model.__name__} has no field '{name}'")
+    return name
+
+
+_F_ITEMS = _field(QualityQAPairsSchema, "items")
+_F_ANSWERS = _field(QualityAnswersSchema, "answers")
+_F_ID = _field(QualityQAItemSchema, "id")
+_F_QUESTION = _field(QualityQAItemSchema, "question")
+_F_ANSWER = _field(QualityAnswerSchema, "answer")
+_F_REFERENCE_ANSWER = _field(QualityQAItemSchema, "reference_answer")
+
+
+# ---------------------------------------------------------------------------
+# Generator params
+# ---------------------------------------------------------------------------
+
+
+class MetricsParams(BaseModel):
+    sensitivity_weights: dict[str, float]
+
+
+class RepairNeedsParams(BaseModel):
+    auto_repair_privacy: bool
+    repair_any_high_leak: bool
+    effective_threshold: float
+
+
+# ---------------------------------------------------------------------------
+# Prompts (Jinja2 templates resolved by NDD)
+# ---------------------------------------------------------------------------
+
+
+def _quality_reanswer_prompt() -> str:
+    prompt = """You are taking a reading comprehension exam. You will answer each question about the text.
+
+<rules>
+- If the text does not state the answer, use "unknown"
+- Keep answers concise and factual
+- Do not invent details
+</rules>
+
+<text>
+{{ <<COL_REWRITTEN_TEXT>> }}
+</text>
+
+<questions>
+{% for it in <<COL_QUALITY_QA>>['<<F_ITEMS>>'] %}- {{ it['<<F_ID>>'] }}: {{ it['<<F_QUESTION>>'] }}
+{% endfor %}</questions>
+"""
+    return (
+        prompt.replace("<<COL_REWRITTEN_TEXT>>", COL_REWRITTEN_TEXT)
+        .replace("<<COL_QUALITY_QA>>", COL_QUALITY_QA)
+        .replace("<<F_ITEMS>>", _F_ITEMS)
+        .replace("<<F_ID>>", _F_ID)
+        .replace("<<F_QUESTION>>", _F_QUESTION)
+    )
+
+
+def _privacy_reanswer_prompt() -> str:
+    prompt = """You are a privacy auditor. Read the text and answer each question with "yes" or "no".
+
+<rules>
+- Answer "yes" if the specific entity value can be identified or reasonably inferred from the text.
+- Answer "no" if it cannot be answered from the text.
+- You must commit to "yes" or "no". Do not hedge.
+</rules>
+
+<text>
+{{ <<COL_REWRITTEN_TEXT>> }}
+</text>
+
+<questions>
+{% for it in <<COL_PRIVACY_QA>>['<<F_ITEMS>>'] %}- {{ it['<<F_ID>>'] }}: {{ it['<<F_QUESTION>>'] }}
+{% endfor %}</questions>
+"""
+    return (
+        prompt.replace("<<COL_REWRITTEN_TEXT>>", COL_REWRITTEN_TEXT)
+        .replace("<<COL_PRIVACY_QA>>", COL_PRIVACY_QA)
+        .replace("<<F_ITEMS>>", _F_ITEMS)
+        .replace("<<F_ID>>", _F_ID)
+        .replace("<<F_QUESTION>>", _F_QUESTION)
+    )
+
+
+def _quality_compare_prompt() -> str:
+    prompt = """A student took a reading comprehension exam.
+
+<scoring_rubric>
+Compare the student's answer to the reference answer and grade each on a 0.0-1.0 scale:
+* 1.0 = Perfect match (semantically equivalent)
+* 0.7-0.9 = Mostly correct (minor details missing/different)
+* 0.4-0.6 = Partially correct (some key info present)
+* 0.1-0.3 = Minimal match (tangentially related)
+* 0.0 = No match (wrong, "unknown", or contradictory)
+</scoring_rubric>
+
+<grading_rules>
+* Grade conservatively
+* No credit for invented/contradictory info
+* Semantically equivalent answers get full credit
+* "unknown" answers get 0.0 score
+</grading_rules>
+
+<qa_pairs>
+{{ <<COL_QA_COMPARISON_BLOCK>> }}
+</qa_pairs>
+"""
+    return prompt.replace("<<COL_QA_COMPARISON_BLOCK>>", _COL_QA_COMPARISON_BLOCK)
+
+
+# ---------------------------------------------------------------------------
+# Parse helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_privacy_answers(raw: Any) -> list[PrivacyAnswerItemSchema]:
+    if isinstance(raw, PrivacyAnswersSchema):
+        return raw.answers
+    if isinstance(raw, dict):
+        return PrivacyAnswersSchema.model_validate(raw).answers
+    raise TypeError(f"Expected PrivacyAnswersSchema or dict, got {type(raw).__name__}")
+
+
+def _parse_quality_qa(raw: Any) -> QualityQAPairsSchema:
+    if isinstance(raw, QualityQAPairsSchema):
+        return raw
+    if isinstance(raw, dict):
+        return QualityQAPairsSchema.model_validate(raw)
+    raise TypeError(f"Expected QualityQAPairsSchema or dict, got {type(raw).__name__}")
+
+
+def _parse_quality_answers(raw: Any) -> list[QualityAnswerSchema]:
+    if isinstance(raw, QualityAnswersSchema):
+        return raw.answers
+    if isinstance(raw, dict):
+        return QualityAnswersSchema.model_validate(raw).answers
+    raise TypeError(f"Expected QualityAnswersSchema or dict, got {type(raw).__name__}")
+
+
+def _parse_quality_compare(raw: Any) -> list[float]:
+    if isinstance(raw, QACompareResultsSchema):
+        return [item.score for item in raw.per_item]
+    if isinstance(raw, dict):
+        parsed = QACompareResultsSchema.model_validate(raw)
+        return [item.score for item in parsed.per_item]
+    raise TypeError(f"Expected QACompareResultsSchema or dict, got {type(raw).__name__}")
+
+
+def _parse_privacy_qa(raw: Any) -> PrivacyQAPairsSchema:
+    if isinstance(raw, PrivacyQAPairsSchema):
+        return raw
+    if isinstance(raw, dict):
+        return PrivacyQAPairsSchema.model_validate(raw)
+    raise TypeError(f"Expected PrivacyQAPairsSchema or dict, got {type(raw).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python metric helpers (public, testable)
+# ---------------------------------------------------------------------------
+
+
+def compute_utility_score(compare_scores: list[float]) -> float:
+    """Mean of per-item QA comparison scores, or 0.0 if empty."""
+    if not compare_scores:
+        return 0.0
+    return sum(compare_scores) / len(compare_scores)
+
+
+def compute_leakage_mass(
+    privacy_answers: list[PrivacyAnswerItemSchema],
+    privacy_qa: PrivacyQAPairsSchema,
+    sensitivity_weights: dict[str, float],
+) -> float:
+    """Weighted sum of leaked entities.
+
+    An entity is "leaked" when the privacy re-answer is ``yes``.
+    The weight comes from ``sensitivity_weights[entity.sensitivity]``.
+    """
+    qa_lookup: dict[int, str] = {item.id: item.sensitivity for item in privacy_qa.items}
+    total = 0.0
+    for answer in privacy_answers:
+        if answer.answer == PrivacyAnswer.yes:
+            sensitivity = qa_lookup.get(answer.id, SensitivityLevel.low)
+            weight = sensitivity_weights[sensitivity]
+            total += weight
+    return total
+
+
+def compute_any_high_leaked(
+    privacy_answers: list[PrivacyAnswerItemSchema],
+    privacy_qa: PrivacyQAPairsSchema,
+) -> bool:
+    """Return True if any HIGH-sensitivity entity has answer=yes."""
+    qa_lookup: dict[int, str] = {item.id: item.sensitivity for item in privacy_qa.items}
+    return any(
+        answer.answer == PrivacyAnswer.yes and qa_lookup.get(answer.id) == SensitivityLevel.high
+        for answer in privacy_answers
+    )
+
+
+def determine_repair_needs(
+    *,
+    any_high_leaked: bool,
+    leakage_mass: float,
+    auto_repair_privacy: bool,
+    repair_any_high_leak: bool,
+    effective_threshold: float,
+) -> bool:
+    """Decide whether a single row needs repair."""
+    if not auto_repair_privacy:
+        return False
+    if repair_any_high_leak and any_high_leaked:
+        return True
+    return leakage_mass >= effective_threshold
+
+
+# ---------------------------------------------------------------------------
+# Custom column generators
+# ---------------------------------------------------------------------------
+
+
+@custom_column_generator(required_columns=[COL_QUALITY_QA, COL_QUALITY_QA_REANSWER])
+def _pair_qa_for_comparison(row: dict[str, Any]) -> dict[str, Any]:
+    """Match quality QA items with their reanswered counterparts by ID for the compare prompt."""
+    qa = _parse_quality_qa(row.get(COL_QUALITY_QA, {}))
+    reanswer = _parse_quality_answers(row.get(COL_QUALITY_QA_REANSWER))
+    answer_lookup: dict[int, str] = {a.id: a.answer for a in reanswer}
+
+    lines = []
+    for item in qa.items:
+        student = answer_lookup.get(item.id, "(no answer)")
+        lines.append(
+            f"- question ID: {item.id}\n"
+            f"  question: {item.question}\n"
+            f"  expected answer: {item.reference_answer}\n"
+            f"  student answer: {student}"
+        )
+    row[_COL_QA_COMPARISON_BLOCK] = "\n".join(lines)
+    return row
+
+
+@custom_column_generator(
+    required_columns=[COL_QUALITY_QA_COMPARE, COL_PRIVACY_QA_REANSWER, COL_PRIVACY_QA],
+    side_effect_columns=[COL_LEAKAGE_MASS, COL_ANY_HIGH_LEAKED],
+)
+def _compute_metrics_columns(row: dict[str, Any], generator_params: MetricsParams) -> dict[str, Any]:
+    """Compute utility_score, leakage_mass, and any_high_leaked from evaluation outputs."""
+    compare_scores = _parse_quality_compare(row.get(COL_QUALITY_QA_COMPARE))
+    privacy_answers = _parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
+    privacy_qa = _parse_privacy_qa(row.get(COL_PRIVACY_QA))
+
+    row[COL_UTILITY_SCORE] = compute_utility_score(compare_scores)
+    row[COL_LEAKAGE_MASS] = compute_leakage_mass(privacy_answers, privacy_qa, generator_params.sensitivity_weights)
+    row[COL_ANY_HIGH_LEAKED] = compute_any_high_leaked(privacy_answers, privacy_qa)
+    return row
+
+
+@custom_column_generator(required_columns=[COL_ANY_HIGH_LEAKED, COL_LEAKAGE_MASS])
+def _determine_repair_needs_column(row: dict[str, Any], generator_params: RepairNeedsParams) -> dict[str, Any]:
+    """Set _needs_repair flag based on evaluation criteria."""
+    row[_COL_NEEDS_REPAIR] = determine_repair_needs(
+        any_high_leaked=bool(row.get(COL_ANY_HIGH_LEAKED, False)),
+        leakage_mass=float(row.get(COL_LEAKAGE_MASS, 0.0)),
+        auto_repair_privacy=generator_params.auto_repair_privacy,
+        repair_any_high_leak=generator_params.repair_any_high_leak,
+        effective_threshold=generator_params.effective_threshold,
+    )
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+
+
+class EvaluateWorkflow:
+    """Evaluate rewritten text for quality preservation and privacy leakage.
+
+    Produces metric columns (utility_score, leakage_mass, any_high_leaked)
+    and a _needs_repair flag. The orchestrator uses these to decide whether
+    to run RepairWorkflow on failing rows and whether to iterate.
+    """
+
+    def __init__(self, adapter: NddAdapter) -> None:
+        self._adapter = adapter
+
+    def columns(
+        self,
+        *,
+        selected_models: RewriteModelSelection,
+        evaluation: EvaluationCriteria,
+        domain: str | None = None,
+    ) -> list[ColumnConfigT]:
+        evaluator_alias = resolve_model_alias("evaluator", selected_models)
+        effective_threshold = evaluation.get_effective_threshold(domain)
+
+        return [
+            # Step 1 -- Quality re-answer (LLM)
+            LLMStructuredColumnConfig(
+                name=COL_QUALITY_QA_REANSWER,
+                prompt=_quality_reanswer_prompt(),
+                model_alias=evaluator_alias,
+                output_format=QualityAnswersSchema,
+            ),
+            # Step 2 -- Privacy re-answer (LLM)
+            LLMStructuredColumnConfig(
+                name=COL_PRIVACY_QA_REANSWER,
+                prompt=_privacy_reanswer_prompt(),
+                model_alias=evaluator_alias,
+                output_format=PrivacyAnswersSchema,
+            ),
+            # Step 3 -- Pair QA items by ID for comparison (pure Python)
+            CustomColumnConfig(
+                name=_COL_QA_COMPARISON_BLOCK,
+                generator_function=_pair_qa_for_comparison,
+            ),
+            # Step 4 -- Quality comparison (LLM)
+            LLMStructuredColumnConfig(
+                name=COL_QUALITY_QA_COMPARE,
+                prompt=_quality_compare_prompt(),
+                model_alias=evaluator_alias,
+                output_format=QACompareResultsSchema,
+            ),
+            # Step 5 -- Compute metrics (pure Python)
+            CustomColumnConfig(
+                name=COL_UTILITY_SCORE,
+                generator_function=_compute_metrics_columns,
+                generator_params=MetricsParams(sensitivity_weights=evaluation.sensitivity_weights),
+            ),
+            # Step 6 -- Determine repair needs (pure Python)
+            CustomColumnConfig(
+                name=_COL_NEEDS_REPAIR,
+                generator_function=_determine_repair_needs_column,
+                generator_params=RepairNeedsParams(
+                    auto_repair_privacy=evaluation.auto_repair_privacy,
+                    repair_any_high_leak=evaluation.repair_any_high_leak,
+                    effective_threshold=effective_threshold,
+                ),
+            ),
+        ]

--- a/src/anonymizer/engine/rewrite/parsers.py
+++ b/src/anonymizer/engine/rewrite/parsers.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared parse helpers and schema field validation for rewrite workflows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from anonymizer.engine.schemas.rewrite import (
+    PrivacyAnswerItemSchema,
+    PrivacyAnswersSchema,
+    PrivacyQAPairsSchema,
+    QACompareResultsSchema,
+    QualityAnswerSchema,
+    QualityAnswersSchema,
+    QualityQAPairsSchema,
+    SensitivityDispositionSchema,
+)
+
+
+def field(model: type, name: str) -> str:
+    """Return *name* after verifying it exists on *model* as a Pydantic field.
+
+    Called at module import time so a renamed schema field raises
+    ``KeyError`` immediately instead of producing a broken prompt at runtime.
+    """
+    if name not in model.model_fields:
+        raise KeyError(f"{model.__name__} has no field '{name}'")
+    return name
+
+
+def parse_privacy_answers(raw: Any) -> list[PrivacyAnswerItemSchema]:
+    if isinstance(raw, PrivacyAnswersSchema):
+        return raw.answers
+    if isinstance(raw, dict):
+        return PrivacyAnswersSchema.model_validate(raw).answers
+    raise TypeError(f"Expected PrivacyAnswersSchema or dict, got {type(raw).__name__}")
+
+
+def parse_quality_qa(raw: Any) -> QualityQAPairsSchema:
+    if isinstance(raw, QualityQAPairsSchema):
+        return raw
+    if isinstance(raw, dict):
+        return QualityQAPairsSchema.model_validate(raw)
+    raise TypeError(f"Expected QualityQAPairsSchema or dict, got {type(raw).__name__}")
+
+
+def parse_quality_answers(raw: Any) -> list[QualityAnswerSchema]:
+    if isinstance(raw, QualityAnswersSchema):
+        return raw.answers
+    if isinstance(raw, dict):
+        return QualityAnswersSchema.model_validate(raw).answers
+    raise TypeError(f"Expected QualityAnswersSchema or dict, got {type(raw).__name__}")
+
+
+def parse_quality_compare(raw: Any) -> tuple[list[int], list[float]]:
+    """Return (ids, scores) from a QACompareResultsSchema or dict."""
+    if isinstance(raw, QACompareResultsSchema):
+        return [item.id for item in raw.per_item], [item.score for item in raw.per_item]
+    if isinstance(raw, dict):
+        parsed = QACompareResultsSchema.model_validate(raw)
+        return [item.id for item in parsed.per_item], [item.score for item in parsed.per_item]
+    raise TypeError(f"Expected QACompareResultsSchema or dict, got {type(raw).__name__}")
+
+
+def parse_privacy_qa(raw: Any) -> PrivacyQAPairsSchema:
+    if isinstance(raw, PrivacyQAPairsSchema):
+        return raw
+    if isinstance(raw, dict):
+        return PrivacyQAPairsSchema.model_validate(raw)
+    raise TypeError(f"Expected PrivacyQAPairsSchema or dict, got {type(raw).__name__}")
+
+
+def parse_sensitivity_disposition(raw: Any) -> SensitivityDispositionSchema:
+    if isinstance(raw, SensitivityDispositionSchema):
+        return raw
+    if isinstance(raw, dict):
+        return SensitivityDispositionSchema.model_validate(raw)
+    raise ValueError(f"Cannot parse sensitivity disposition from {type(raw)}")

--- a/src/anonymizer/engine/rewrite/parsers.py
+++ b/src/anonymizer/engine/rewrite/parsers.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared parse helpers and schema field validation for rewrite workflows."""
+"""Shared parse helpers, schema field validation, and prompt utilities for rewrite workflows."""
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from anonymizer.engine.schemas.rewrite import (
@@ -17,6 +18,19 @@ from anonymizer.engine.schemas.rewrite import (
     QualityQAPairsSchema,
     SensitivityDispositionSchema,
 )
+
+
+def render_template(template: str, replacements: dict[str, str]) -> str:
+    """Single-pass placeholder substitution.
+
+    All ``<<PLACEHOLDER>>`` markers are replaced simultaneously so that
+    user-controlled values inserted for one placeholder cannot collide
+    with markers intended for a later placeholder.
+    """
+    if not replacements:
+        return template
+    pattern = re.compile("|".join(re.escape(k) for k in replacements))
+    return pattern.sub(lambda m: replacements[m.group(0)], template)
 
 
 def field(model: type, name: str) -> str:

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -32,6 +32,7 @@ from anonymizer.engine.rewrite.parsers import (
     parse_privacy_answers,
     parse_privacy_qa,
     parse_sensitivity_disposition,
+    render_template,
 )
 from anonymizer.engine.schemas.rewrite import (
     EntityDispositionSchema,
@@ -162,9 +163,7 @@ Provide ONLY the rewritten text. Do not include explanations, comments, or markd
         "<<LEAKED_ITEMS>>": str(row.get(_COL_LEAKED_PRIVACY_ITEMS, "")),
         "<<UTILITY_SCORE>>": str(row.get(COL_UTILITY_SCORE, 0.0)),
     }
-    for key, value in replacements.items():
-        prompt = prompt.replace(key, value)
-    return prompt
+    return render_template(prompt, replacements)
 
 
 # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -27,28 +27,29 @@ from anonymizer.engine.constants import (
 )
 from anonymizer.engine.ndd.adapter import NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.rewrite.parsers import (
+    field,
+    parse_privacy_answers,
+    parse_privacy_qa,
+    parse_sensitivity_disposition,
+)
 from anonymizer.engine.schemas.rewrite import (
     EntityDispositionSchema,
     PrivacyAnswer,
     PrivacyAnswerItemSchema,
-    PrivacyAnswersSchema,
     PrivacyQAPairsSchema,
     RewriteOutputSchema,
-    SensitivityDispositionSchema,
 )
 
 logger = logging.getLogger("anonymizer.rewrite.repair")
 
 _COL_LEAKED_PRIVACY_ITEMS = "_leaked_privacy_items"
 
-# Schema field names validated at import time.
-_F_NEEDS_PROTECTION = EntityDispositionSchema.model_fields["needs_protection"] and "needs_protection"
-_F_ENTITY_LABEL = EntityDispositionSchema.model_fields["entity_label"] and "entity_label"
-_F_ENTITY_VALUE = EntityDispositionSchema.model_fields["entity_value"] and "entity_value"
-_F_PROTECTION_METHOD = (
-    EntityDispositionSchema.model_fields["protection_method_suggestion"] and "protection_method_suggestion"
-)
-_F_PROTECTION_REASON = EntityDispositionSchema.model_fields["protection_reason"] and "protection_reason"
+_F_NEEDS_PROTECTION = field(EntityDispositionSchema, "needs_protection")
+_F_ENTITY_LABEL = field(EntityDispositionSchema, "entity_label")
+_F_ENTITY_VALUE = field(EntityDispositionSchema, "entity_value")
+_F_PROTECTION_METHOD = field(EntityDispositionSchema, "protection_method_suggestion")
+_F_PROTECTION_REASON = field(EntityDispositionSchema, "protection_reason")
 
 
 # ---------------------------------------------------------------------------
@@ -59,35 +60,6 @@ _F_PROTECTION_REASON = EntityDispositionSchema.model_fields["protection_reason"]
 class RepairParams(BaseModel):
     privacy_goal_str: str
     max_privacy_leak: float
-
-
-# ---------------------------------------------------------------------------
-# Parse helpers
-# ---------------------------------------------------------------------------
-
-
-def _parse_privacy_answers(raw: Any) -> list[PrivacyAnswerItemSchema]:
-    if isinstance(raw, PrivacyAnswersSchema):
-        return raw.answers
-    if isinstance(raw, dict):
-        return PrivacyAnswersSchema.model_validate(raw).answers
-    raise TypeError(f"Expected PrivacyAnswersSchema or dict, got {type(raw).__name__}")
-
-
-def _parse_privacy_qa(raw: Any) -> PrivacyQAPairsSchema:
-    if isinstance(raw, PrivacyQAPairsSchema):
-        return raw
-    if isinstance(raw, dict):
-        return PrivacyQAPairsSchema.model_validate(raw)
-    raise TypeError(f"Expected PrivacyQAPairsSchema or dict, got {type(raw).__name__}")
-
-
-def _parse_sensitivity_disposition(raw: Any) -> SensitivityDispositionSchema:
-    if isinstance(raw, SensitivityDispositionSchema):
-        return raw
-    if isinstance(raw, dict):
-        return SensitivityDispositionSchema.model_validate(raw)
-    raise ValueError(f"Cannot parse sensitivity disposition from {type(raw)}")
 
 
 # ---------------------------------------------------------------------------
@@ -114,7 +86,7 @@ def _leaked_items_text(
 
 def _format_protection_block(row: dict[str, Any]) -> str:
     """Format the protection decisions section of the repair prompt."""
-    disposition = _parse_sensitivity_disposition(row.get(COL_SENSITIVITY_DISPOSITION, {}))
+    disposition = parse_sensitivity_disposition(row.get(COL_SENSITIVITY_DISPOSITION, {}))
     lines = [
         f'- {e.entity_label}: "{e.entity_value}" -> {e.protection_method_suggestion}\n  Reason: {e.protection_reason}'
         for e in disposition.sensitivity_disposition
@@ -125,7 +97,7 @@ def _format_protection_block(row: dict[str, Any]) -> str:
 
 def _render_repair_prompt(row: dict[str, Any], params: RepairParams) -> str:
     """Build the repair prompt from row values (no Jinja2)."""
-    disposition = _parse_sensitivity_disposition(row.get(COL_SENSITIVITY_DISPOSITION, {}))
+    disposition = parse_sensitivity_disposition(row.get(COL_SENSITIVITY_DISPOSITION, {}))
     has_replace_entities = any(
         e.protection_method_suggestion == "replace" and e.needs_protection for e in disposition.sensitivity_disposition
     )
@@ -203,8 +175,8 @@ Provide ONLY the rewritten text. Do not include explanations, comments, or markd
 @custom_column_generator(required_columns=[COL_PRIVACY_QA_REANSWER, COL_PRIVACY_QA])
 def _inject_leaked_items_column(row: dict[str, Any]) -> dict[str, Any]:
     """Format leaked privacy items into a text block for the repair prompt."""
-    privacy_answers = _parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
-    privacy_qa = _parse_privacy_qa(row.get(COL_PRIVACY_QA))
+    privacy_answers = parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
+    privacy_qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
     row[_COL_LEAKED_PRIVACY_ITEMS] = _leaked_items_text(privacy_answers, privacy_qa)
     return row
 

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -17,10 +17,12 @@ from anonymizer.config.rewrite import PrivacyGoal
 from anonymizer.engine.constants import (
     COL_ANY_HIGH_LEAKED,
     COL_LEAKAGE_MASS,
+    COL_LEAKED_PRIVACY_ITEMS,
     COL_PRIVACY_QA,
     COL_PRIVACY_QA_REANSWER,
     COL_REPLACEMENT_MAP_FOR_PROMPT,
     COL_REWRITTEN_TEXT,
+    COL_REWRITTEN_TEXT_NEXT,
     COL_SENSITIVITY_DISPOSITION,
     COL_TEXT,
     COL_UTILITY_SCORE,
@@ -44,8 +46,6 @@ from anonymizer.engine.schemas.rewrite import (
 
 logger = logging.getLogger("anonymizer.rewrite.repair")
 
-_COL_LEAKED_PRIVACY_ITEMS = "_leaked_privacy_items"
-COL_REWRITTEN_TEXT_NEXT = COL_REWRITTEN_TEXT + "__next"
 
 _F_NEEDS_PROTECTION = field(EntityDispositionSchema, "needs_protection")
 _F_ENTITY_LABEL = field(EntityDispositionSchema, "entity_label")
@@ -161,7 +161,7 @@ Provide ONLY the rewritten text. Do not include explanations, comments, or markd
         "<<HIGH_WARN>>": "\nWARNING: HIGH-SENSITIVITY LEAK DETECTED - must be fixed!"
         if row.get(COL_ANY_HIGH_LEAKED)
         else "",
-        "<<LEAKED_ITEMS>>": str(row.get(_COL_LEAKED_PRIVACY_ITEMS, "")),
+        "<<LEAKED_ITEMS>>": str(row.get(COL_LEAKED_PRIVACY_ITEMS, "")),
         "<<UTILITY_SCORE>>": str(row.get(COL_UTILITY_SCORE, 0.0)),
     }
     return render_template(prompt, replacements)
@@ -177,7 +177,7 @@ def _inject_leaked_items_column(row: dict[str, Any]) -> dict[str, Any]:
     """Format leaked privacy items into a text block for the repair prompt."""
     privacy_answers = parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
     privacy_qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
-    row[_COL_LEAKED_PRIVACY_ITEMS] = _leaked_items_text(privacy_answers, privacy_qa)
+    row[COL_LEAKED_PRIVACY_ITEMS] = _leaked_items_text(privacy_answers, privacy_qa)
     return row
 
 
@@ -186,7 +186,7 @@ def _make_repair_column(repairer_alias: str) -> Any:
 
     @custom_column_generator(
         required_columns=[
-            _COL_LEAKED_PRIVACY_ITEMS,
+            COL_LEAKED_PRIVACY_ITEMS,
             COL_REWRITTEN_TEXT,
             COL_SENSITIVITY_DISPOSITION,
             COL_TEXT,
@@ -235,7 +235,7 @@ class RepairWorkflow:
         return [
             # Step 1 -- Format leaked items for repair prompt (pure Python)
             CustomColumnConfig(
-                name=_COL_LEAKED_PRIVACY_ITEMS,
+                name=COL_LEAKED_PRIVACY_ITEMS,
                 generator_function=_inject_leaked_items_column,
             ),
             # Step 2 -- Repair rewritten text (LLM via custom column)

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -45,6 +45,7 @@ from anonymizer.engine.schemas.rewrite import (
 logger = logging.getLogger("anonymizer.rewrite.repair")
 
 _COL_LEAKED_PRIVACY_ITEMS = "_leaked_privacy_items"
+COL_REWRITTEN_TEXT_NEXT = COL_REWRITTEN_TEXT + "__next"
 
 _F_NEEDS_PROTECTION = field(EntityDispositionSchema, "needs_protection")
 _F_ENTITY_LABEL = field(EntityDispositionSchema, "entity_label")
@@ -200,7 +201,7 @@ def _make_repair_column(repairer_alias: str) -> Any:
         recipe = PydanticResponseRecipe(data_type=RewriteOutputSchema)
         prompt = recipe.apply_recipe_to_user_prompt(_render_repair_prompt(row, generator_params))
         result, _ = models[repairer_alias].generate(prompt=prompt, parser=recipe.parse, max_correction_steps=3)
-        row[COL_REWRITTEN_TEXT] = result.rewritten_text
+        row[COL_REWRITTEN_TEXT_NEXT] = result.rewritten_text
         return row
 
     return _repair_column
@@ -239,7 +240,7 @@ class RepairWorkflow:
             ),
             # Step 2 -- Repair rewritten text (LLM via custom column)
             CustomColumnConfig(
-                name=COL_REWRITTEN_TEXT,
+                name=COL_REWRITTEN_TEXT_NEXT,
                 generator_function=_make_repair_column(repairer_alias),
                 generator_params=RepairParams(
                     privacy_goal_str=privacy_goal.to_prompt_string(),

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -185,7 +185,16 @@ def _make_repair_column(repairer_alias: str) -> Any:
     """Factory that creates a repair column generator bound to a resolved model alias."""
 
     @custom_column_generator(
-        required_columns=[_COL_LEAKED_PRIVACY_ITEMS, COL_REWRITTEN_TEXT],
+        required_columns=[
+            _COL_LEAKED_PRIVACY_ITEMS,
+            COL_REWRITTEN_TEXT,
+            COL_SENSITIVITY_DISPOSITION,
+            COL_TEXT,
+            COL_REPLACEMENT_MAP_FOR_PROMPT,
+            COL_LEAKAGE_MASS,
+            COL_ANY_HIGH_LEAKED,
+            COL_UTILITY_SCORE,
+        ],
         model_aliases=[repairer_alias],
     )
     def _repair_column(row: dict[str, Any], generator_params: RepairParams, models: dict) -> dict[str, Any]:

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from data_designer.config import custom_column_generator
+from data_designer.config.column_configs import CustomColumnConfig
+from data_designer.config.column_types import ColumnConfigT
+from data_designer.engine.models.recipes.response_recipes import PydanticResponseRecipe
+from pydantic import BaseModel
+
+from anonymizer.config.models import RewriteModelSelection
+from anonymizer.config.rewrite import PrivacyGoal
+from anonymizer.engine.constants import (
+    COL_ANY_HIGH_LEAKED,
+    COL_LEAKAGE_MASS,
+    COL_PRIVACY_QA,
+    COL_PRIVACY_QA_REANSWER,
+    COL_REPLACEMENT_MAP,
+    COL_REWRITTEN_TEXT,
+    COL_SENSITIVITY_DISPOSITION,
+    COL_TEXT,
+    COL_UTILITY_SCORE,
+)
+from anonymizer.engine.ndd.adapter import NddAdapter
+from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.schemas.rewrite import (
+    EntityDispositionSchema,
+    PrivacyAnswer,
+    PrivacyAnswerItemSchema,
+    PrivacyAnswersSchema,
+    PrivacyQAPairsSchema,
+    RewriteOutputSchema,
+    SensitivityDispositionSchema,
+)
+
+_COL_LEAKED_PRIVACY_ITEMS = "_leaked_privacy_items"
+
+# Schema field names validated at import time.
+_F_NEEDS_PROTECTION = EntityDispositionSchema.model_fields["needs_protection"] and "needs_protection"
+_F_ENTITY_LABEL = EntityDispositionSchema.model_fields["entity_label"] and "entity_label"
+_F_ENTITY_VALUE = EntityDispositionSchema.model_fields["entity_value"] and "entity_value"
+_F_PROTECTION_METHOD = (
+    EntityDispositionSchema.model_fields["protection_method_suggestion"] and "protection_method_suggestion"
+)
+_F_PROTECTION_REASON = EntityDispositionSchema.model_fields["protection_reason"] and "protection_reason"
+
+
+# ---------------------------------------------------------------------------
+# Generator params
+# ---------------------------------------------------------------------------
+
+
+class RepairParams(BaseModel):
+    privacy_goal_str: str
+    max_privacy_leak: float
+
+
+# ---------------------------------------------------------------------------
+# Parse helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_privacy_answers(raw: Any) -> list[PrivacyAnswerItemSchema]:
+    if isinstance(raw, PrivacyAnswersSchema):
+        return raw.answers
+    if isinstance(raw, dict):
+        return PrivacyAnswersSchema.model_validate(raw).answers
+    raise TypeError(f"Expected PrivacyAnswersSchema or dict, got {type(raw).__name__}")
+
+
+def _parse_privacy_qa(raw: Any) -> PrivacyQAPairsSchema:
+    if isinstance(raw, PrivacyQAPairsSchema):
+        return raw
+    if isinstance(raw, dict):
+        return PrivacyQAPairsSchema.model_validate(raw)
+    raise TypeError(f"Expected PrivacyQAPairsSchema or dict, got {type(raw).__name__}")
+
+
+def _parse_sensitivity_disposition(raw: Any) -> SensitivityDispositionSchema:
+    if isinstance(raw, SensitivityDispositionSchema):
+        return raw
+    if isinstance(raw, dict):
+        return SensitivityDispositionSchema.model_validate(raw)
+    raise ValueError(f"Cannot parse sensitivity disposition from {type(raw)}")
+
+
+# ---------------------------------------------------------------------------
+# Prompt helpers
+# ---------------------------------------------------------------------------
+
+
+def _leaked_items_text(
+    privacy_answers: list[PrivacyAnswerItemSchema],
+    privacy_qa: PrivacyQAPairsSchema,
+) -> str:
+    """Format leaked privacy items for the repair prompt."""
+    qa_lookup: dict[int, Any] = {item.id: item for item in privacy_qa.items}
+    lines = []
+    for answer in privacy_answers:
+        if answer.answer == PrivacyAnswer.yes:
+            item = qa_lookup.get(answer.id)
+            if item:
+                lines.append(
+                    f'- [{item.sensitivity.upper()}] {item.entity_label}: "{item.entity_value}" -- {item.question}'
+                )
+    return "\n".join(lines)
+
+
+def _format_protection_block(row: dict[str, Any]) -> str:
+    """Format the protection decisions section of the repair prompt."""
+    disposition = _parse_sensitivity_disposition(row.get(COL_SENSITIVITY_DISPOSITION, {}))
+    lines = [
+        f'- {e.entity_label}: "{e.entity_value}" -> {e.protection_method_suggestion}\n  Reason: {e.protection_reason}'
+        for e in disposition.sensitivity_disposition
+        if e.needs_protection
+    ]
+    return "\n".join(lines)
+
+
+def _render_repair_prompt(row: dict[str, Any], params: RepairParams) -> str:
+    """Build the repair prompt from row values (no Jinja2)."""
+    prompt = """You are helping to rewrite text for privacy protection.
+
+<privacy_goal>
+<<PRIVACY_GOAL>>
+</privacy_goal>
+
+<protection_decisions>
+<<PROTECTION_BLOCK>>
+</protection_decisions>
+
+<original_text>
+<<ORIGINAL_TEXT>>
+</original_text>
+
+<previous_rewrite>
+<<REWRITTEN_TEXT>>
+</previous_rewrite>
+
+<replacement_map>
+<<REPLACEMENT_MAP>>
+</replacement_map>
+
+<privacy_issues>
+The following questions about sensitive information can still be answered from the rewrite.
+Leakage mass: <<LEAKAGE_MASS>> (target: < <<MAX_PRIVACY_LEAK>>)<<HIGH_WARN>>
+<<LEAKED_ITEMS>>
+</privacy_issues>
+
+<task>
+Fix the privacy leaks by following the protection decisions above:
+1. For "replace" - use synthetic values from the replacement map
+2. For "generalize" - use broader categories
+3. For "remove" - omit the detail entirely
+4. For "paraphrase" - rewrite surrounding context
+
+Maintain content quality (utility score: <<UTILITY_SCORE>>), consistency, and naturalness.
+
+Provide ONLY the rewritten text. Do not include explanations, comments, or markdown formatting.
+</task>
+"""
+    # TODO(#49): swap COL_REPLACEMENT_MAP for COL_REPLACEMENT_MAP_FOR_PROMPT after rebase
+    replacements = {
+        "<<PRIVACY_GOAL>>": params.privacy_goal_str,
+        "<<MAX_PRIVACY_LEAK>>": str(params.max_privacy_leak),
+        "<<PROTECTION_BLOCK>>": _format_protection_block(row),
+        "<<ORIGINAL_TEXT>>": str(row.get(COL_TEXT, "")),
+        "<<REWRITTEN_TEXT>>": str(row.get(COL_REWRITTEN_TEXT, "")),
+        "<<REPLACEMENT_MAP>>": str(row.get(COL_REPLACEMENT_MAP, "")),
+        "<<LEAKAGE_MASS>>": str(row.get(COL_LEAKAGE_MASS, 0.0)),
+        "<<HIGH_WARN>>": "\nWARNING: HIGH-SENSITIVITY LEAK DETECTED - must be fixed!"
+        if row.get(COL_ANY_HIGH_LEAKED)
+        else "",
+        "<<LEAKED_ITEMS>>": str(row.get(_COL_LEAKED_PRIVACY_ITEMS, "")),
+        "<<UTILITY_SCORE>>": str(row.get(COL_UTILITY_SCORE, 0.0)),
+    }
+    for key, value in replacements.items():
+        prompt = prompt.replace(key, value)
+    return prompt
+
+
+# ---------------------------------------------------------------------------
+# Custom column generators
+# ---------------------------------------------------------------------------
+
+
+@custom_column_generator(required_columns=[COL_PRIVACY_QA_REANSWER, COL_PRIVACY_QA])
+def _inject_leaked_items_column(row: dict[str, Any]) -> dict[str, Any]:
+    """Format leaked privacy items into a text block for the repair prompt."""
+    privacy_answers = _parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
+    privacy_qa = _parse_privacy_qa(row.get(COL_PRIVACY_QA))
+    row[_COL_LEAKED_PRIVACY_ITEMS] = _leaked_items_text(privacy_answers, privacy_qa)
+    return row
+
+
+def _make_repair_column(repairer_alias: str) -> Any:
+    """Factory that creates a repair column generator bound to a resolved model alias."""
+
+    @custom_column_generator(
+        required_columns=[_COL_LEAKED_PRIVACY_ITEMS, COL_REWRITTEN_TEXT],
+        model_aliases=[repairer_alias],
+    )
+    def _repair_column(row: dict[str, Any], generator_params: RepairParams, models: dict) -> dict[str, Any]:
+        recipe = PydanticResponseRecipe(data_type=RewriteOutputSchema)
+        prompt = recipe.apply_recipe_to_user_prompt(_render_repair_prompt(row, generator_params))
+        result, _ = models[repairer_alias].generate(prompt=prompt, parser=recipe.parse, max_correction_steps=3)
+        row[COL_REWRITTEN_TEXT] = result.rewritten_text
+        return row
+
+    return _repair_column
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+
+
+class RepairWorkflow:
+    """Repair rewritten text that failed privacy evaluation.
+
+    The orchestrator is responsible for filtering to rows where
+    _needs_repair=True before calling this workflow. Every row
+    processed here receives an unconditional repair LLM call.
+    """
+
+    def __init__(self, adapter: NddAdapter) -> None:
+        self._adapter = adapter
+
+    def columns(
+        self,
+        *,
+        selected_models: RewriteModelSelection,
+        privacy_goal: PrivacyGoal,
+        effective_threshold: float,
+    ) -> list[ColumnConfigT]:
+        repairer_alias = resolve_model_alias("repairer", selected_models)
+
+        return [
+            # Step 1 -- Format leaked items for repair prompt (pure Python)
+            CustomColumnConfig(
+                name=_COL_LEAKED_PRIVACY_ITEMS,
+                generator_function=_inject_leaked_items_column,
+            ),
+            # Step 2 -- Repair rewritten text (LLM via custom column)
+            CustomColumnConfig(
+                name=COL_REWRITTEN_TEXT,
+                generator_function=_make_repair_column(repairer_alias),
+                generator_params=RepairParams(
+                    privacy_goal_str=privacy_goal.to_prompt_string(),
+                    max_privacy_leak=effective_threshold,
+                ),
+            ),
+        ]

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from data_designer.config import custom_column_generator
@@ -18,7 +19,7 @@ from anonymizer.engine.constants import (
     COL_LEAKAGE_MASS,
     COL_PRIVACY_QA,
     COL_PRIVACY_QA_REANSWER,
-    COL_REPLACEMENT_MAP,
+    COL_REPLACEMENT_MAP_FOR_PROMPT,
     COL_REWRITTEN_TEXT,
     COL_SENSITIVITY_DISPOSITION,
     COL_TEXT,
@@ -35,6 +36,8 @@ from anonymizer.engine.schemas.rewrite import (
     RewriteOutputSchema,
     SensitivityDispositionSchema,
 )
+
+logger = logging.getLogger("anonymizer.rewrite.repair")
 
 _COL_LEAKED_PRIVACY_ITEMS = "_leaked_privacy_items"
 
@@ -122,6 +125,17 @@ def _format_protection_block(row: dict[str, Any]) -> str:
 
 def _render_repair_prompt(row: dict[str, Any], params: RepairParams) -> str:
     """Build the repair prompt from row values (no Jinja2)."""
+    disposition = _parse_sensitivity_disposition(row.get(COL_SENSITIVITY_DISPOSITION, {}))
+    has_replace_entities = any(
+        e.protection_method_suggestion == "replace" and e.needs_protection for e in disposition.sensitivity_disposition
+    )
+    raw_map = row.get(COL_REPLACEMENT_MAP_FOR_PROMPT)
+    if has_replace_entities and (not raw_map or raw_map == {"replacements": []}):
+        logger.warning(
+            "Repair prompt has entities requiring replacement but COL_REPLACEMENT_MAP_FOR_PROMPT is empty; "
+            "the LLM will have no synthetic values to use."
+        )
+
     prompt = """You are helping to rewrite text for privacy protection.
 
 <privacy_goal>
@@ -162,14 +176,13 @@ Maintain content quality (utility score: <<UTILITY_SCORE>>), consistency, and na
 Provide ONLY the rewritten text. Do not include explanations, comments, or markdown formatting.
 </task>
 """
-    # TODO(#49): swap COL_REPLACEMENT_MAP for COL_REPLACEMENT_MAP_FOR_PROMPT after rebase
     replacements = {
         "<<PRIVACY_GOAL>>": params.privacy_goal_str,
         "<<MAX_PRIVACY_LEAK>>": str(params.max_privacy_leak),
         "<<PROTECTION_BLOCK>>": _format_protection_block(row),
         "<<ORIGINAL_TEXT>>": str(row.get(COL_TEXT, "")),
         "<<REWRITTEN_TEXT>>": str(row.get(COL_REWRITTEN_TEXT, "")),
-        "<<REPLACEMENT_MAP>>": str(row.get(COL_REPLACEMENT_MAP, "")),
+        "<<REPLACEMENT_MAP>>": str(row.get(COL_REPLACEMENT_MAP_FOR_PROMPT, "")),
         "<<LEAKAGE_MASS>>": str(row.get(COL_LEAKAGE_MASS, 0.0)),
         "<<HIGH_WARN>>": "\nWARNING: HIGH-SENSITIVITY LEAK DETECTED - must be fixed!"
         if row.get(COL_ANY_HIGH_LEAKED)

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -306,6 +306,24 @@ class RewriteOutputSchema(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _validate_id_coverage(expected_ids: list[int], returned_ids: list[int], label: str) -> None:
+    """Enforce exact ID coverage: no missing, duplicate, or extra IDs."""
+    expected_set = set(expected_ids)
+    returned_set = set(returned_ids)
+
+    missing = sorted(expected_set - returned_set)
+    if missing:
+        raise ValueError(f"Missing {label} IDs: {missing}")
+
+    duplicates = sorted(id for id in returned_set if returned_ids.count(id) > 1)
+    if duplicates:
+        raise ValueError(f"Duplicate {label} IDs: {duplicates}")
+
+    extra = sorted(returned_set - expected_set)
+    if extra:
+        raise ValueError(f"Extra {label} IDs not in expected set: {extra}")
+
+
 class QualityAnswerSchema(BaseModel):
     id: int
     answer: str
@@ -315,7 +333,7 @@ class QualityAnswersSchema(BaseModel):
     """LLM output schema for quality QA re-answer step (on rewritten text).
 
     When validated with ``context={"expected_ids": [1, 2, ...]}``,
-    raises if any expected ID is missing from the answers.
+    enforces exact coverage: no missing, duplicate, or extra IDs.
     """
 
     answers: list[QualityAnswerSchema]
@@ -324,10 +342,7 @@ class QualityAnswersSchema(BaseModel):
     def _check_coverage(self, info: ValidationInfo) -> QualityAnswersSchema:
         expected_ids = (info.context or {}).get("expected_ids")
         if expected_ids is not None:
-            returned_ids = {a.id for a in self.answers}
-            missing = sorted(set(expected_ids) - returned_ids)
-            if missing:
-                raise ValueError(f"Missing answer IDs: {missing}")
+            _validate_id_coverage(expected_ids, [a.id for a in self.answers], "answer")
         return self
 
 
@@ -340,7 +355,7 @@ class PrivacyAnswersSchema(BaseModel):
     """LLM output schema for privacy QA re-answer step (on rewritten text).
 
     When validated with ``context={"expected_ids": [1, 2, ...]}``,
-    raises if any expected ID is missing from the answers.
+    enforces exact coverage: no missing, duplicate, or extra IDs.
     """
 
     answers: list[PrivacyAnswerItemSchema]
@@ -349,10 +364,7 @@ class PrivacyAnswersSchema(BaseModel):
     def _check_coverage(self, info: ValidationInfo) -> PrivacyAnswersSchema:
         expected_ids = (info.context or {}).get("expected_ids")
         if expected_ids is not None:
-            returned_ids = {a.id for a in self.answers}
-            missing = sorted(set(expected_ids) - returned_ids)
-            if missing:
-                raise ValueError(f"Missing answer IDs: {missing}")
+            _validate_id_coverage(expected_ids, [a.id for a in self.answers], "answer")
         return self
 
 
@@ -366,7 +378,7 @@ class QACompareResultsSchema(BaseModel):
     """LLM output schema for quality QA comparison step.
 
     When validated with ``context={"expected_ids": [1, 2, ...]}``,
-    raises if any expected ID is missing from the results.
+    enforces exact coverage: no missing, duplicate, or extra IDs.
     """
 
     per_item: list[QACompareItemSchema]
@@ -375,10 +387,7 @@ class QACompareResultsSchema(BaseModel):
     def _check_coverage(self, info: ValidationInfo) -> QACompareResultsSchema:
         expected_ids = (info.context or {}).get("expected_ids")
         if expected_ids is not None:
-            returned_ids = {a.id for a in self.per_item}
-            missing = sorted(set(expected_ids) - returned_ids)
-            if missing:
-                raise ValueError(f"Missing compare IDs: {missing}")
+            _validate_id_coverage(expected_ids, [a.id for a in self.per_item], "compare")
         return self
 
 

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 
 # ---------------------------------------------------------------------------
 # Domain
@@ -312,9 +312,23 @@ class QualityAnswerSchema(BaseModel):
 
 
 class QualityAnswersSchema(BaseModel):
-    """LLM output schema for quality QA re-answer step (on rewritten text)."""
+    """LLM output schema for quality QA re-answer step (on rewritten text).
+
+    When validated with ``context={"expected_ids": [1, 2, ...]}``,
+    raises if any expected ID is missing from the answers.
+    """
 
     answers: list[QualityAnswerSchema]
+
+    @model_validator(mode="after")
+    def _check_coverage(self, info: ValidationInfo) -> QualityAnswersSchema:
+        expected_ids = (info.context or {}).get("expected_ids")
+        if expected_ids is not None:
+            returned_ids = {a.id for a in self.answers}
+            missing = sorted(set(expected_ids) - returned_ids)
+            if missing:
+                raise ValueError(f"Missing answer IDs: {missing}")
+        return self
 
 
 class PrivacyAnswerItemSchema(BaseModel):
@@ -323,9 +337,23 @@ class PrivacyAnswerItemSchema(BaseModel):
 
 
 class PrivacyAnswersSchema(BaseModel):
-    """LLM output schema for privacy QA re-answer step (on rewritten text)."""
+    """LLM output schema for privacy QA re-answer step (on rewritten text).
+
+    When validated with ``context={"expected_ids": [1, 2, ...]}``,
+    raises if any expected ID is missing from the answers.
+    """
 
     answers: list[PrivacyAnswerItemSchema]
+
+    @model_validator(mode="after")
+    def _check_coverage(self, info: ValidationInfo) -> PrivacyAnswersSchema:
+        expected_ids = (info.context or {}).get("expected_ids")
+        if expected_ids is not None:
+            returned_ids = {a.id for a in self.answers}
+            missing = sorted(set(expected_ids) - returned_ids)
+            if missing:
+                raise ValueError(f"Missing answer IDs: {missing}")
+        return self
 
 
 class QACompareItemSchema(BaseModel):
@@ -335,9 +363,23 @@ class QACompareItemSchema(BaseModel):
 
 
 class QACompareResultsSchema(BaseModel):
-    """LLM output schema for quality QA comparison step."""
+    """LLM output schema for quality QA comparison step.
+
+    When validated with ``context={"expected_ids": [1, 2, ...]}``,
+    raises if any expected ID is missing from the results.
+    """
 
     per_item: list[QACompareItemSchema]
+
+    @model_validator(mode="after")
+    def _check_coverage(self, info: ValidationInfo) -> QACompareResultsSchema:
+        expected_ids = (info.context or {}).get("expected_ids")
+        if expected_ids is not None:
+            returned_ids = {a.id for a in self.per_item}
+            missing = sorted(set(expected_ids) - returned_ids)
+            if missing:
+                raise ValueError(f"Missing compare IDs: {missing}")
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -199,10 +199,10 @@ class SensitivityDispositionSchema(BaseModel):
         return [e for e in self.sensitivity_disposition if e.protection_method_suggestion == method]
 
     def format_for_rewrite_context(self) -> str:
-        """Format disposition for injection into rewrite prompts — medium and high sensitivity entities only."""
-        entities = self.medium_and_high_sensitivity_entities
+        """Format disposition for injection into rewrite prompts — all entities needing protection."""
+        entities = self.protected_entities
         if not entities:
-            return "No medium or high sensitivity entities identified."
+            return "No entities needing protection."
         lines = []
         for e in entities:
             lines.append(

--- a/tests/engine/test_evaluate.py
+++ b/tests/engine/test_evaluate.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+from data_designer.config.models import ModelConfig
+
+from anonymizer.config.models import RewriteModelSelection
+from anonymizer.config.rewrite import SENSITIVITY_WEIGHTS, EvaluationCriteria
+from anonymizer.engine.constants import (
+    COL_PRIVACY_QA_REANSWER,
+    COL_QUALITY_QA_COMPARE,
+    COL_QUALITY_QA_REANSWER,
+    COL_UTILITY_SCORE,
+)
+from anonymizer.engine.rewrite.evaluate import (
+    EvaluateWorkflow,
+    compute_any_high_leaked,
+    compute_leakage_mass,
+    compute_utility_score,
+    determine_repair_needs,
+)
+from anonymizer.engine.schemas.rewrite import (
+    PrivacyAnswerItemSchema,
+    PrivacyQAPairsSchema,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def privacy_qa_high_and_low() -> dict:
+    return {
+        "items": [
+            {
+                "id": 1,
+                "question": "Can the first_name 'Alice' be deduced?",
+                "sensitivity": "high",
+                "entity_label": "first_name",
+                "entity_value": "Alice",
+                "category": "direct_identifier",
+            },
+            {
+                "id": 2,
+                "question": "Can the city 'Seattle' be deduced?",
+                "sensitivity": "low",
+                "entity_label": "city",
+                "entity_value": "Seattle",
+                "category": "quasi_identifier",
+            },
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# compute_leakage_mass
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLeakageMass:
+    def test_no_leaks(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == 0.0
+
+    def test_high_leak_only(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == 1.0
+
+    def test_low_leak_only(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == 0.3
+
+    def test_both_leaked(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == pytest.approx(1.3)
+
+    def test_custom_weights(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass(answers, qa, {"high": 2.0, "medium": 1.0, "low": 0.5}) == pytest.approx(2.5)
+
+    def test_empty_answers(self, privacy_qa_high_and_low: dict) -> None:
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass([], qa, dict(SENSITIVITY_WEIGHTS)) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# compute_any_high_leaked
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAnyHighLeaked:
+    def test_high_leaked(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_any_high_leaked(answers, qa) is True
+
+    def test_only_low_leaked(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_any_high_leaked(answers, qa) is False
+
+    def test_no_leaks(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_any_high_leaked(answers, qa) is False
+
+
+# ---------------------------------------------------------------------------
+# compute_utility_score
+# ---------------------------------------------------------------------------
+
+
+class TestComputeUtilityScore:
+    def test_perfect_scores(self) -> None:
+        assert compute_utility_score([1.0, 1.0, 1.0]) == 1.0
+
+    def test_mixed_scores(self) -> None:
+        assert compute_utility_score([0.8, 0.6]) == pytest.approx(0.7)
+
+    def test_empty(self) -> None:
+        assert compute_utility_score([]) == 0.0
+
+    def test_single_score(self) -> None:
+        assert compute_utility_score([0.5]) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# determine_repair_needs
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineRepairNeeds:
+    def test_high_leak_triggers_repair(self) -> None:
+        assert determine_repair_needs(
+            any_high_leaked=True,
+            leakage_mass=0.0,
+            auto_repair_privacy=True,
+            repair_any_high_leak=True,
+            effective_threshold=1.0,
+        )
+
+    def test_leakage_mass_above_threshold(self) -> None:
+        assert determine_repair_needs(
+            any_high_leaked=False,
+            leakage_mass=1.5,
+            auto_repair_privacy=True,
+            repair_any_high_leak=True,
+            effective_threshold=1.0,
+        )
+
+    def test_below_threshold_no_repair(self) -> None:
+        assert not determine_repair_needs(
+            any_high_leaked=False,
+            leakage_mass=0.3,
+            auto_repair_privacy=True,
+            repair_any_high_leak=True,
+            effective_threshold=1.0,
+        )
+
+    def test_auto_repair_disabled(self) -> None:
+        assert not determine_repair_needs(
+            any_high_leaked=True,
+            leakage_mass=5.0,
+            auto_repair_privacy=False,
+            repair_any_high_leak=True,
+            effective_threshold=1.0,
+        )
+
+    def test_repair_any_high_leak_false(self) -> None:
+        assert not determine_repair_needs(
+            any_high_leaked=True,
+            leakage_mass=0.3,
+            auto_repair_privacy=True,
+            repair_any_high_leak=False,
+            effective_threshold=1.0,
+        )
+
+    def test_domain_adjusts_threshold(self) -> None:
+        evaluation = EvaluationCriteria(auto_adjust_by_domain=True, repair_any_high_leak=False)
+        assert determine_repair_needs(
+            any_high_leaked=False,
+            leakage_mass=0.8,
+            auto_repair_privacy=True,
+            repair_any_high_leak=False,
+            effective_threshold=evaluation.get_effective_threshold("medical"),
+        )
+        assert not determine_repair_needs(
+            any_high_leaked=False,
+            leakage_mass=0.8,
+            auto_repair_privacy=True,
+            repair_any_high_leak=False,
+            effective_threshold=evaluation.get_effective_threshold("social_media"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# EvaluateWorkflow.columns()
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_columns_pipeline(
+    stub_model_configs: list[ModelConfig],
+    stub_rewrite_model_selection: RewriteModelSelection,
+) -> None:
+    wf = EvaluateWorkflow(adapter=Mock())
+    cols = wf.columns(
+        selected_models=stub_rewrite_model_selection,
+        evaluation=EvaluationCriteria(),
+    )
+
+    assert len(cols) == 6
+    assert isinstance(cols[0], LLMStructuredColumnConfig)
+    assert cols[0].name == COL_QUALITY_QA_REANSWER
+    assert isinstance(cols[1], LLMStructuredColumnConfig)
+    assert cols[1].name == COL_PRIVACY_QA_REANSWER
+    assert isinstance(cols[2], CustomColumnConfig)
+    assert isinstance(cols[3], LLMStructuredColumnConfig)
+    assert cols[3].name == COL_QUALITY_QA_COMPARE
+    assert isinstance(cols[4], CustomColumnConfig)
+    assert cols[4].name == COL_UTILITY_SCORE
+    assert isinstance(cols[5], CustomColumnConfig)

--- a/tests/engine/test_evaluate.py
+++ b/tests/engine/test_evaluate.py
@@ -6,17 +6,12 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 import pytest
-from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.models import ModelConfig
 
 from anonymizer.config.models import RewriteModelSelection
 from anonymizer.config.rewrite import SENSITIVITY_WEIGHTS, EvaluationCriteria
-from anonymizer.engine.constants import (
-    COL_PRIVACY_QA_REANSWER,
-    COL_QUALITY_QA_COMPARE,
-    COL_QUALITY_QA_REANSWER,
-    COL_UTILITY_SCORE,
-)
+from anonymizer.engine.constants import COL_UTILITY_SCORE
 from anonymizer.engine.rewrite.evaluate import (
     EvaluateWorkflow,
     compute_any_high_leaked,
@@ -219,14 +214,7 @@ def test_evaluate_columns_pipeline(
         evaluation=EvaluationCriteria(),
     )
 
-    assert len(cols) == 6
-    assert isinstance(cols[0], LLMStructuredColumnConfig)
-    assert cols[0].name == COL_QUALITY_QA_REANSWER
-    assert isinstance(cols[1], LLMStructuredColumnConfig)
-    assert cols[1].name == COL_PRIVACY_QA_REANSWER
-    assert isinstance(cols[2], CustomColumnConfig)
-    assert isinstance(cols[3], LLMStructuredColumnConfig)
-    assert cols[3].name == COL_QUALITY_QA_COMPARE
-    assert isinstance(cols[4], CustomColumnConfig)
-    assert cols[4].name == COL_UTILITY_SCORE
-    assert isinstance(cols[5], CustomColumnConfig)
+    assert len(cols) == 5
+    for col in cols:
+        assert isinstance(col, CustomColumnConfig)
+    assert cols[3].name == COL_UTILITY_SCORE

--- a/tests/engine/test_parsers.py
+++ b/tests/engine/test_parsers.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from anonymizer.engine.rewrite.parsers import (
+    field,
+    parse_privacy_answers,
+    parse_privacy_qa,
+    parse_quality_answers,
+    parse_quality_compare,
+    parse_quality_qa,
+    parse_sensitivity_disposition,
+    render_template,
+)
+from anonymizer.engine.schemas.rewrite import (
+    PrivacyAnswersSchema,
+    QACompareResultsSchema,
+    QualityQAPairsSchema,
+)
+
+# ---------------------------------------------------------------------------
+# render_template
+# ---------------------------------------------------------------------------
+
+
+def test_render_template_basic() -> None:
+    assert render_template("Hello <<NAME>>!", {"<<NAME>>": "Alice"}) == "Hello Alice!"
+
+
+def test_render_template_multiple_placeholders() -> None:
+    assert render_template("<<A>> and <<B>>", {"<<A>>": "X", "<<B>>": "Y"}) == "X and Y"
+
+
+def test_render_template_no_cross_contamination() -> None:
+    result = render_template(
+        "text: <<TEXT>>, score: <<SCORE>>",
+        {"<<TEXT>>": "contains <<SCORE>> literally", "<<SCORE>>": "0.9"},
+    )
+    assert result == "text: contains <<SCORE>> literally, score: 0.9"
+
+
+def test_render_template_unmatched_placeholder_left_as_is() -> None:
+    assert render_template("<<A>> and <<B>>", {"<<A>>": "X"}) == "X and <<B>>"
+
+
+def test_render_template_empty_replacements() -> None:
+    assert render_template("no placeholders", {}) == "no placeholders"
+
+
+# ---------------------------------------------------------------------------
+# field
+# ---------------------------------------------------------------------------
+
+
+def test_field_valid() -> None:
+    class MyModel(BaseModel):
+        name: str
+
+    assert field(MyModel, "name") == "name"
+
+
+def test_field_invalid_raises() -> None:
+    class MyModel(BaseModel):
+        name: str
+
+    with pytest.raises(KeyError, match="has no field 'missing'"):
+        field(MyModel, "missing")
+
+
+# ---------------------------------------------------------------------------
+# parse_privacy_answers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_privacy_answers_from_dict() -> None:
+    result = parse_privacy_answers({"answers": [{"id": 1, "answer": "yes"}]})
+    assert len(result) == 1
+    assert result[0].id == 1
+
+
+def test_parse_privacy_answers_from_schema() -> None:
+    schema = PrivacyAnswersSchema.model_validate({"answers": [{"id": 1, "answer": "no"}]})
+    assert len(parse_privacy_answers(schema)) == 1
+
+
+def test_parse_privacy_answers_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        parse_privacy_answers("bad")
+
+
+# ---------------------------------------------------------------------------
+# parse_quality_qa
+# ---------------------------------------------------------------------------
+
+
+def test_parse_quality_qa_from_dict() -> None:
+    raw = {"items": [{"id": 1, "aspect": "role", "question": "What?", "reference_answer": "X"}]}
+    assert len(parse_quality_qa(raw).items) == 1
+
+
+def test_parse_quality_qa_from_schema() -> None:
+    schema = QualityQAPairsSchema.model_validate(
+        {"items": [{"id": 1, "aspect": "role", "question": "What?", "reference_answer": "X"}]}
+    )
+    assert len(parse_quality_qa(schema).items) == 1
+
+
+def test_parse_quality_qa_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        parse_quality_qa(42)
+
+
+# ---------------------------------------------------------------------------
+# parse_quality_answers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_quality_answers_from_dict() -> None:
+    assert len(parse_quality_answers({"answers": [{"id": 1, "answer": "yes"}]})) == 1
+
+
+def test_parse_quality_answers_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        parse_quality_answers([])
+
+
+# ---------------------------------------------------------------------------
+# parse_quality_compare
+# ---------------------------------------------------------------------------
+
+
+def test_parse_quality_compare_from_dict() -> None:
+    ids, scores = parse_quality_compare({"per_item": [{"id": 1, "score": 0.9}, {"id": 2, "score": 0.5}]})
+    assert ids == [1, 2]
+    assert scores == [0.9, 0.5]
+
+
+def test_parse_quality_compare_from_schema() -> None:
+    schema = QACompareResultsSchema.model_validate({"per_item": [{"id": 1, "score": 0.8}]})
+    ids, scores = parse_quality_compare(schema)
+    assert ids == [1]
+    assert scores == [0.8]
+
+
+def test_parse_quality_compare_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        parse_quality_compare(None)
+
+
+# ---------------------------------------------------------------------------
+# parse_privacy_qa
+# ---------------------------------------------------------------------------
+
+
+def test_parse_privacy_qa_from_dict() -> None:
+    raw = {
+        "items": [
+            {
+                "id": 1,
+                "question": "Q?",
+                "sensitivity": "high",
+                "entity_label": "name",
+                "entity_value": "Alice",
+                "category": "direct_identifier",
+            }
+        ]
+    }
+    assert len(parse_privacy_qa(raw).items) == 1
+
+
+def test_parse_privacy_qa_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        parse_privacy_qa(123)
+
+
+# ---------------------------------------------------------------------------
+# parse_sensitivity_disposition
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sensitivity_disposition_from_dict() -> None:
+    raw = {
+        "sensitivity_disposition": [
+            {
+                "id": 1,
+                "source": "tagged",
+                "category": "direct_identifier",
+                "sensitivity": "high",
+                "entity_label": "name",
+                "entity_value": "Alice",
+                "needs_protection": True,
+                "protection_reason": "Direct identifier that enables re-identification",
+                "protection_method_suggestion": "replace",
+                "combined_risk_level": "high",
+            }
+        ]
+    }
+    assert len(parse_sensitivity_disposition(raw).sensitivity_disposition) == 1
+
+
+def test_parse_sensitivity_disposition_invalid_type() -> None:
+    with pytest.raises(ValueError):
+        parse_sensitivity_disposition("bad")

--- a/tests/engine/test_repair.py
+++ b/tests/engine/test_repair.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from data_designer.config.column_configs import CustomColumnConfig
+from data_designer.config.models import ModelConfig
+
+from anonymizer.config.models import RewriteModelSelection
+from anonymizer.config.rewrite import PrivacyGoal
+from anonymizer.engine.constants import COL_REWRITTEN_TEXT
+from anonymizer.engine.rewrite.repair import RepairWorkflow
+
+_STUB_PRIVACY_GOAL = PrivacyGoal(
+    protect="Direct identifiers, quasi-identifier combinations, and latent inferences",
+    preserve="General utility, content quality, and semantic meaning of the original text",
+)
+
+
+def test_repair_columns_pipeline(
+    stub_model_configs: list[ModelConfig],
+    stub_rewrite_model_selection: RewriteModelSelection,
+) -> None:
+    wf = RepairWorkflow(adapter=Mock())
+    cols = wf.columns(
+        selected_models=stub_rewrite_model_selection,
+        privacy_goal=_STUB_PRIVACY_GOAL,
+        effective_threshold=1.0,
+    )
+
+    assert len(cols) == 2
+    assert isinstance(cols[0], CustomColumnConfig)
+    assert isinstance(cols[1], CustomColumnConfig)
+    assert cols[1].name == COL_REWRITTEN_TEXT

--- a/tests/engine/test_repair.py
+++ b/tests/engine/test_repair.py
@@ -17,12 +17,12 @@ from anonymizer.engine.constants import (
     COL_PRIVACY_QA_REANSWER,
     COL_REPLACEMENT_MAP_FOR_PROMPT,
     COL_REWRITTEN_TEXT,
+    COL_REWRITTEN_TEXT_NEXT,
     COL_SENSITIVITY_DISPOSITION,
     COL_TEXT,
     COL_UTILITY_SCORE,
 )
 from anonymizer.engine.rewrite.repair import (
-    COL_REWRITTEN_TEXT_NEXT,
     RepairParams,
     RepairWorkflow,
     _format_protection_block,

--- a/tests/engine/test_repair.py
+++ b/tests/engine/test_repair.py
@@ -10,13 +10,180 @@ from data_designer.config.models import ModelConfig
 
 from anonymizer.config.models import RewriteModelSelection
 from anonymizer.config.rewrite import PrivacyGoal
-from anonymizer.engine.constants import COL_REWRITTEN_TEXT
-from anonymizer.engine.rewrite.repair import RepairWorkflow
+from anonymizer.engine.constants import (
+    COL_ANY_HIGH_LEAKED,
+    COL_LEAKAGE_MASS,
+    COL_PRIVACY_QA,
+    COL_PRIVACY_QA_REANSWER,
+    COL_REPLACEMENT_MAP_FOR_PROMPT,
+    COL_REWRITTEN_TEXT,
+    COL_SENSITIVITY_DISPOSITION,
+    COL_TEXT,
+    COL_UTILITY_SCORE,
+)
+from anonymizer.engine.rewrite.repair import (
+    RepairParams,
+    RepairWorkflow,
+    _format_protection_block,
+    _leaked_items_text,
+    _render_repair_prompt,
+)
+from anonymizer.engine.schemas.rewrite import (
+    PrivacyAnswerItemSchema,
+    PrivacyQAPairsSchema,
+)
 
 _STUB_PRIVACY_GOAL = PrivacyGoal(
     protect="Direct identifiers, quasi-identifier combinations, and latent inferences",
     preserve="General utility, content quality, and semantic meaning of the original text",
 )
+
+_STUB_DISPOSITION = {
+    "sensitivity_disposition": [
+        {
+            "id": 1,
+            "source": "tagged",
+            "category": "direct_identifier",
+            "sensitivity": "high",
+            "entity_label": "first_name",
+            "entity_value": "Alice",
+            "needs_protection": True,
+            "protection_reason": "Direct identifier that enables re-identification",
+            "protection_method_suggestion": "replace",
+            "combined_risk_level": "high",
+        },
+        {
+            "id": 2,
+            "source": "tagged",
+            "category": "quasi_identifier",
+            "sensitivity": "low",
+            "entity_label": "city",
+            "entity_value": "Seattle",
+            "needs_protection": False,
+            "protection_method_suggestion": "left_as_is",
+            "protection_reason": "Low risk, not identifying alone",
+            "combined_risk_level": "low",
+        },
+    ]
+}
+
+_STUB_PRIVACY_QA = {
+    "items": [
+        {
+            "id": 1,
+            "question": "Can the first_name 'Alice' be deduced?",
+            "sensitivity": "high",
+            "entity_label": "first_name",
+            "entity_value": "Alice",
+            "category": "direct_identifier",
+        },
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# _leaked_items_text
+# ---------------------------------------------------------------------------
+
+
+class TestLeakedItemsText:
+    def test_leaked_item_formatted(self) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="yes")]
+        qa = PrivacyQAPairsSchema.model_validate(_STUB_PRIVACY_QA)
+        result = _leaked_items_text(answers, qa)
+        assert "[HIGH]" in result
+        assert "first_name" in result
+        assert "Alice" in result
+
+    def test_no_leaks_returns_empty(self) -> None:
+        answers = [PrivacyAnswerItemSchema(id=1, answer="no")]
+        qa = PrivacyQAPairsSchema.model_validate(_STUB_PRIVACY_QA)
+        assert _leaked_items_text(answers, qa) == ""
+
+
+# ---------------------------------------------------------------------------
+# _format_protection_block
+# ---------------------------------------------------------------------------
+
+
+class TestFormatProtectionBlock:
+    def test_includes_protected_entities(self) -> None:
+        row = {COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION}
+        result = _format_protection_block(row)
+        assert "Alice" in result
+        assert "replace" in result
+        assert "Seattle" not in result
+
+    def test_empty_when_none_protected(self) -> None:
+        row = {
+            COL_SENSITIVITY_DISPOSITION: {
+                "sensitivity_disposition": [
+                    {
+                        "id": 1,
+                        "source": "tagged",
+                        "category": "quasi_identifier",
+                        "sensitivity": "low",
+                        "entity_label": "city",
+                        "entity_value": "Portland",
+                        "needs_protection": False,
+                        "protection_method_suggestion": "left_as_is",
+                        "protection_reason": "Low risk location",
+                        "combined_risk_level": "low",
+                    },
+                ]
+            }
+        }
+        assert _format_protection_block(row) == ""
+
+
+# ---------------------------------------------------------------------------
+# _render_repair_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestRenderRepairPrompt:
+    def test_contains_key_sections(self) -> None:
+        row = {
+            COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION,
+            COL_TEXT: "Alice lives in Seattle.",
+            COL_REWRITTEN_TEXT: "Bob lives in Portland.",
+            COL_REPLACEMENT_MAP_FOR_PROMPT: {
+                "replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Bob"}]
+            },
+            COL_LEAKAGE_MASS: 1.0,
+            COL_ANY_HIGH_LEAKED: True,
+            COL_UTILITY_SCORE: 0.85,
+            COL_PRIVACY_QA_REANSWER: {"answers": [{"id": 1, "answer": "yes"}]},
+            COL_PRIVACY_QA: _STUB_PRIVACY_QA,
+            "_leaked_privacy_items": '- [HIGH] first_name: "Alice"',
+        }
+        params = RepairParams(privacy_goal_str=_STUB_PRIVACY_GOAL.to_prompt_string(), max_privacy_leak=1.0)
+        result = _render_repair_prompt(row, params)
+        assert "<privacy_goal>" in result
+        assert "<protection_decisions>" in result
+        assert "Alice" in result
+        assert "WARNING" in result
+        assert "0.85" in result
+
+    def test_no_high_warn_when_no_high_leak(self) -> None:
+        row = {
+            COL_SENSITIVITY_DISPOSITION: _STUB_DISPOSITION,
+            COL_TEXT: "",
+            COL_REWRITTEN_TEXT: "",
+            COL_REPLACEMENT_MAP_FOR_PROMPT: "",
+            COL_LEAKAGE_MASS: 0.5,
+            COL_ANY_HIGH_LEAKED: False,
+            COL_UTILITY_SCORE: 0.9,
+            "_leaked_privacy_items": "",
+        }
+        params = RepairParams(privacy_goal_str=_STUB_PRIVACY_GOAL.to_prompt_string(), max_privacy_leak=1.0)
+        result = _render_repair_prompt(row, params)
+        assert "WARNING" not in result
+
+
+# ---------------------------------------------------------------------------
+# RepairWorkflow.columns()
+# ---------------------------------------------------------------------------
 
 
 def test_repair_columns_pipeline(

--- a/tests/engine/test_repair.py
+++ b/tests/engine/test_repair.py
@@ -22,6 +22,7 @@ from anonymizer.engine.constants import (
     COL_UTILITY_SCORE,
 )
 from anonymizer.engine.rewrite.repair import (
+    COL_REWRITTEN_TEXT_NEXT,
     RepairParams,
     RepairWorkflow,
     _format_protection_block,
@@ -200,4 +201,4 @@ def test_repair_columns_pipeline(
     assert len(cols) == 2
     assert isinstance(cols[0], CustomColumnConfig)
     assert isinstance(cols[1], CustomColumnConfig)
-    assert cols[1].name == COL_REWRITTEN_TEXT
+    assert cols[1].name == COL_REWRITTEN_TEXT_NEXT

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -353,3 +353,43 @@ def test_judge_evaluation_parses_all_rubrics() -> None:
 def test_judge_evaluation_requires_all_rubrics() -> None:
     with pytest.raises(ValidationError):
         JudgeEvaluationSchema(privacy=JudgeScoreSchema(score=8, reason="good"))
+
+
+# Context-validated answer coverage
+
+
+def test_quality_answers_reject_missing_ids_with_context() -> None:
+    with pytest.raises(ValidationError, match="Missing answer IDs"):
+        QualityAnswersSchema.model_validate(
+            {"answers": [{"id": 1, "answer": "yes"}]},
+            context={"expected_ids": [1, 2]},
+        )
+
+
+def test_quality_answers_accept_complete_with_context() -> None:
+    result = QualityAnswersSchema.model_validate(
+        {"answers": [{"id": 1, "answer": "yes"}, {"id": 2, "answer": "no"}]},
+        context={"expected_ids": [1, 2]},
+    )
+    assert len(result.answers) == 2
+
+
+def test_quality_answers_no_enforcement_without_context() -> None:
+    result = QualityAnswersSchema.model_validate({"answers": [{"id": 1, "answer": "yes"}]})
+    assert len(result.answers) == 1
+
+
+def test_privacy_answers_reject_missing_ids_with_context() -> None:
+    with pytest.raises(ValidationError, match="Missing answer IDs"):
+        PrivacyAnswersSchema.model_validate(
+            {"answers": [{"id": 1, "answer": "no"}]},
+            context={"expected_ids": [1, 2]},
+        )
+
+
+def test_qa_compare_reject_missing_ids_with_context() -> None:
+    with pytest.raises(ValidationError, match="Missing compare IDs"):
+        QACompareResultsSchema.model_validate(
+            {"per_item": [{"id": 1, "score": 0.9}]},
+            context={"expected_ids": [1, 2]},
+        )

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -393,3 +393,19 @@ def test_qa_compare_reject_missing_ids_with_context() -> None:
             {"per_item": [{"id": 1, "score": 0.9}]},
             context={"expected_ids": [1, 2]},
         )
+
+
+def test_quality_answers_reject_duplicate_ids() -> None:
+    with pytest.raises(ValidationError, match="Duplicate answer IDs"):
+        QualityAnswersSchema.model_validate(
+            {"answers": [{"id": 1, "answer": "yes"}, {"id": 1, "answer": "no"}, {"id": 2, "answer": "yes"}]},
+            context={"expected_ids": [1, 2]},
+        )
+
+
+def test_quality_answers_reject_extra_ids() -> None:
+    with pytest.raises(ValidationError, match="Extra answer IDs"):
+        QualityAnswersSchema.model_validate(
+            {"answers": [{"id": 1, "answer": "yes"}, {"id": 2, "answer": "no"}, {"id": 99, "answer": "yes"}]},
+            context={"expected_ids": [1, 2]},
+        )

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -285,7 +285,7 @@ def test_sensitivity_disposition_format_for_rewrite_context(mixed_disposition: S
     assert "→ replace" in context
 
 
-def test_sensitivity_disposition_format_for_rewrite_context_empty_when_all_low() -> None:
+def test_sensitivity_disposition_format_for_rewrite_context_empty_when_no_protection() -> None:
     schema = SensitivityDispositionSchema.model_validate(
         {
             "sensitivity_disposition": [
@@ -295,7 +295,30 @@ def test_sensitivity_disposition_format_for_rewrite_context_empty_when_all_low()
             ]
         }
     )
-    assert schema.format_for_rewrite_context() == "No medium or high sensitivity entities identified."
+    assert schema.format_for_rewrite_context() == "No entities needing protection."
+
+
+def test_sensitivity_disposition_format_for_rewrite_context_includes_low_when_protected() -> None:
+    schema = SensitivityDispositionSchema.model_validate(
+        {
+            "sensitivity_disposition": [
+                _make_entity(
+                    id=1,
+                    sensitivity="low",
+                    entity_label="city",
+                    entity_value="Portland",
+                    needs_protection=True,
+                    protection_method_suggestion="generalize",
+                    combined_risk_level="medium",
+                    protection_reason="City combined with other quasi-identifiers enables re-identification",
+                ),
+            ]
+        }
+    )
+    context = schema.format_for_rewrite_context()
+    assert "[LOW]" in context
+    assert "Portland" in context
+    assert "→ generalize" in context
 
 
 def test_quality_answers_use_integer_ids() -> None:


### PR DESCRIPTION
## Summary

Implements Step 5 of the rewrite pipeline: evaluate rewritten text for quality and privacy, then repair if privacy leaks are detected.

**`EvaluateWorkflow`** (`engine/rewrite/evaluate.py`) — 6-column NDD pipeline: LLM quality re-answer, LLM privacy re-answer, QA pairing, LLM quality comparison, metric computation (utility_score, leakage_mass, any_high_leaked), and repair-needs determination.

**`RepairWorkflow`** (`engine/rewrite/repair.py`) — 2-column NDD pipeline: leaked-items formatting and LLM repair via `PydanticResponseRecipe` inside a custom column generator with dynamically-resolved model alias.

**Schema changes**: `PrivacyAnswer` enum enforces yes/no only — privacy questions are binary ("can entity X be deduced?"), so "unknown" is a hedge that doesn't serve the pipeline; `format_for_rewrite_context()` now uses `protected_entities` instead of `medium_and_high_sensitivity_entities` — the rewriter and evaluator must operate on the same entity set, otherwise LOW-sensitivity entities flagged for protection (due to combinatorial re-identification risk) would be evaluated but never shown to the rewriter.

**Design decision** - separate workflows instead of one combined pipeline, so the orchestrator can run evaluate on all rows, filter to failing rows, run repair on just those, and re-evaluate only repaired rows (no wasted LLM calls on passing rows)

Prompts ported from the research repo with XML section tags, `<<PLACEHOLDER>>` + `.replace()` convention, and schema field names validated at import time via `_field()`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [x] Added/updated tests for changes

## Related Issues
Closes #34