### PR TITLE
refactor: extract shared row-partitioning helpers

### DIFF
--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -54,9 +54,7 @@ class LlmReplaceWorkflow:
         working_df["_entities_for_replace_json"] = working_df["_entities_for_replace"].apply(json.dumps)
 
         # Partition: rows with an empty entity list bypass replacement-map generation.
-        entity_rows, passthrough_rows = split_rows(
-            working_df, column="_entities_for_replace", predicate=bool
-        )
+        entity_rows, passthrough_rows = split_rows(working_df, column="_entities_for_replace", predicate=bool)
         passthrough_rows[COL_REPLACEMENT_MAP] = [{"replacements": []} for _ in range(len(passthrough_rows))]
 
         if entity_rows.empty:
@@ -97,7 +95,9 @@ class LlmReplaceWorkflow:
             axis=1,
         )
 
-        combined = merge_and_reorder(output_df, passthrough_rows, attrs={**run_result.dataframe.attrs, **dataframe.attrs})
+        combined = merge_and_reorder(
+            output_df, passthrough_rows, attrs={**run_result.dataframe.attrs, **dataframe.attrs}
+        )
         return LlmReplaceResult(dataframe=combined, failed_records=run_result.failed_records)
 
 

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -15,6 +15,7 @@ from anonymizer.config.models import ReplaceModelSelection
 from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, ENTITY_LABEL_EXAMPLES
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
 from anonymizer.engine.schemas import EntitiesByValueSchema, EntityReplacementMapSchema
 
 logger = logging.getLogger("anonymizer.replace.llm_workflow")
@@ -45,7 +46,6 @@ class LlmReplaceWorkflow:
         replace_alias = resolve_model_alias("replacement_generator", selected_models)
 
         working_df = dataframe.copy()
-        working_df["_anonymizer_row_order"] = range(len(working_df))
 
         # Parse the per-row entity payload once, then reuse it for prompt inputs.
         parsed_entities = working_df[entities_column].apply(EntitiesByValueSchema.from_raw)
@@ -53,25 +53,19 @@ class LlmReplaceWorkflow:
         working_df["_entities_for_replace"] = parsed_entities.apply(_enrich_entities_for_template)
         working_df["_entities_for_replace_json"] = working_df["_entities_for_replace"].apply(json.dumps)
 
-        # Rows with an empty entity list should bypass replacement-map generation.
-        has_entities_mask = working_df["_entities_for_replace"].apply(bool)
-
-        # Passthrough rows get an empty replacement map immediately.
-        passthrough_rows = working_df[~has_entities_mask].copy()
+        # Partition: rows with an empty entity list bypass replacement-map generation.
+        entity_rows, passthrough_rows = split_rows(
+            working_df, column="_entities_for_replace", predicate=bool
+        )
         passthrough_rows[COL_REPLACEMENT_MAP] = [{"replacements": []} for _ in range(len(passthrough_rows))]
 
-        if not has_entities_mask.any():
-            passthrough_rows = (
-                passthrough_rows.sort_values("_anonymizer_row_order")
-                .drop(columns="_anonymizer_row_order")
-                .reset_index(drop=True)
+        if entity_rows.empty:
+            return LlmReplaceResult(
+                dataframe=merge_and_reorder(passthrough_rows, attrs=dataframe.attrs),
+                failed_records=[],
             )
-            passthrough_rows.attrs = {**dataframe.attrs}
-            return LlmReplaceResult(dataframe=passthrough_rows, failed_records=[])
 
         # Only rows with actual entities are sent to the LLM.
-        entity_rows = working_df[has_entities_mask].copy()
-
         effective_preview_num_records = (
             min(preview_num_records, len(entity_rows)) if preview_num_records is not None else None
         )
@@ -103,19 +97,8 @@ class LlmReplaceWorkflow:
             axis=1,
         )
 
-        # Recombine LLM-processed rows with passthrough rows in original order.
-        output_df = (
-            pd.concat([output_df, passthrough_rows], axis=0)
-            .sort_values("_anonymizer_row_order")
-            .drop(columns="_anonymizer_row_order")
-            .reset_index(drop=True)
-        )
-        # Carry pipeline metadata (e.g. original_text_column) through to downstream steps.
-        # pandas .attrs is experimental and not preserved through merge/concat/groupby,
-        # but is preserved through copy which is all we do here.
-        # TODO: consider wrapping df + metadata in a typed container.
-        output_df.attrs = {**run_result.dataframe.attrs, **dataframe.attrs}
-        return LlmReplaceResult(dataframe=output_df, failed_records=run_result.failed_records)
+        combined = merge_and_reorder(output_df, passthrough_rows, attrs={**run_result.dataframe.attrs, **dataframe.attrs})
+        return LlmReplaceResult(dataframe=combined, failed_records=run_result.failed_records)
 
 
 def _enrich_entities_for_template(parsed: EntitiesByValueSchema) -> list[dict[str, str | list[str]]]:

