### PR TITLE
feat: add confidence-aware privacy re-answers and weighted leakage metric

### DIFF
--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -77,6 +77,7 @@ COL_JUDGE_EVALUATION = "_judge_evaluation"
 # User-facing output columns
 COL_UTILITY_SCORE = "utility_score"
 COL_LEAKAGE_MASS = "leakage_mass"
+COL_WEIGHTED_LEAKAGE_RATE = "weighted_leakage_rate"
 COL_ANY_HIGH_LEAKED = "any_high_leaked"
 COL_NEEDS_HUMAN_REVIEW = "needs_human_review"
 

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -18,6 +18,7 @@ from anonymizer.config.rewrite import EvaluationCriteria
 from anonymizer.engine.constants import (
     COL_ANY_HIGH_LEAKED,
     COL_LEAKAGE_MASS,
+    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_REPAIR,
     COL_PRIVACY_QA,
     COL_PRIVACY_QA_REANSWER,
@@ -363,6 +364,18 @@ def compute_any_high_leaked(
     )
 
 
+def compute_weighted_leakage_rate(
+    leakage_mass: float,
+    privacy_qa: PrivacyQAPairsSchema,
+    sensitivity_weights: dict[str, float],
+) -> float:
+    """Normalized leakage in [0, 1] relative to maximum possible leakage mass."""
+    max_possible_mass = sum(sensitivity_weights[item.sensitivity] for item in privacy_qa.items)
+    if max_possible_mass <= 0.0:
+        return 0.0
+    return leakage_mass / max_possible_mass
+
+
 def determine_repair_needs(
     *,
     any_high_leaked: bool,
@@ -448,16 +461,20 @@ def _make_quality_compare_column(evaluator_alias: str) -> Any:
 
 @custom_column_generator(
     required_columns=[COL_QUALITY_QA_COMPARE, COL_PRIVACY_QA_REANSWER, COL_PRIVACY_QA, COL_QUALITY_QA],
-    side_effect_columns=[COL_LEAKAGE_MASS, COL_ANY_HIGH_LEAKED],
+    side_effect_columns=[COL_LEAKAGE_MASS, COL_WEIGHTED_LEAKAGE_RATE, COL_ANY_HIGH_LEAKED],
 )
 def _compute_metrics_columns(row: dict[str, Any], generator_params: MetricsParams) -> dict[str, Any]:
-    """Compute utility_score, leakage_mass, and any_high_leaked from evaluation outputs."""
+    """Compute utility_score, leakage_mass, weighted_leakage_rate, and any_high_leaked from evaluation outputs."""
     _, compare_scores = parse_quality_compare(row.get(COL_QUALITY_QA_COMPARE))
     privacy_answers = parse_privacy_answers(row.get(COL_PRIVACY_QA_REANSWER))
     privacy_qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
 
     row[COL_UTILITY_SCORE] = compute_utility_score(compare_scores)
-    row[COL_LEAKAGE_MASS] = compute_leakage_mass(privacy_answers, privacy_qa, generator_params.sensitivity_weights)
+    leakage_mass = compute_leakage_mass(privacy_answers, privacy_qa, generator_params.sensitivity_weights)
+    row[COL_LEAKAGE_MASS] = leakage_mass
+    row[COL_WEIGHTED_LEAKAGE_RATE] = compute_weighted_leakage_rate(
+        leakage_mass, privacy_qa, generator_params.sensitivity_weights
+    )
     row[COL_ANY_HIGH_LEAKED] = compute_any_high_leaked(privacy_answers, privacy_qa)
     return row
 

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -104,7 +104,9 @@ Fill in the "answer" field for each item. Do not add or remove items.
 
 def _render_privacy_reanswer_prompt(row: dict[str, Any]) -> str:
     qa = parse_privacy_qa(row.get(COL_PRIVACY_QA))
-    skeleton = [{"id": item.id, "question": item.question, "answer": ""} for item in qa.items]
+    skeleton = [
+        {"id": item.id, "question": item.question, "answer": "", "confidence": 1.0, "reason": ""} for item in qa.items
+    ]
 
     prompt = """You are a privacy auditor. Read the text and answer each question with "yes" or "no".
 
@@ -112,7 +114,9 @@ def _render_privacy_reanswer_prompt(row: dict[str, Any]) -> str:
 - Answer "yes" if the specific entity value can be identified or reasonably inferred from the text
 - Answer "no" if it cannot
 - You must commit to "yes" or "no". Do not hedge.
-- You MUST provide an answer for EVERY item in the template below
+- Set confidence from 0.0 to 1.0 reflecting how strongly the answer is supported
+- Provide a brief reason grounded in the text
+- You MUST provide answer, confidence, and reason for EVERY item in the template below
 </rules>
 
 <text>
@@ -120,7 +124,8 @@ def _render_privacy_reanswer_prompt(row: dict[str, Any]) -> str:
 </text>
 
 <task>
-Fill in the "answer" field for each item with "yes" or "no". Do not add or remove items.
+Fill in the "answer" ("yes"/"no"), "confidence" (0.0-1.0), and "reason" fields for each item.
+Do not add or remove items.
 </task>
 <answer_template>
 <<SKELETON>>
@@ -222,7 +227,12 @@ def _make_privacy_answer_parser(
             payload.get("answers"),
             expected_ids=expected_ids,
             label="privacy answer",
-            default_item_factory=lambda item_id: {"id": item_id, "answer": "yes"},
+            default_item_factory=lambda item_id: {
+                "id": item_id,
+                "answer": "yes",
+                "confidence": 1.0,
+                "reason": "Model omitted this item; defaulted to highest-confidence leak.",
+            },
         )
         return PrivacyAnswersSchema.model_validate(
             payload,
@@ -324,7 +334,7 @@ def compute_leakage_mass(
     privacy_qa: PrivacyQAPairsSchema,
     sensitivity_weights: dict[str, float],
 ) -> float:
-    """Weighted sum of leaked entities.
+    """Confidence-weighted sum of leaked entities.
 
     An entity is "leaked" when the privacy re-answer is ``yes``.
     Answer coverage is enforced upstream by the context-validated parser
@@ -337,7 +347,7 @@ def compute_leakage_mass(
             sensitivity = qa_lookup.get(answer.id)
             if sensitivity is None:
                 continue
-            total += sensitivity_weights[sensitivity]
+            total += sensitivity_weights[sensitivity] * answer.confidence
     return total
 
 

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -18,7 +18,6 @@ from anonymizer.config.rewrite import EvaluationCriteria
 from anonymizer.engine.constants import (
     COL_ANY_HIGH_LEAKED,
     COL_LEAKAGE_MASS,
-    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_REPAIR,
     COL_PRIVACY_QA,
     COL_PRIVACY_QA_REANSWER,
@@ -27,6 +26,7 @@ from anonymizer.engine.constants import (
     COL_QUALITY_QA_REANSWER,
     COL_REWRITTEN_TEXT,
     COL_UTILITY_SCORE,
+    COL_WEIGHTED_LEAKAGE_RATE,
 )
 from anonymizer.engine.ndd.adapter import NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -159,6 +159,12 @@ Fix the privacy leaks by following the protection decisions above:
 3. For "remove" - omit the detail entirely
 4. For "paraphrase" - rewrite surrounding context
 
+If privacy issues remain, you may override earlier "left_as_is" decisions when needed to satisfy privacy goals.
+You may modify surrounding context beyond the explicit entity span to break inferential leakage.
+Modify the text such that latent attributes cannot be reliably inferred by a motivated reader.
+This may involve reducing specificity, removing or weakening key details, breaking causal or identifying linkages,
+or introducing ambiguity, while preserving overall narrative coherence.
+
 Maintain content quality (utility score: <<UTILITY_SCORE>>), consistency, and naturalness.
 
 Provide ONLY the rewritten text. Do not include explanations, comments, or markdown formatting.

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -93,7 +93,8 @@ def _leaked_items_text(
             item = qa_lookup.get(answer.id)
             if item:
                 lines.append(
-                    f'- [{item.sensitivity.upper()}] {item.entity_label}: "{item.entity_value}" -- {item.question}'
+                    f'- [{item.sensitivity.upper()}] {item.entity_label}: "{item.entity_value}" -- {item.question} '
+                    f"(confidence_leakage_occurred: {answer.confidence:.2f}; reason: {answer.reason})"
                 )
     return "\n".join(lines)
 

--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -17,7 +17,6 @@ from anonymizer.engine.constants import (
     COL_ENTITIES_BY_VALUE,
     COL_JUDGE_EVALUATION,
     COL_LEAKAGE_MASS,
-    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_HUMAN_REVIEW,
     COL_NEEDS_REPAIR,
     COL_REPAIR_ITERATIONS,
@@ -25,6 +24,7 @@ from anonymizer.engine.constants import (
     COL_REWRITTEN_TEXT_NEXT,
     COL_TEXT,
     COL_UTILITY_SCORE,
+    COL_WEIGHTED_LEAKAGE_RATE,
 )
 from anonymizer.engine.ndd.adapter import RECORD_ID_COLUMN, FailedRecord, NddAdapter
 from anonymizer.engine.replace.llm_replace_workflow import LlmReplaceWorkflow

--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -17,6 +17,7 @@ from anonymizer.engine.constants import (
     COL_ENTITIES_BY_VALUE,
     COL_JUDGE_EVALUATION,
     COL_LEAKAGE_MASS,
+    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_HUMAN_REVIEW,
     COL_NEEDS_REPAIR,
     COL_REPAIR_ITERATIONS,
@@ -42,6 +43,7 @@ logger = logging.getLogger("anonymizer.rewrite.workflow")
 _PASSTHROUGH_DEFAULTS: dict[str, object] = {
     COL_UTILITY_SCORE: 1.0,
     COL_LEAKAGE_MASS: 0.0,
+    COL_WEIGHTED_LEAKAGE_RATE: 0.0,
     COL_ANY_HIGH_LEAKED: False,
     COL_NEEDS_HUMAN_REVIEW: False,
     COL_JUDGE_EVALUATION: None,

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -347,6 +347,8 @@ class QualityAnswersSchema(BaseModel):
 class PrivacyAnswerItemSchema(BaseModel):
     id: int
     answer: PrivacyAnswer
+    confidence: float = Field(ge=0.0, le=1.0)
+    reason: str = Field(min_length=1, max_length=200)
 
 
 class PrivacyAnswersSchema(BaseModel):

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -23,6 +23,7 @@ from anonymizer.engine.constants import (
     COL_DETECTED_ENTITIES,
     COL_FINAL_ENTITIES,
     COL_LEAKAGE_MASS,
+    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_HUMAN_REVIEW,
     COL_REPLACED_TEXT,
     COL_REWRITTEN_TEXT,
@@ -360,7 +361,7 @@ def _build_user_dataframe(trace_dataframe: pd.DataFrame) -> pd.DataFrame:
     """Filter trace dataframe to the public column set for the active mode.
 
     Replace:     {text_col}, {text_col}_replaced, {text_col}_with_spans, final_entities
-    Rewrite:     {text_col}, {text_col}_rewritten, utility_score, leakage_mass,
+    Rewrite:     {text_col}, {text_col}_rewritten, utility_score, leakage_mass, weighted_leakage_rate,
                  any_high_leaked, needs_human_review
     Detect-only: {text_col}, {text_col}_with_spans, final_entities
     """
@@ -373,6 +374,7 @@ def _build_user_dataframe(trace_dataframe: pd.DataFrame) -> pd.DataFrame:
             f"{text_col}_rewritten",
             COL_UTILITY_SCORE,
             COL_LEAKAGE_MASS,
+            COL_WEIGHTED_LEAKAGE_RATE,
             COL_ANY_HIGH_LEAKED,
             COL_NEEDS_HUMAN_REVIEW,
         }

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -23,13 +23,13 @@ from anonymizer.engine.constants import (
     COL_DETECTED_ENTITIES,
     COL_FINAL_ENTITIES,
     COL_LEAKAGE_MASS,
-    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_HUMAN_REVIEW,
     COL_REPLACED_TEXT,
     COL_REWRITTEN_TEXT,
     COL_TAGGED_TEXT,
     COL_TEXT,
     COL_UTILITY_SCORE,
+    COL_WEIGHTED_LEAKAGE_RATE,
     DEFAULT_ENTITY_LABELS,
 )
 from anonymizer.engine.detection.detection_workflow import EntityDetectionWorkflow

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -377,12 +377,18 @@ def _render_scores_section(row: pd.Series) -> str:
 
     utility = row.get("utility_score")
     leakage = row.get("leakage_mass")
+    weighted_leakage_rate = row.get("weighted_leakage_rate")
     needs_review = row.get("needs_human_review")
 
     if utility is not None:
         parts.append(f"<span style='margin-right:16px'><strong>Utility:</strong> {float(utility):.2f}</span>")
     if leakage is not None:
         parts.append(f"<span style='margin-right:16px'><strong>Leakage:</strong> {float(leakage):.2f}</span>")
+    if weighted_leakage_rate is not None:
+        parts.append(
+            "<span style='margin-right:16px'><strong>Weighted Leakage Rate:</strong> "
+            f"{float(weighted_leakage_rate):.2f}</span>"
+        )
     if needs_review is not None:
         badge_color = "#ef4444" if needs_review else "#22c55e"
         badge_text = "Yes" if needs_review else "No"

--- a/tests/engine/test_evaluate.py
+++ b/tests/engine/test_evaluate.py
@@ -17,8 +17,8 @@ from anonymizer.engine.rewrite.evaluate import (
     _normalize_answer_items,
     compute_any_high_leaked,
     compute_leakage_mass,
-    compute_weighted_leakage_rate,
     compute_utility_score,
+    compute_weighted_leakage_rate,
     determine_repair_needs,
 )
 from anonymizer.engine.schemas.rewrite import (

--- a/tests/engine/test_evaluate.py
+++ b/tests/engine/test_evaluate.py
@@ -54,6 +54,12 @@ def privacy_qa_high_and_low() -> dict:
     }
 
 
+def _privacy_answer(
+    item_id: int, answer: str, confidence: float = 1.0, reason: str = "evidence in text"
+) -> PrivacyAnswerItemSchema:
+    return PrivacyAnswerItemSchema(id=item_id, answer=answer, confidence=confidence, reason=reason)
+
+
 # ---------------------------------------------------------------------------
 # compute_leakage_mass
 # ---------------------------------------------------------------------------
@@ -61,33 +67,38 @@ def privacy_qa_high_and_low() -> dict:
 
 class TestComputeLeakageMass:
     def test_no_leaks(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        answers = [_privacy_answer(1, "no"), _privacy_answer(2, "no")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == 0.0
 
     def test_high_leak_only(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        answers = [_privacy_answer(1, "yes"), _privacy_answer(2, "no")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == 1.0
 
     def test_low_leak_only(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        answers = [_privacy_answer(1, "no"), _privacy_answer(2, "yes")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == 0.3
 
     def test_both_leaked(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        answers = [_privacy_answer(1, "yes"), _privacy_answer(2, "yes")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == pytest.approx(1.3)
 
     def test_custom_weights(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        answers = [_privacy_answer(1, "yes"), _privacy_answer(2, "yes")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass(answers, qa, {"high": 2.0, "medium": 1.0, "low": 0.5}) == pytest.approx(2.5)
 
     def test_empty_answers(self, privacy_qa_high_and_low: dict) -> None:
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass([], qa, dict(SENSITIVITY_WEIGHTS)) == 0.0
+
+    def test_confidence_weights_leakage_mass(self, privacy_qa_high_and_low: dict) -> None:
+        answers = [_privacy_answer(1, "yes", confidence=0.4), _privacy_answer(2, "yes", confidence=0.5)]
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == pytest.approx(0.55)
 
 
 # ---------------------------------------------------------------------------
@@ -97,17 +108,17 @@ class TestComputeLeakageMass:
 
 class TestComputeAnyHighLeaked:
     def test_high_leaked(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="yes"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        answers = [_privacy_answer(1, "yes"), _privacy_answer(2, "no")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_any_high_leaked(answers, qa) is True
 
     def test_only_low_leaked(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="yes")]
+        answers = [_privacy_answer(1, "no"), _privacy_answer(2, "yes")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_any_high_leaked(answers, qa) is False
 
     def test_no_leaks(self, privacy_qa_high_and_low: dict) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="no"), PrivacyAnswerItemSchema(id=2, answer="no")]
+        answers = [_privacy_answer(1, "no"), _privacy_answer(2, "no")]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_any_high_leaked(answers, qa) is False
 
@@ -223,12 +234,25 @@ def test_evaluate_columns_pipeline(
 
 def test_normalize_answer_items_fills_missing_privacy_answers_conservatively() -> None:
     normalized = _normalize_answer_items(
-        [{"id": 1, "answer": "no"}],
+        [{"id": 1, "answer": "no", "confidence": 0.0, "reason": "not inferable"}],
         expected_ids=[1, 2],
         label="privacy answer",
-        default_item_factory=lambda item_id: {"id": item_id, "answer": "yes"},
+        default_item_factory=lambda item_id: {
+            "id": item_id,
+            "answer": "yes",
+            "confidence": 1.0,
+            "reason": "Model omitted this item; defaulted to highest-confidence leak.",
+        },
     )
-    assert normalized == [{"id": 1, "answer": "no"}, {"id": 2, "answer": "yes"}]
+    assert normalized == [
+        {"id": 1, "answer": "no", "confidence": 0.0, "reason": "not inferable"},
+        {
+            "id": 2,
+            "answer": "yes",
+            "confidence": 1.0,
+            "reason": "Model omitted this item; defaulted to highest-confidence leak.",
+        },
+    ]
 
 
 def test_normalize_answer_items_drops_extra_and_duplicate_ids() -> None:

--- a/tests/engine/test_evaluate.py
+++ b/tests/engine/test_evaluate.py
@@ -17,6 +17,7 @@ from anonymizer.engine.rewrite.evaluate import (
     _normalize_answer_items,
     compute_any_high_leaked,
     compute_leakage_mass,
+    compute_weighted_leakage_rate,
     compute_utility_score,
     determine_repair_needs,
 )
@@ -99,6 +100,34 @@ class TestComputeLeakageMass:
         answers = [_privacy_answer(1, "yes", confidence=0.4), _privacy_answer(2, "yes", confidence=0.5)]
         qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
         assert compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS)) == pytest.approx(0.55)
+
+
+# ---------------------------------------------------------------------------
+# compute_weighted_leakage_rate
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_leakage_rate_positive_when_any_leak_present(privacy_qa_high_and_low: dict) -> None:
+    qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+    answers = [_privacy_answer(1, "no"), _privacy_answer(2, "yes")]
+    leakage_mass = compute_leakage_mass(answers, qa, dict(SENSITIVITY_WEIGHTS))
+    weighted_leakage_rate = compute_weighted_leakage_rate(leakage_mass, qa, dict(SENSITIVITY_WEIGHTS))
+    assert weighted_leakage_rate > 0.0
+    assert weighted_leakage_rate == pytest.approx(0.3 / 1.3)
+
+
+class TestComputeWeightedLeakageRate:
+    def test_normalizes_to_unit_interval(self, privacy_qa_high_and_low: dict) -> None:
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_weighted_leakage_rate(0.65, qa, dict(SENSITIVITY_WEIGHTS)) == pytest.approx(0.5)
+
+    def test_zero_when_no_mass(self, privacy_qa_high_and_low: dict) -> None:
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_weighted_leakage_rate(0.0, qa, dict(SENSITIVITY_WEIGHTS)) == 0.0
+
+    def test_zero_when_no_possible_weight(self, privacy_qa_high_and_low: dict) -> None:
+        qa = PrivacyQAPairsSchema.model_validate(privacy_qa_high_and_low)
+        assert compute_weighted_leakage_rate(1.0, qa, {"high": 0.0, "medium": 0.0, "low": 0.0}) == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_parsers.py
+++ b/tests/engine/test_parsers.py
@@ -78,13 +78,15 @@ def test_field_invalid_raises() -> None:
 
 
 def test_parse_privacy_answers_from_dict() -> None:
-    result = parse_privacy_answers({"answers": [{"id": 1, "answer": "yes"}]})
+    result = parse_privacy_answers({"answers": [{"id": 1, "answer": "yes", "confidence": 0.8, "reason": "explicit"}]})
     assert len(result) == 1
     assert result[0].id == 1
 
 
 def test_parse_privacy_answers_from_schema() -> None:
-    schema = PrivacyAnswersSchema.model_validate({"answers": [{"id": 1, "answer": "no"}]})
+    schema = PrivacyAnswersSchema.model_validate(
+        {"answers": [{"id": 1, "answer": "no", "confidence": 0.0, "reason": "not inferable"}]}
+    )
     assert len(parse_privacy_answers(schema)) == 1
 
 
@@ -94,7 +96,9 @@ def test_parse_privacy_answers_invalid_type() -> None:
 
 
 def test_parse_privacy_answers_normalizes_numpy_array_payload() -> None:
-    result = parse_privacy_answers({"answers": np.array([{"id": 1, "answer": "yes"}], dtype=object)})
+    result = parse_privacy_answers(
+        {"answers": np.array([{"id": 1, "answer": "yes", "confidence": 0.9, "reason": "explicit"}], dtype=object)}
+    )
     assert len(result) == 1
     assert result[0].id == 1
 

--- a/tests/engine/test_repair.py
+++ b/tests/engine/test_repair.py
@@ -90,15 +90,17 @@ _STUB_PRIVACY_QA = {
 
 class TestLeakedItemsText:
     def test_leaked_item_formatted(self) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="yes")]
+        answers = [PrivacyAnswerItemSchema(id=1, answer="yes", confidence=0.9, reason="Name remains explicit")]
         qa = PrivacyQAPairsSchema.model_validate(_STUB_PRIVACY_QA)
         result = _leaked_items_text(answers, qa)
         assert "[HIGH]" in result
         assert "first_name" in result
         assert "Alice" in result
+        assert "confidence_leakage_occurred: 0.90" in result
+        assert "reason: Name remains explicit" in result
 
     def test_no_leaks_returns_empty(self) -> None:
-        answers = [PrivacyAnswerItemSchema(id=1, answer="no")]
+        answers = [PrivacyAnswerItemSchema(id=1, answer="no", confidence=0.0, reason="Not inferable")]
         qa = PrivacyQAPairsSchema.model_validate(_STUB_PRIVACY_QA)
         assert _leaked_items_text(answers, qa) == ""
 
@@ -155,7 +157,9 @@ class TestRenderRepairPrompt:
             COL_LEAKAGE_MASS: 1.0,
             COL_ANY_HIGH_LEAKED: True,
             COL_UTILITY_SCORE: 0.85,
-            COL_PRIVACY_QA_REANSWER: {"answers": [{"id": 1, "answer": "yes"}]},
+            COL_PRIVACY_QA_REANSWER: {
+                "answers": [{"id": 1, "answer": "yes", "confidence": 0.9, "reason": "Name remains explicit"}]
+            },
             COL_PRIVACY_QA: _STUB_PRIVACY_QA,
             "_leaked_privacy_items": '- [HIGH] first_name: "Alice"',
         }

--- a/tests/engine/test_rewrite_workflow.py
+++ b/tests/engine/test_rewrite_workflow.py
@@ -17,6 +17,7 @@ from anonymizer.engine.constants import (
     COL_ENTITIES_BY_VALUE,
     COL_JUDGE_EVALUATION,
     COL_LEAKAGE_MASS,
+    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_HUMAN_REVIEW,
     COL_NEEDS_REPAIR,
     COL_REPAIR_ITERATIONS,
@@ -209,6 +210,7 @@ def test_passthrough_defaults_populated(
     assert df[COL_REWRITTEN_TEXT].tolist() == ["The sky is blue", "Water is wet"]
     assert df[COL_UTILITY_SCORE].tolist() == [1.0, 1.0]
     assert df[COL_LEAKAGE_MASS].tolist() == [0.0, 0.0]
+    assert df[COL_WEIGHTED_LEAKAGE_RATE].tolist() == [0.0, 0.0]
     assert df[COL_ANY_HIGH_LEAKED].tolist() == [False, False]
     assert df[COL_NEEDS_HUMAN_REVIEW].tolist() == [False, False]
     assert df[COL_JUDGE_EVALUATION].tolist() == [None, None]

--- a/tests/engine/test_rewrite_workflow.py
+++ b/tests/engine/test_rewrite_workflow.py
@@ -17,7 +17,6 @@ from anonymizer.engine.constants import (
     COL_ENTITIES_BY_VALUE,
     COL_JUDGE_EVALUATION,
     COL_LEAKAGE_MASS,
-    COL_WEIGHTED_LEAKAGE_RATE,
     COL_NEEDS_HUMAN_REVIEW,
     COL_NEEDS_REPAIR,
     COL_REPAIR_ITERATIONS,
@@ -25,6 +24,7 @@ from anonymizer.engine.constants import (
     COL_REWRITTEN_TEXT_NEXT,
     COL_TEXT,
     COL_UTILITY_SCORE,
+    COL_WEIGHTED_LEAKAGE_RATE,
 )
 from anonymizer.engine.ndd.adapter import RECORD_ID_COLUMN, FailedRecord, WorkflowRunResult
 from anonymizer.engine.rewrite.rewrite_workflow import RewriteWorkflow

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -358,7 +358,14 @@ def test_quality_answers_use_integer_ids() -> None:
 
 def test_privacy_answers_reject_unknown_and_use_integer_ids() -> None:
     with pytest.raises(ValidationError):
-        PrivacyAnswersSchema.model_validate({"answers": [{"id": 1, "answer": "unknown"}]})
+        PrivacyAnswersSchema.model_validate(
+            {"answers": [{"id": 1, "answer": "unknown", "confidence": 0.9, "reason": "unsupported enum value"}]}
+        )
+
+
+def test_privacy_answers_require_confidence_and_reason() -> None:
+    with pytest.raises(ValidationError):
+        PrivacyAnswersSchema.model_validate({"answers": [{"id": 1, "answer": "yes"}]})
 
 
 def test_qa_compare_results_use_integer_ids() -> None:
@@ -393,7 +400,7 @@ def test_quality_answers_no_enforcement_without_context() -> None:
 def test_privacy_answers_reject_missing_ids_with_context() -> None:
     with pytest.raises(ValidationError, match="Missing answer IDs"):
         PrivacyAnswersSchema.model_validate(
-            {"answers": [{"id": 1, "answer": "no"}]},
+            {"answers": [{"id": 1, "answer": "no", "confidence": 0.0, "reason": "not inferable"}]},
             context={"expected_ids": [1, 2]},
         )
 

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -62,6 +62,7 @@ def _make_anonymizer(
             COL_REWRITTEN_TEXT: ["Beth works at Globex"],
             "utility_score": [0.85],
             "leakage_mass": [0.3],
+            "weighted_leakage_rate": [0.23],
             "any_high_leaked": [False],
             "needs_human_review": [False],
         }
@@ -427,6 +428,7 @@ def test_run_rewrite_output_columns(stub_input: AnonymizerInput) -> None:
     assert "text_rewritten" in result.dataframe.columns
     assert "utility_score" in result.dataframe.columns
     assert "leakage_mass" in result.dataframe.columns
+    assert "weighted_leakage_rate" in result.dataframe.columns
     assert "any_high_leaked" in result.dataframe.columns
     assert "needs_human_review" in result.dataframe.columns
 
@@ -440,6 +442,7 @@ def test_run_rewrite_internal_columns_only_in_trace(stub_input: AnonymizerInput)
             "_sensitivity_disposition": [None],
             "utility_score": [0.85],
             "leakage_mass": [0.3],
+            "weighted_leakage_rate": [0.23],
             "any_high_leaked": [False],
             "needs_human_review": [False],
         }
@@ -471,6 +474,7 @@ def test_run_rewrite_merges_failed_records(stub_input: AnonymizerInput) -> None:
             COL_REWRITTEN_TEXT: ["Beth"],
             "utility_score": [0.85],
             "leakage_mass": [0.3],
+            "weighted_leakage_rate": [0.23],
             "any_high_leaked": [False],
             "needs_human_review": [False],
         }

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -469,6 +469,7 @@ def test_render_record_html_rewrite_mode_shows_rewrite_layout() -> None:
             },
             "utility_score": 0.85,
             "leakage_mass": 0.3,
+            "weighted_leakage_rate": 0.23,
             "needs_human_review": False,
         }
     )
@@ -479,6 +480,7 @@ def test_render_record_html_rewrite_mode_shows_rewrite_layout() -> None:
     assert "Scores" in result
     assert "0.85" in result
     assert "0.30" in result
+    assert "0.23" in result
     assert "Replaced" not in result
     assert "Replacement Map" not in result
 


### PR DESCRIPTION
## Summary
- Added strict privacy re-answer fields (`confidence`, `reason`) and updated evaluator prompt/parser handling.
- Updated leakage computation to be confidence-aware (`leakage_mass` is now weighted by confidence for leaked items).
- Updated repair context formatting to include explicit leakage confidence and reason signals.
- Added and exposed normalized `weighted_leakage_rate` in rewrite outputs and preview display.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [x] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally 
  - NA at the moment because docs have not merged, will do in #84 if this merges first, or here if #84 merges first! 

## Related Issues
Closes #72  
Closes #74