### PR TITLE
refactor: migrate prompt .replace() chains to substitute_placeholders

### DIFF
--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -48,6 +48,7 @@ from anonymizer.engine.detection.custom_columns import (
 from anonymizer.engine.detection.postprocess import EntitySpan, group_entities_by_value
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.schemas import (
     AugmentedEntitiesSchema,
     EntitiesByValueSchema,
@@ -441,14 +442,17 @@ Output: {"decisions": [{"id": "first_name_3_7", "value": "name", "label": "first
 Input text: <<TAGGED_TEXT>>
 Template: <<VALIDATION_SKELETON>>
 """
-    prompt = (
-        prompt.replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
-        .replace("<<TAGGED_TEXT>>", _jinja(COL_MERGED_TAGGED_TEXT))
-        .replace("<<VALIDATION_SKELETON>>", _jinja(COL_VALIDATION_SKELETON))
-        .replace("<<LABEL_EXAMPLES>>", _format_label_examples(labels))
-    )
     context_section = f"\nData context: {data_summary}\n" if data_summary else ""
-    return prompt.replace("<<DATA_SUMMARY>>", context_section)
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<TAG_NOTATION>>": COL_TAG_NOTATION,
+            "<<TAGGED_TEXT>>": _jinja(COL_MERGED_TAGGED_TEXT),
+            "<<VALIDATION_SKELETON>>": _jinja(COL_VALIDATION_SKELETON),
+            "<<LABEL_EXAMPLES>>": _format_label_examples(labels),
+            "<<DATA_SUMMARY>>": context_section,
+        },
+    )
 
 
 def _get_augment_prompt(*, data_summary: str | None, labels: list[str], strict_labels: bool = False) -> str:
@@ -521,16 +525,22 @@ Other information:
 Input text: <<TAGGED_TEXT>>
 Already-detected entities: <<SEED_ENTITIES>>
 """
-    prompt = (
-        prompt.replace("<<LABEL_BLOCK>>", label_block)
-        .replace("<<EXAMPLE_BLOCK>>", example_block)
-        .replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
-        .replace("<<TAGGED_TEXT>>", _jinja(COL_INITIAL_TAGGED_TEXT))
-        .replace("<<SEED_ENTITIES>>", _jinja(COL_SEED_ENTITIES_JSON))
-        .replace("<<VALID_CLASSES>>", ", ".join(labels))
-    )
+    # Pre-substitute nested placeholders inside the block strings before
+    # passing them into the single-pass substitution of the main prompt.
+    label_block = label_block.replace("<<VALID_CLASSES>>", ", ".join(labels))
+    example_block = example_block.replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
     context_section = data_summary if data_summary else "Not provided"
-    return prompt.replace("<<DATA_SUMMARY>>", context_section)
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<LABEL_BLOCK>>": label_block,
+            "<<EXAMPLE_BLOCK>>": example_block,
+            "<<TAG_NOTATION>>": COL_TAG_NOTATION,
+            "<<TAGGED_TEXT>>": _jinja(COL_INITIAL_TAGGED_TEXT),
+            "<<SEED_ENTITIES>>": _jinja(COL_SEED_ENTITIES_JSON),
+            "<<DATA_SUMMARY>>": context_section,
+        },
+    )
 
 
 def _get_latent_prompt(*, data_summary: str | None, privacy_goal: PrivacyGoal | None) -> str:
@@ -619,11 +629,14 @@ Quality checks before finalizing
 
 Now produce the JSON for the input.
 """
-    return (
-        prompt.replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
-        .replace("<<PRIVACY_GOAL>>", privacy_goal_text)
-        .replace("<<DATA_SUMMARY>>", summary_line)
-        .replace("<<TAGGED_TEXT>>", _jinja(COL_TAGGED_TEXT))
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<TAG_NOTATION>>": COL_TAG_NOTATION,
+            "<<PRIVACY_GOAL>>": privacy_goal_text,
+            "<<DATA_SUMMARY>>": summary_line,
+            "<<TAGGED_TEXT>>": _jinja(COL_TAGGED_TEXT),
+        },
     )
 
 

--- a/src/anonymizer/engine/prompt_utils.py
+++ b/src/anonymizer/engine/prompt_utils.py
@@ -10,6 +10,7 @@ import re
 
 logger = logging.getLogger("anonymizer.prompt_utils")
 
+# \w+ matches [a-zA-Z0-9_] only; hyphens in placeholder names are not supported.
 _PLACEHOLDER_RE = re.compile(r"<<\w+>>")
 
 

--- a/src/anonymizer/engine/prompt_utils.py
+++ b/src/anonymizer/engine/prompt_utils.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-pass placeholder substitution for LLM prompt templates."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger("anonymizer.prompt_utils")
+
+_PLACEHOLDER_RE = re.compile(r"<<\w+>>")
+
+
+def substitute_placeholders(
+    template: str,
+    replacements: dict[str, str],
+    *,
+    strict: bool = True,
+) -> str:
+    """Single-pass placeholder substitution.
+
+    All ``<<PLACEHOLDER>>`` markers are replaced simultaneously so that
+    user-controlled values inserted for one placeholder cannot collide
+    with markers intended for a later placeholder.
+
+    When *strict* is True (default):
+
+    - Raises ``ValueError`` if any key does not match the ``<<...>>`` format.
+    - Raises ``ValueError`` if any ``<<...>>`` placeholders remain after substitution.
+    - Logs a warning if the dict contains keys not present in the template.
+    """
+    if not replacements:
+        if strict:
+            remaining = _PLACEHOLDER_RE.findall(template)
+            if remaining:
+                raise ValueError(f"Unresolved placeholders in prompt: {remaining}")
+        return template
+
+    if strict:
+        bad_keys = [k for k in replacements if not _PLACEHOLDER_RE.fullmatch(k)]
+        if bad_keys:
+            raise ValueError(f"Replacement keys must use <<...>> format, got: {bad_keys}")
+
+        unused = [k for k in replacements if k not in template]
+        if unused:
+            logger.warning("Replacement keys not found in template: %s", unused)
+
+        # Check for unresolved placeholders by comparing original template
+        # placeholders against provided keys.  Scanning the *result* would
+        # false-positive when a replacement value itself contains <<...>>.
+        original_placeholders = set(_PLACEHOLDER_RE.findall(template))
+        unresolved = sorted(original_placeholders - set(replacements))
+        if unresolved:
+            raise ValueError(f"Unresolved placeholders in prompt: {unresolved}")
+
+    pattern = re.compile("|".join(re.escape(k) for k in replacements))
+    return pattern.sub(lambda m: replacements[m.group(0)], template)

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -15,6 +15,7 @@ from anonymizer.config.models import ReplaceModelSelection
 from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, ENTITY_LABEL_EXAMPLES
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
 from anonymizer.engine.schemas import EntitiesByValueSchema, EntityReplacementMapSchema
 
@@ -239,7 +240,13 @@ Before generating replacements, verify:
    - That each new_value is clearly different in meaning from the original and is not a synonym or simple rewording.
    - That all geographic replacements remain mutually consistent (cities belong to the replaced state/region, and travel routes remain plausible).
 """
-    return prompt.replace("<<INSTRUCTION_BLOCK>>", instruction_block).replace("<<ENTITIES_COLUMN>>", entities_column)
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<INSTRUCTION_BLOCK>>": instruction_block,
+            "<<ENTITIES_COLUMN>>": entities_column,
+        },
+    )
 
 
 _EXAMPLE_LOOKUP: dict[str, str] = {

--- a/src/anonymizer/engine/rewrite/domain_classification.py
+++ b/src/anonymizer/engine/rewrite/domain_classification.py
@@ -12,6 +12,7 @@ from data_designer.config.column_types import ColumnConfigT
 from anonymizer.config.models import RewriteModelSelection
 from anonymizer.engine.constants import COL_DOMAIN, COL_DOMAIN_SUPPLEMENT, COL_TEXT, _jinja
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.schemas import Domain, DomainClassificationSchema
 
 # ---------------------------------------------------------------------------
@@ -407,10 +408,13 @@ Choose the domain that best reflects how the text is meant to be used or interpr
 <text_to_classify>
 <<TEXT>>
 </text_to_classify>"""
-    return (
-        prompt.replace("<<TEXT>>", _jinja(COL_TEXT))
-        .replace("<<DOMAINS>>", domains_text)
-        .replace("<<DATA_CONTEXT>>", data_context_section)
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<TEXT>>": _jinja(COL_TEXT),
+            "<<DOMAINS>>": domains_text,
+            "<<DATA_CONTEXT>>": data_context_section,
+        },
     )
 
 

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -30,13 +30,13 @@ from anonymizer.engine.constants import (
 )
 from anonymizer.engine.ndd.adapter import NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.rewrite.parsers import (
     parse_privacy_answers,
     parse_privacy_qa,
     parse_quality_answers,
     parse_quality_compare,
     parse_quality_qa,
-    render_template,
 )
 from anonymizer.engine.schemas.rewrite import (
     PrivacyAnswer,
@@ -93,7 +93,7 @@ Fill in the "answer" field for each item. Do not add or remove items.
 <<SKELETON>>
 </answer_template>
 """
-    return render_template(
+    return substitute_placeholders(
         prompt,
         {
             "<<SKELETON>>": json.dumps({"answers": skeleton}, indent=2),
@@ -131,7 +131,7 @@ Do not add or remove items.
 <<SKELETON>>
 </answer_template>
 """
-    return render_template(
+    return substitute_placeholders(
         prompt,
         {
             "<<SKELETON>>": json.dumps({"answers": skeleton}, indent=2),
@@ -182,7 +182,7 @@ Fill in the "score" (0.0-1.0) and "reason" fields for each item. Do not add or r
 <<SKELETON>>
 </answer_template>
 """
-    return render_template(
+    return substitute_placeholders(
         prompt,
         {
             "<<SKELETON>>": json.dumps({"per_item": skeleton}, indent=2),

--- a/src/anonymizer/engine/rewrite/final_judge.py
+++ b/src/anonymizer/engine/rewrite/final_judge.py
@@ -23,7 +23,7 @@ from anonymizer.engine.constants import (
     _jinja,
 )
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
-from anonymizer.engine.rewrite.parsers import render_template
+from anonymizer.engine.prompt_utils import substitute_placeholders
 
 # ---------------------------------------------------------------------------
 # Generator params
@@ -128,7 +128,7 @@ Score each dimension independently.
       changes content, and it can preserve content while still sounding awkward.
 </naturalness_scoring_instructions>
 """
-    return render_template(
+    return substitute_placeholders(
         prompt,
         {
             "<<PRIVACY_GOAL>>": privacy_goal.to_prompt_string(),

--- a/src/anonymizer/engine/rewrite/parsers.py
+++ b/src/anonymizer/engine/rewrite/parsers.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared parse helpers, schema field validation, and prompt utilities for rewrite workflows."""
+"""Shared parse helpers and schema field validation for rewrite workflows."""
 
 from __future__ import annotations
 
 import json
-import re
 from typing import Any
 
 from pydantic import BaseModel
@@ -21,19 +20,6 @@ from anonymizer.engine.schemas.rewrite import (
     QualityQAPairsSchema,
     SensitivityDispositionSchema,
 )
-
-
-def render_template(template: str, replacements: dict[str, str]) -> str:
-    """Single-pass placeholder substitution.
-
-    All ``<<PLACEHOLDER>>`` markers are replaced simultaneously so that
-    user-controlled values inserted for one placeholder cannot collide
-    with markers intended for a later placeholder.
-    """
-    if not replacements:
-        return template
-    pattern = re.compile("|".join(re.escape(k) for k in replacements))
-    return pattern.sub(lambda m: replacements[m.group(0)], template)
 
 
 def field(model: type, name: str) -> str:

--- a/src/anonymizer/engine/rewrite/qa_generation.py
+++ b/src/anonymizer/engine/rewrite/qa_generation.py
@@ -24,6 +24,7 @@ from anonymizer.engine.constants import (
     _jinja,
 )
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.rewrite.parsers import parse_sensitivity_disposition
 from anonymizer.engine.schemas import (
     Domain,
@@ -186,11 +187,14 @@ Sensitivity disposition:
 <<ENTITY_PROTECTION_BLOCK>>
 >>>
 </input>"""
-    return (
-        prompt.replace("<<ENTITY_PROTECTION_BLOCK>>", _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK))
-        .replace("<<DOMAIN>>", _jinja(COL_DOMAIN, key=_DOMAIN_KEY))
-        .replace("<<DOMAIN_SUPPLEMENT>>", _jinja(COL_DOMAIN_SUPPLEMENT))
-        .replace("<<TEXT>>", _jinja(COL_TEXT))
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<ENTITY_PROTECTION_BLOCK>>": _jinja(COL_SENSITIVITY_DISPOSITION_BLOCK),
+            "<<DOMAIN>>": _jinja(COL_DOMAIN, key=_DOMAIN_KEY),
+            "<<DOMAIN_SUPPLEMENT>>": _jinja(COL_DOMAIN_SUPPLEMENT),
+            "<<TEXT>>": _jinja(COL_TEXT),
+        },
     )
 
 
@@ -252,7 +256,10 @@ Meaning units:
 <<MEANING_UNITS_SERIALIZED>>
 ---
 </input>"""
-    return prompt.replace("<<MEANING_UNITS_SERIALIZED>>", _jinja(COL_MEANING_UNITS_SERIALIZED))
+    return substitute_placeholders(
+        prompt,
+        {"<<MEANING_UNITS_SERIALIZED>>": _jinja(COL_MEANING_UNITS_SERIALIZED)},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/rewrite/repair.py
+++ b/src/anonymizer/engine/rewrite/repair.py
@@ -29,13 +29,13 @@ from anonymizer.engine.constants import (
 )
 from anonymizer.engine.ndd.adapter import NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.rewrite.parsers import (
     field,
     normalize_payload,
     parse_privacy_answers,
     parse_privacy_qa,
     parse_sensitivity_disposition,
-    render_template,
 )
 from anonymizer.engine.schemas.rewrite import (
     EntityDispositionSchema,
@@ -184,7 +184,7 @@ Provide ONLY the rewritten text. Do not include explanations, comments, or markd
         "<<LEAKED_ITEMS>>": str(row.get(COL_LEAKED_PRIVACY_ITEMS, "")),
         "<<UTILITY_SCORE>>": str(row.get(COL_UTILITY_SCORE, 0.0)),
     }
-    return render_template(prompt, replacements)
+    return substitute_placeholders(prompt, replacements)
 
 
 # ---------------------------------------------------------------------------

--- a/src/anonymizer/engine/rewrite/rewrite_generation.py
+++ b/src/anonymizer/engine/rewrite/rewrite_generation.py
@@ -24,6 +24,7 @@ from anonymizer.engine.constants import (
     _jinja,
 )
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.rewrite.parsers import normalize_payload, parse_sensitivity_disposition
 from anonymizer.engine.schemas import (
     EntityReplacementMapSchema,
@@ -106,14 +107,17 @@ Rules:
 4. The rewritten text must flow naturally and preserve the meaning and narrative structure of the original.
 5. Do not introduce new identifying details not present in the original.
 </output_requirements>"""
-    return (
-        prompt.replace("<<PRIVACY_GOAL>>", privacy_goal.to_prompt_string())
-        .replace("<<DATA_CONTEXT>>", data_context_section)
-        .replace("<<TAG_NOTATION>>", COL_TAG_NOTATION)
-        .replace("<<TAGGED_TEXT>>", _jinja(COL_TAGGED_TEXT))
-        .replace("<<REWRITE_DISPOSITION_BLOCK>>", COL_REWRITE_DISPOSITION_BLOCK)
-        .replace("<<REPLACEMENT_MAP_COL>>", COL_REPLACEMENT_MAP_FOR_PROMPT)
-        .replace("<<REPLACEMENT_MAP>>", _jinja(COL_REPLACEMENT_MAP_FOR_PROMPT))
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<PRIVACY_GOAL>>": privacy_goal.to_prompt_string(),
+            "<<DATA_CONTEXT>>": data_context_section,
+            "<<TAG_NOTATION>>": COL_TAG_NOTATION,
+            "<<TAGGED_TEXT>>": _jinja(COL_TAGGED_TEXT),
+            "<<REWRITE_DISPOSITION_BLOCK>>": COL_REWRITE_DISPOSITION_BLOCK,
+            "<<REPLACEMENT_MAP_COL>>": COL_REPLACEMENT_MAP_FOR_PROMPT,
+            "<<REPLACEMENT_MAP>>": _jinja(COL_REPLACEMENT_MAP_FOR_PROMPT),
+        },
     )
 
 

--- a/src/anonymizer/engine/rewrite/sensitivity_disposition.py
+++ b/src/anonymizer/engine/rewrite/sensitivity_disposition.py
@@ -18,6 +18,7 @@ from anonymizer.engine.constants import (
     _jinja,
 )
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
+from anonymizer.engine.prompt_utils import substitute_placeholders
 from anonymizer.engine.schemas import SensitivityDispositionSchema
 
 
@@ -153,14 +154,17 @@ QUALITY REQUIREMENTS:
 - protection_reason must be specific to this document (not generic boilerplate).
 - combined_risk_level must consider other entities being retained.
 </output_requirements>"""
-    return (
-        prompt.replace("<<PRIVACY_GOAL>>", privacy_goal_str)
-        .replace("<<DOMAIN>>", _jinja(COL_DOMAIN, key="domain"))
-        .replace("<<DATA_SUMMARY>>", data_summary_line)
-        .replace("<<DOMAIN_SUPPLEMENT>>", _jinja(COL_DOMAIN_SUPPLEMENT))
-        .replace("<<TAGGED_TEXT>>", _jinja(COL_TAGGED_TEXT))
-        .replace("<<FINAL_ENTITIES>>", _jinja(COL_ENTITIES_BY_VALUE))
-        .replace("<<LATENT_ENTITIES>>", _jinja(COL_LATENT_ENTITIES))
+    return substitute_placeholders(
+        prompt,
+        {
+            "<<PRIVACY_GOAL>>": privacy_goal_str,
+            "<<DOMAIN>>": _jinja(COL_DOMAIN, key="domain"),
+            "<<DATA_SUMMARY>>": data_summary_line,
+            "<<DOMAIN_SUPPLEMENT>>": _jinja(COL_DOMAIN_SUPPLEMENT),
+            "<<TAGGED_TEXT>>": _jinja(COL_TAGGED_TEXT),
+            "<<FINAL_ENTITIES>>": _jinja(COL_ENTITIES_BY_VALUE),
+            "<<LATENT_ENTITIES>>": _jinja(COL_LATENT_ENTITIES),
+        },
     )
 
 

--- a/tests/engine/test_parsers.py
+++ b/tests/engine/test_parsers.py
@@ -15,42 +15,12 @@ from anonymizer.engine.rewrite.parsers import (
     parse_quality_compare,
     parse_quality_qa,
     parse_sensitivity_disposition,
-    render_template,
 )
 from anonymizer.engine.schemas.rewrite import (
     PrivacyAnswersSchema,
     QACompareResultsSchema,
     QualityQAPairsSchema,
 )
-
-# ---------------------------------------------------------------------------
-# render_template
-# ---------------------------------------------------------------------------
-
-
-def test_render_template_basic() -> None:
-    assert render_template("Hello <<NAME>>!", {"<<NAME>>": "Alice"}) == "Hello Alice!"
-
-
-def test_render_template_multiple_placeholders() -> None:
-    assert render_template("<<A>> and <<B>>", {"<<A>>": "X", "<<B>>": "Y"}) == "X and Y"
-
-
-def test_render_template_no_cross_contamination() -> None:
-    result = render_template(
-        "text: <<TEXT>>, score: <<SCORE>>",
-        {"<<TEXT>>": "contains <<SCORE>> literally", "<<SCORE>>": "0.9"},
-    )
-    assert result == "text: contains <<SCORE>> literally, score: 0.9"
-
-
-def test_render_template_unmatched_placeholder_leave_as_is() -> None:
-    assert render_template("<<A>> and <<B>>", {"<<A>>": "X"}) == "X and <<B>>"
-
-
-def test_render_template_empty_replacements() -> None:
-    assert render_template("no placeholders", {}) == "no placeholders"
-
 
 # ---------------------------------------------------------------------------
 # field

--- a/tests/engine/test_prompt_utils.py
+++ b/tests/engine/test_prompt_utils.py
@@ -31,6 +31,16 @@ def test_no_cross_contamination() -> None:
     assert result == "text: contains <<SCORE>> literally, score: 0.9"
 
 
+def test_repeated_placeholder() -> None:
+    result = substitute_placeholders("<<X>> and <<X>>", {"<<X>>": "Y"})
+    assert result == "Y and Y"
+
+
+def test_empty_replacement_value() -> None:
+    result = substitute_placeholders("a<<X>>b", {"<<X>>": ""})
+    assert result == "ab"
+
+
 def test_empty_replacements_no_placeholders() -> None:
     assert substitute_placeholders("no placeholders", {}) == "no placeholders"
 

--- a/tests/engine/test_prompt_utils.py
+++ b/tests/engine/test_prompt_utils.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from anonymizer.engine.prompt_utils import substitute_placeholders
+
+# ---------------------------------------------------------------------------
+# Basic substitution
+# ---------------------------------------------------------------------------
+
+
+def test_basic_substitution() -> None:
+    assert substitute_placeholders("Hello <<NAME>>!", {"<<NAME>>": "Alice"}) == "Hello Alice!"
+
+
+def test_multiple_placeholders() -> None:
+    result = substitute_placeholders("<<A>> and <<B>>", {"<<A>>": "X", "<<B>>": "Y"})
+    assert result == "X and Y"
+
+
+def test_no_cross_contamination() -> None:
+    result = substitute_placeholders(
+        "text: <<TEXT>>, score: <<SCORE>>",
+        {"<<TEXT>>": "contains <<SCORE>> literally", "<<SCORE>>": "0.9"},
+    )
+    assert result == "text: contains <<SCORE>> literally, score: 0.9"
+
+
+def test_empty_replacements_no_placeholders() -> None:
+    assert substitute_placeholders("no placeholders", {}) == "no placeholders"
+
+
+# ---------------------------------------------------------------------------
+# Strict mode (default)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_raises_on_malformed_keys() -> None:
+    with pytest.raises(ValueError, match="must use <<\\.\\.\\.>> format"):
+        substitute_placeholders("some text", {"TEXT": "value"})
+
+
+def test_strict_raises_on_unresolved_placeholders() -> None:
+    with pytest.raises(ValueError, match="Unresolved placeholders"):
+        substitute_placeholders("<<A>> and <<B>>", {"<<A>>": "X"})
+
+
+def test_strict_raises_on_unresolved_with_empty_replacements() -> None:
+    with pytest.raises(ValueError, match="Unresolved placeholders"):
+        substitute_placeholders("<<A>> is here", {})
+
+
+def test_strict_warns_on_unused_keys(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="anonymizer.prompt_utils"):
+        result = substitute_placeholders("just <<A>>", {"<<A>>": "X", "<<B>>": "unused"})
+    assert result == "just X"
+    assert "<<B>>" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Non-strict mode
+# ---------------------------------------------------------------------------
+
+
+def test_non_strict_leaves_unresolved() -> None:
+    result = substitute_placeholders("<<A>> and <<B>>", {"<<A>>": "X"}, strict=False)
+    assert result == "X and <<B>>"
+
+
+def test_non_strict_allows_malformed_keys() -> None:
+    result = substitute_placeholders("hello world", {"world": "earth"}, strict=False)
+    assert result == "hello earth"
+
+
+def test_non_strict_empty_replacements() -> None:
+    assert substitute_placeholders("<<A>>", {}, strict=False) == "<<A>>"


### PR DESCRIPTION
## Summary

- Extracts `render_template` from `rewrite/parsers.py` into a shared `engine/prompt_utils.py` module, renamed to `substitute_placeholders`
- Uses single-pass regex substitution to prevent cross-contamination when user-controlled text contains placeholder tokens (e.g. `<<SCORE>>` appearing in a replacement value won't be double-substituted)
- Adds strict mode (default) that raises `ValueError` on malformed keys and unresolved placeholders, and warns on unused keys
- Migrates all 12 prompt-building functions across `detection/`, `replace/`, and `rewrite/` modules

Closes #66

## Changes

| File | Summary |
|------|---------|
| `engine/prompt_utils.py` (new) | `substitute_placeholders()` with strict/non-strict modes |
| `tests/engine/test_prompt_utils.py` (new) | 11 tests: basic substitution, cross-contamination, strict mode, non-strict mode |
| `detection/detection_workflow.py` | 3 prompt functions migrated |
| `replace/llm_replace_workflow.py` | 1 prompt function migrated |
| `rewrite/domain_classification.py` | `.replace()` chain -> `substitute_placeholders()` |
| `rewrite/evaluate.py` | import swap |
| `rewrite/final_judge.py` | import swap |
| `rewrite/parsers.py` | Removed `render_template` and unused `import re` |
| `rewrite/qa_generation.py` | 2 prompt functions migrated |
| `rewrite/repair.py` | import swap |
| `rewrite/rewrite_generation.py` | 1 prompt function migrated |
| `rewrite/sensitivity_disposition.py` | `.replace()` chain -> `substitute_placeholders()` |
| `tests/engine/test_parsers.py` | Removed `render_template` tests (moved to test_prompt_utils) |

## Test plan

- [x] All 500 existing tests pass
- [x] 11 new tests for `substitute_placeholders` covering basic substitution, cross-contamination prevention, strict mode validation, and non-strict fallback
- [x] `ruff format` and `ruff check` pass