--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -196,9 +196,7 @@ class RewriteWorkflow:
     ) -> RewriteResult:
         all_failed: list[FailedRecord] = []
 
-        entity_rows, passthrough_rows = split_rows(
-            dataframe, column=COL_ENTITIES_BY_VALUE, predicate=_has_entities
-        )
+        entity_rows, passthrough_rows = split_rows(dataframe, column=COL_ENTITIES_BY_VALUE, predicate=_has_entities)
 
         # Fast path: no entities anywhere
         if entity_rows.empty:

--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -36,6 +36,7 @@ from anonymizer.engine.rewrite.repair import RepairWorkflow
 from anonymizer.engine.rewrite.rewrite_generation import RewriteGenerationWorkflow
 from anonymizer.engine.rewrite.sensitivity_disposition import SensitivityDispositionWorkflow
 from anonymizer.engine.rewrite.workflow_utils import derive_seed_columns, select_seed_cols
+from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
 
 logger = logging.getLogger("anonymizer.rewrite.workflow")
 
@@ -48,13 +49,6 @@ _PASSTHROUGH_DEFAULTS: dict[str, object] = {
     COL_REPAIR_ITERATIONS: 0,
 }
 
-_ROW_ORDER_COL = "_anonymizer_row_order"
-
-
-# ---------------------------------------------------------------------------
-# Row split / merge helpers — TODO(#60): move to shared module
-# ---------------------------------------------------------------------------
-
 
 def _has_entities(entities_by_value: object) -> bool:
     """Return True if this record has at least one detected entity."""
@@ -65,31 +59,6 @@ def _has_entities(entities_by_value: object) -> bool:
     if not isinstance(items, list):
         return False
     return len(items) > 0
-
-
-def _split_by_entities(
-    df: pd.DataFrame,
-) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Partition df into (entity_rows, passthrough_rows) with row-order tracking."""
-    working = df.copy()
-    working[_ROW_ORDER_COL] = range(len(working))
-    mask = working[COL_ENTITIES_BY_VALUE].apply(_has_entities)
-    return working[mask].copy(), working[~mask].copy()
-
-
-def _merge_and_reorder(
-    *parts: pd.DataFrame,
-    attrs: dict,
-) -> pd.DataFrame:
-    """Concat partitions, restore original row order, drop the tracking column."""
-    combined = (
-        pd.concat(list(parts), ignore_index=True)
-        .sort_values(_ROW_ORDER_COL)
-        .drop(columns=[_ROW_ORDER_COL])
-        .reset_index(drop=True)
-    )
-    combined.attrs = {**attrs}
-    return combined
 
 
 def _join_new_columns(
@@ -227,12 +196,14 @@ class RewriteWorkflow:
     ) -> RewriteResult:
         all_failed: list[FailedRecord] = []
 
-        entity_rows, passthrough_rows = _split_by_entities(dataframe)
+        entity_rows, passthrough_rows = split_rows(
+            dataframe, column=COL_ENTITIES_BY_VALUE, predicate=_has_entities
+        )
 
         # Fast path: no entities anywhere
         if entity_rows.empty:
             _apply_passthrough_defaults(passthrough_rows)
-            result_df = _merge_and_reorder(passthrough_rows, attrs=dataframe.attrs)
+            result_df = merge_and_reorder(passthrough_rows, attrs=dataframe.attrs)
             return RewriteResult(dataframe=result_df, failed_records=all_failed)
 
         # --- Step 1: replacement map (needs only detection output) ---
@@ -298,7 +269,7 @@ class RewriteWorkflow:
 
         # --- Merge and return ---
         _apply_passthrough_defaults(passthrough_rows)
-        combined = _merge_and_reorder(entity_rows, passthrough_rows, attrs=dataframe.attrs)
+        combined = merge_and_reorder(entity_rows, passthrough_rows, attrs=dataframe.attrs)
         return RewriteResult(dataframe=combined, failed_records=all_failed)
 
     # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/row_partitioning.py
+++ b/src/anonymizer/engine/row_partitioning.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for partitioning DataFrames by a row predicate and recombining them."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+
+_ROW_ORDER_COL = "_anonymizer_row_order"
+
+
+def split_rows(
+    df: pd.DataFrame,
+    *,
+    column: str,
+    predicate: Callable[[Any], bool],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Partition *df* into (matching, non-matching) rows with row-order tracking.
+
+    A ``_anonymizer_row_order`` column is added so that :func:`merge_and_reorder`
+    can restore the original ordering after the two partitions are processed
+    independently.
+    """
+    working = df.copy()
+    working[_ROW_ORDER_COL] = range(len(working))
+    mask = working[column].apply(predicate)
+    return working[mask].copy(), working[~mask].copy()
+
+
+def merge_and_reorder(
+    *parts: pd.DataFrame,
+    attrs: dict,
+) -> pd.DataFrame:
+    """Concat partitions, restore original row order, and propagate *attrs*."""
+    combined = (
+        pd.concat(list(parts), ignore_index=True)
+        .sort_values(_ROW_ORDER_COL)
+        .drop(columns=[_ROW_ORDER_COL])
+        .reset_index(drop=True)
+    )
+    combined.attrs = {**attrs}
+    return combined

--- a/src/anonymizer/engine/row_partitioning.py
+++ b/src/anonymizer/engine/row_partitioning.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pandas as pd
 
-_ROW_ORDER_COL = "_anonymizer_row_order"
+ROW_ORDER_COL = "_anonymizer_row_order"
 
 
 def split_rows(
@@ -26,7 +26,7 @@ def split_rows(
     independently.
     """
     working = df.copy()
-    working[_ROW_ORDER_COL] = range(len(working))
+    working[ROW_ORDER_COL] = range(len(working))
     mask = working[column].apply(predicate)
     return working[mask].copy(), working[~mask].copy()
 
@@ -36,10 +36,12 @@ def merge_and_reorder(
     attrs: dict,
 ) -> pd.DataFrame:
     """Concat partitions, restore original row order, and propagate *attrs*."""
+    if not parts:
+        raise ValueError("merge_and_reorder requires at least one partition")
     combined = (
         pd.concat(list(parts), ignore_index=True)
-        .sort_values(_ROW_ORDER_COL)
-        .drop(columns=[_ROW_ORDER_COL])
+        .sort_values(ROW_ORDER_COL)
+        .drop(columns=[ROW_ORDER_COL])
         .reset_index(drop=True)
     )
     combined.attrs = {**attrs}

--- a/tests/engine/test_row_partitioning.py
+++ b/tests/engine/test_row_partitioning.py
@@ -24,9 +24,7 @@ _MIXED_VALUES = [1, 0, 3, 0, 5]
     ],
     ids=["mixed", "all-matching", "none-matching"],
 )
-def test_split_rows_partitions(
-    values: list[int], expected_match: list[int], expected_non_match: list[int]
-) -> None:
+def test_split_rows_partitions(values: list[int], expected_match: list[int], expected_non_match: list[int]) -> None:
     df = pd.DataFrame({"val": values})
     matching, non_matching = split_rows(df, column="val", predicate=bool)
 

--- a/tests/engine/test_row_partitioning.py
+++ b/tests/engine/test_row_partitioning.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
+
+_MIXED_VALUES = [1, 0, 3, 0, 5]
+
+# ---------------------------------------------------------------------------
+# split_rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "values, expected_match, expected_non_match",
+    [
+        (_MIXED_VALUES, [1, 3, 5], [0, 0]),
+        ([1, 2, 3], [1, 2, 3], []),
+        ([0, 0, 0], [], [0, 0, 0]),
+    ],
+    ids=["mixed", "all-matching", "none-matching"],
+)
+def test_split_rows_partitions(
+    values: list[int], expected_match: list[int], expected_non_match: list[int]
+) -> None:
+    df = pd.DataFrame({"val": values})
+    matching, non_matching = split_rows(df, column="val", predicate=bool)
+
+    assert list(matching["val"]) == expected_match
+    assert list(non_matching["val"]) == expected_non_match
+    assert "_anonymizer_row_order" in matching.columns
+    assert "_anonymizer_row_order" in non_matching.columns
+
+
+def test_split_rows_empty_df() -> None:
+    df = pd.DataFrame({"val": pd.Series([], dtype=int)})
+    matching, non_matching = split_rows(df, column="val", predicate=bool)
+    assert len(matching) == 0
+    assert len(non_matching) == 0
+
+
+def test_split_rows_does_not_mutate_input() -> None:
+    df = pd.DataFrame({"val": _MIXED_VALUES})
+    original_cols = list(df.columns)
+    split_rows(df, column="val", predicate=bool)
+    assert list(df.columns) == original_cols
+
+
+def test_split_rows_custom_predicate() -> None:
+    df = pd.DataFrame({"name": ["alice", "bob", "charlie"]})
+    matching, _ = split_rows(df, column="name", predicate=lambda x: len(x) > 3)
+    assert list(matching["name"]) == ["alice", "charlie"]
+
+
+# ---------------------------------------------------------------------------
+# merge_and_reorder
+# ---------------------------------------------------------------------------
+
+
+def test_merge_and_reorder_restores_order() -> None:
+    df = pd.DataFrame({"val": _MIXED_VALUES})
+    matching, non_matching = split_rows(df, column="val", predicate=bool)
+    combined = merge_and_reorder(matching, non_matching, attrs={})
+
+    assert list(combined["val"]) == _MIXED_VALUES
+    assert "_anonymizer_row_order" not in combined.columns
+    assert list(combined.index) == list(range(len(combined)))
+
+
+def test_merge_and_reorder_propagates_attrs() -> None:
+    df = pd.DataFrame({"val": _MIXED_VALUES})
+    matching, non_matching = split_rows(df, column="val", predicate=bool)
+    attrs = {"key": "value", "nested": {"a": 1}}
+    combined = merge_and_reorder(matching, non_matching, attrs=attrs)
+    assert combined.attrs == attrs
+
+
+def test_merge_and_reorder_single_partition() -> None:
+    df = pd.DataFrame({"val": [1, 2, 3]})
+    matching, _ = split_rows(df, column="val", predicate=bool)
+    combined = merge_and_reorder(matching, attrs={})
+    assert list(combined["val"]) == [1, 2, 3]
+
+
+def test_roundtrip_preserves_columns_added_after_split() -> None:
+    df = pd.DataFrame({"val": [1, 0, 3]})
+    matching, non_matching = split_rows(df, column="val", predicate=bool)
+
+    matching["extra"] = "processed"
+    non_matching["extra"] = "skipped"
+
+    combined = merge_and_reorder(matching, non_matching, attrs={})
+    assert list(combined["extra"]) == ["processed", "skipped", "processed"]

--- a/tests/engine/test_row_partitioning.py
+++ b/tests/engine/test_row_partitioning.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
+from anonymizer.engine.row_partitioning import ROW_ORDER_COL, merge_and_reorder, split_rows
 
 _MIXED_VALUES = [1, 0, 3, 0, 5]
 
@@ -30,8 +30,8 @@ def test_split_rows_partitions(values: list[int], expected_match: list[int], exp
 
     assert list(matching["val"]) == expected_match
     assert list(non_matching["val"]) == expected_non_match
-    assert "_anonymizer_row_order" in matching.columns
-    assert "_anonymizer_row_order" in non_matching.columns
+    assert ROW_ORDER_COL in matching.columns
+    assert ROW_ORDER_COL in non_matching.columns
 
 
 def test_split_rows_empty_df() -> None:
@@ -65,7 +65,7 @@ def test_merge_and_reorder_restores_order() -> None:
     combined = merge_and_reorder(matching, non_matching, attrs={})
 
     assert list(combined["val"]) == _MIXED_VALUES
-    assert "_anonymizer_row_order" not in combined.columns
+    assert ROW_ORDER_COL not in combined.columns
     assert list(combined.index) == list(range(len(combined)))
 
 
@@ -75,6 +75,11 @@ def test_merge_and_reorder_propagates_attrs() -> None:
     attrs = {"key": "value", "nested": {"a": 1}}
     combined = merge_and_reorder(matching, non_matching, attrs=attrs)
     assert combined.attrs == attrs
+
+
+def test_merge_and_reorder_raises_on_empty_parts() -> None:
+    with pytest.raises(ValueError, match="at least one partition"):
+        merge_and_reorder(attrs={})
 
 
 def test_merge_and_reorder_single_partition() -> None:
@@ -92,4 +97,5 @@ def test_roundtrip_preserves_columns_added_after_split() -> None:
     non_matching["extra"] = "skipped"
 
     combined = merge_and_reorder(matching, non_matching, attrs={})
+    assert list(combined["val"]) == [1, 0, 3]
     assert list(combined["extra"]) == ["processed", "skipped", "processed"]


### PR DESCRIPTION
## Summary

- Extract the duplicated split/reorder/recombine DataFrame pattern into a shared `engine/row_partitioning.py` module with `split_rows()` and `merge_and_reorder()`
- Refactor `rewrite_workflow.py` and `llm_replace_workflow.py` to use the shared helpers instead of inline implementations
- Net reduction of ~46 lines of duplicated logic

Closes #60

## Test plan

- [x] 10 new unit tests for `row_partitioning.py` (partitioning, edge cases, roundtrip)
- [x] All 495 existing tests pass with no changes
- [x] Lint clean (`ruff check`)