### PR TITLE
refactor: simplify rewrite config and rename risk tolerance levels

### DIFF
--- a/src/anonymizer/__init__.py
+++ b/src/anonymizer/__init__.py
@@ -7,7 +7,7 @@ from importlib.metadata import version
 
 __version__ = version("nemo-anonymizer")
 
-from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Detect, Rewrite
+from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Detect, Rewrite, RiskTolerance
 from anonymizer.config.replace_strategies import Annotate, Hash, Redact, Substitute
 from anonymizer.engine.constants import DEFAULT_ENTITY_LABELS as _DEFAULT_ENTITY_LABELS
 from anonymizer.interface.anonymizer import Anonymizer
@@ -38,6 +38,7 @@ __all__ = [
     "LoggingConfig",
     "Redact",
     "Rewrite",
+    "RiskTolerance",
     "Substitute",
     "configure_logging",
 ]

--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -14,6 +14,7 @@ from anonymizer.config.rewrite import (
     DEFAULT_PROTECT_TEXT,
     EvaluationCriteria,
     PrivacyGoal,
+    RiskTolerance,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,9 +80,14 @@ class Rewrite(BaseModel):
     )
     instructions: str | None = Field(default=None, description="Additional instructions for the rewrite LLM.")
     skip_low_sensitivity_pii: bool = Field(default=False, description="Skip low-sensitivity PII during rewrite.")
-    evaluation: EvaluationCriteria = Field(
-        default_factory=EvaluationCriteria,
-        description="Criteria and thresholds for privacy leakage and utility scoring.",
+    risk_tolerance: RiskTolerance = Field(
+        default=RiskTolerance.low,
+        description="Preset controlling repair thresholds and review flagging.",
+    )
+    max_repair_iterations: int = Field(
+        default=2,
+        ge=0,
+        description="Maximum repair rounds. Set to 0 to disable repair.",
     )
 
     @model_validator(mode="after")
@@ -93,13 +99,22 @@ class Rewrite(BaseModel):
             )
         return self
 
+    @property
+    def evaluation(self) -> EvaluationCriteria:
+        """Internal: construct EvaluationCriteria for the engine."""
+        return EvaluationCriteria(
+            risk_tolerance=self.risk_tolerance,
+            max_repair_iterations=self.max_repair_iterations,
+        )
+
 
 class AnonymizerConfig(BaseModel):
     """Primary user-facing config for anonymization behavior."""
 
     detect: Detect = Field(default_factory=Detect, description="Entity detection configuration.")
     replace: ReplaceMethod | None = Field(
-        default=None, description="Replacement method (Redact(), Annotate(), Hash(), or Substitute())."
+        default=None,
+        description="Replacement method (Substitute(), Redact(), Annotate(), or Hash()).",
     )
     rewrite: Rewrite | None = Field(default=None, description="Optional rewrite-mode parameters. ")
 

--- a/src/anonymizer/config/rewrite.py
+++ b/src/anonymizer/config/rewrite.py
@@ -1,46 +1,33 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# This file is forward looking, and will support future rewrite mode.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 
 from pydantic import BaseModel, Field, field_validator
 
 
 class RiskTolerance(str, Enum):
-    """Risk tolerance presets for leakage mass thresholds."""
+    """Risk tolerance presets for leakage mass thresholds.
 
-    strict = "strict"
-    conservative = "conservative"
+    Each preset bundles a coherent set of repair and review thresholds:
+
+    - **minimal** — Tight leakage threshold (0.6), flags for review aggressively.
+      Good for medical, legal, and financial data.
+    - **low** — Default. Moderate leakage threshold (1.0).
+      Good for most privacy-sensitive data.
+    - **moderate** — Relaxed leakage threshold (1.5), lower review bar.
+    - **high** — High leakage threshold (2.0), does not auto-repair
+      individual high-sensitivity leaks.
+    """
+
+    minimal = "minimal"
+    low = "low"
     moderate = "moderate"
-    permissive = "permissive"
+    high = "high"
 
-
-RISK_TOLERANCE_THRESHOLDS: dict[RiskTolerance, float] = {
-    RiskTolerance.strict: 0.6,
-    RiskTolerance.conservative: 1.0,
-    RiskTolerance.moderate: 1.5,
-    RiskTolerance.permissive: 2.0,
-}
-
-DOMAIN_RISK_TOLERANCE: dict[str, RiskTolerance] = {
-    "medical": RiskTolerance.strict,
-    "clinical": RiskTolerance.strict,
-    "healthcare": RiskTolerance.strict,
-    "legal": RiskTolerance.strict,
-    "financial": RiskTolerance.strict,
-    "banking": RiskTolerance.strict,
-    "insurance": RiskTolerance.strict,
-    "hr": RiskTolerance.conservative,
-    "human_resources": RiskTolerance.conservative,
-    "education": RiskTolerance.conservative,
-    "customer_service": RiskTolerance.conservative,
-    "general": RiskTolerance.moderate,
-    "social_media": RiskTolerance.permissive,
-    "entertainment": RiskTolerance.permissive,
-}
 
 SENSITIVITY_WEIGHTS: dict[str, float] = {
     "high": 1.0,
@@ -52,6 +39,44 @@ DEFAULT_PROTECT_TEXT = (
     "Direct identifiers, quasi-identifier combinations, and latent inferences that could enable re-identification"
 )
 DEFAULT_PRESERVE_TEXT = "General utility, content quality, and semantic meaning of the original text"
+
+
+@dataclass(frozen=True)
+class _RiskToleranceBundle:
+    """Internal: all derived evaluation parameters for a risk_tolerance preset."""
+
+    repair_threshold: float
+    repair_any_high_leak: bool
+    flag_utility_below: float
+    flag_leakage_above: float
+
+
+_RISK_TOLERANCE_BUNDLES: dict[RiskTolerance, _RiskToleranceBundle] = {
+    RiskTolerance.minimal: _RiskToleranceBundle(
+        repair_threshold=0.6,
+        repair_any_high_leak=True,
+        flag_utility_below=0.6,
+        flag_leakage_above=1.0,
+    ),
+    RiskTolerance.low: _RiskToleranceBundle(
+        repair_threshold=1.0,
+        repair_any_high_leak=True,
+        flag_utility_below=0.5,
+        flag_leakage_above=2.0,
+    ),
+    RiskTolerance.moderate: _RiskToleranceBundle(
+        repair_threshold=1.5,
+        repair_any_high_leak=True,
+        flag_utility_below=0.4,
+        flag_leakage_above=2.5,
+    ),
+    RiskTolerance.high: _RiskToleranceBundle(
+        repair_threshold=2.0,
+        repair_any_high_leak=False,
+        flag_utility_below=0.3,
+        flag_leakage_above=3.0,
+    ),
+}
 
 
 class PrivacyGoal(BaseModel):
@@ -78,43 +103,53 @@ class PrivacyGoal(BaseModel):
 
 
 class EvaluationCriteria(BaseModel):
-    """Criteria and thresholds for privacy leakage and utility scoring."""
+    """Criteria for privacy leakage evaluation and repair.
 
-    risk_tolerance: RiskTolerance = RiskTolerance.conservative
-    max_leakage_mass: float | None = Field(default=None, ge=0.0)
-    auto_adjust_by_domain: bool = False
+    ``risk_tolerance`` controls the leakage threshold that triggers repair,
+    whether individual high-sensitivity leaks trigger repair, and the
+    thresholds for flagging records for human review. See ``RiskTolerance``
+    for preset descriptions.
 
-    repair_any_high_leak: bool = True
-    max_repair_iterations: int = Field(default=2, ge=0)
-    auto_repair_privacy: bool = True
+    ``max_repair_iterations`` caps how many repair rounds are attempted
+    (each round = one LLM call per failing row). Set to 0 to disable repair
+    while still producing evaluation metrics.
+    """
 
-    flag_utility_below: float | None = Field(default=0.50, ge=0.0, le=1.0)
-    flag_leakage_mass_above: float | None = Field(default=2.0, ge=0.0)
-    sensitivity_weights: dict[str, float] = Field(default_factory=lambda: dict(SENSITIVITY_WEIGHTS))
+    risk_tolerance: RiskTolerance = Field(
+        default=RiskTolerance.low,
+        description="Preset controlling repair and review thresholds.",
+    )
+    max_repair_iterations: int = Field(
+        default=2,
+        ge=0,
+        description="Maximum repair rounds. Set to 0 to disable repair.",
+    )
 
-    @field_validator("sensitivity_weights")
-    @classmethod
-    def validate_sensitivity_weights(cls, value: dict[str, float]) -> dict[str, float]:
-        required_levels = {"high", "medium", "low"}
-        missing_levels = required_levels - set(value.keys())
-        if missing_levels:
-            missing = ", ".join(sorted(missing_levels))
-            raise ValueError(f"sensitivity_weights is missing required levels: {missing}")
+    @property
+    def _bundle(self) -> _RiskToleranceBundle:
+        return _RISK_TOLERANCE_BUNDLES[self.risk_tolerance]
 
-        negative_weights = [level for level, weight in value.items() if weight < 0]
-        if negative_weights:
-            labels = ", ".join(sorted(negative_weights))
-            raise ValueError(f"sensitivity_weights must be non-negative for all levels, invalid: {labels}")
-        return value
+    @property
+    def repair_threshold(self) -> float:
+        """Leakage mass above which a row is sent for repair."""
+        return self._bundle.repair_threshold
 
-    def get_effective_threshold(self, domain: str | None = None) -> float:
-        """Return the effective leakage-mass threshold for a run."""
-        if self.max_leakage_mass is not None:
-            return self.max_leakage_mass
+    @property
+    def repair_any_high_leak(self) -> bool:
+        """Whether any single high-sensitivity leak triggers repair."""
+        return self._bundle.repair_any_high_leak
 
-        if self.auto_adjust_by_domain and domain:
-            domain_key = domain.lower().replace(" ", "_").replace("-", "_")
-            domain_tolerance = DOMAIN_RISK_TOLERANCE.get(domain_key, RiskTolerance.moderate)
-            return RISK_TOLERANCE_THRESHOLDS[domain_tolerance]
+    @property
+    def flag_utility_below(self) -> float:
+        """Flag for human review if utility score is below this."""
+        return self._bundle.flag_utility_below
 
-        return RISK_TOLERANCE_THRESHOLDS[self.risk_tolerance]
+    @property
+    def flag_leakage_above(self) -> float:
+        """Flag for human review if leakage mass exceeds this."""
+        return self._bundle.flag_leakage_above
+
+    @property
+    def sensitivity_weights(self) -> dict[str, float]:
+        """Weights for high/medium/low sensitivity levels in leakage mass computation."""
+        return dict(SENSITIVITY_WEIGHTS)

--- a/src/anonymizer/engine/rewrite/evaluate.py
+++ b/src/anonymizer/engine/rewrite/evaluate.py
@@ -60,7 +60,6 @@ class MetricsParams(BaseModel):
 
 
 class RepairNeedsParams(BaseModel):
-    auto_repair_privacy: bool
     repair_any_high_leak: bool
     effective_threshold: float
 
@@ -380,13 +379,10 @@ def determine_repair_needs(
     *,
     any_high_leaked: bool,
     leakage_mass: float,
-    auto_repair_privacy: bool,
     repair_any_high_leak: bool,
     effective_threshold: float,
 ) -> bool:
     """Decide whether a single row needs repair."""
-    if not auto_repair_privacy:
-        return False
     if repair_any_high_leak and any_high_leaked:
         return True
     return leakage_mass > effective_threshold
@@ -485,7 +481,6 @@ def _determine_repair_needs_column(row: dict[str, Any], generator_params: Repair
     row[COL_NEEDS_REPAIR] = determine_repair_needs(
         any_high_leaked=bool(row.get(COL_ANY_HIGH_LEAKED, False)),
         leakage_mass=float(row.get(COL_LEAKAGE_MASS, 0.0)),
-        auto_repair_privacy=generator_params.auto_repair_privacy,
         repair_any_high_leak=generator_params.repair_any_high_leak,
         effective_threshold=generator_params.effective_threshold,
     )
@@ -519,10 +514,8 @@ class EvaluateWorkflow:
         *,
         selected_models: RewriteModelSelection,
         evaluation: EvaluationCriteria,
-        domain: str | None = None,
     ) -> list[ColumnConfigT]:
         evaluator_alias = resolve_model_alias("evaluator", selected_models)
-        effective_threshold = evaluation.get_effective_threshold(domain)
 
         return [
             # Step 1 -- Quality re-answer (LLM with context-validated parser)
@@ -551,9 +544,8 @@ class EvaluateWorkflow:
                 name=COL_NEEDS_REPAIR,
                 generator_function=_determine_repair_needs_column,
                 generator_params=RepairNeedsParams(
-                    auto_repair_privacy=evaluation.auto_repair_privacy,
                     repair_any_high_leak=evaluation.repair_any_high_leak,
-                    effective_threshold=effective_threshold,
+                    effective_threshold=evaluation.repair_threshold,
                 ),
             ),
         ]

--- a/src/anonymizer/engine/rewrite/final_judge.py
+++ b/src/anonymizer/engine/rewrite/final_judge.py
@@ -32,7 +32,7 @@ from anonymizer.engine.rewrite.parsers import render_template
 
 class HumanReviewParams(BaseModel):
     flag_utility_below: float | None
-    flag_leakage_mass_above: float | None
+    flag_leakage_above: float | None
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +161,8 @@ def _determine_needs_human_review(row: dict[str, Any], generator_params: HumanRe
             row[COL_NEEDS_HUMAN_REVIEW] = True
             return row
 
-    if generator_params.flag_leakage_mass_above is not None:
-        if float(row[COL_LEAKAGE_MASS]) > generator_params.flag_leakage_mass_above:
+    if generator_params.flag_leakage_above is not None:
+        if float(row[COL_LEAKAGE_MASS]) > generator_params.flag_leakage_above:
             row[COL_NEEDS_HUMAN_REVIEW] = True
             return row
 
@@ -260,7 +260,7 @@ class FinalJudgeWorkflow:
                 generator_function=_determine_needs_human_review,
                 generator_params=HumanReviewParams(
                     flag_utility_below=evaluation.flag_utility_below,
-                    flag_leakage_mass_above=evaluation.flag_leakage_mass_above,
+                    flag_leakage_above=evaluation.flag_leakage_above,
                 ),
             ),
         ]

--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -13,7 +13,6 @@ from anonymizer.config.models import ReplaceModelSelection, RewriteModelSelectio
 from anonymizer.config.rewrite import EvaluationCriteria, PrivacyGoal
 from anonymizer.engine.constants import (
     COL_ANY_HIGH_LEAKED,
-    COL_DOMAIN,
     COL_ENTITIES_BY_VALUE,
     COL_JUDGE_EVALUATION,
     COL_LEAKAGE_MASS,
@@ -244,14 +243,12 @@ class RewriteWorkflow:
         all_failed.extend(pipeline_result.failed_records)
 
         # --- Step 5: evaluate-repair loop ---
-        domain = self._extract_domain(entity_rows)
         entity_rows, eval_repair_failed = self._run_evaluate_repair_loop(
             entity_rows,
             model_configs=model_configs,
             selected_models=selected_models,
             privacy_goal=privacy_goal,
             evaluation=evaluation,
-            domain=domain,
             preview_num_records=preview_num_records,
         )
         all_failed.extend(eval_repair_failed)
@@ -284,11 +281,9 @@ class RewriteWorkflow:
         selected_models: RewriteModelSelection,
         privacy_goal: PrivacyGoal,
         evaluation: EvaluationCriteria,
-        domain: str | None,
         preview_num_records: int | None,
     ) -> tuple[pd.DataFrame, list[FailedRecord]]:
         all_failed: list[FailedRecord] = []
-        effective_threshold = evaluation.get_effective_threshold(domain)
 
         if COL_REPAIR_ITERATIONS not in df.columns:
             df[COL_REPAIR_ITERATIONS] = 0
@@ -296,7 +291,6 @@ class RewriteWorkflow:
         eval_columns = self._evaluate_wf.columns(
             selected_models=selected_models,
             evaluation=evaluation,
-            domain=domain,
         )
         eval_seed_cols = derive_seed_columns(eval_columns, df)
 
@@ -315,7 +309,7 @@ class RewriteWorkflow:
         repair_columns = self._repair_wf.columns(
             selected_models=selected_models,
             privacy_goal=privacy_goal,
-            effective_threshold=effective_threshold,
+            effective_threshold=evaluation.repair_threshold,
         )
 
         for iteration in range(evaluation.max_repair_iterations):
@@ -406,34 +400,3 @@ class RewriteWorkflow:
             df[COL_JUDGE_EVALUATION] = None
             df[COL_NEEDS_HUMAN_REVIEW] = True
             return df, []
-
-    # ---------------------------------------------------------------------------
-    # Helpers
-    # ---------------------------------------------------------------------------
-
-    @staticmethod
-    def _extract_domain(df: pd.DataFrame) -> str | None:
-        """Extract the most common domain from the domain classification column, if present."""
-        if COL_DOMAIN not in df.columns:
-            return None
-        try:
-            domains = (
-                df[COL_DOMAIN]
-                .dropna()
-                .apply(
-                    lambda raw: (
-                        str(raw.domain)
-                        if hasattr(raw, "domain")
-                        else str(raw.get("domain", ""))
-                        if isinstance(raw, dict)
-                        else str(raw)
-                    )
-                )
-            )
-            domains = domains[domains != ""]
-            if domains.empty:
-                return None
-            return str(domains.mode().iloc[0])
-        except Exception:
-            logger.debug("Could not extract domain from COL_DOMAIN", exc_info=True)
-            return None

--- a/tests/config/test_rewrite.py
+++ b/tests/config/test_rewrite.py
@@ -49,68 +49,49 @@ def test_privacy_goal_to_prompt_string() -> None:
     assert "PRESERVE:" in prompt
 
 
-def test_effective_threshold_uses_manual_when_set() -> None:
-    criteria = EvaluationCriteria(max_leakage_mass=1.3)
-    assert criteria.get_effective_threshold(domain="medical") == 1.3
-
-
-def test_effective_threshold_uses_risk_tolerance_default() -> None:
-    criteria = EvaluationCriteria(risk_tolerance=RiskTolerance.strict)
-    assert criteria.get_effective_threshold() == 0.6
+# ---------------------------------------------------------------------------
+# EvaluationCriteria: risk_tolerance presets
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "tolerance,expected",
+    "tolerance,expected_threshold",
     [
-        (RiskTolerance.strict, 0.6),
-        (RiskTolerance.conservative, 1.0),
+        (RiskTolerance.minimal, 0.6),
+        (RiskTolerance.low, 1.0),
         (RiskTolerance.moderate, 1.5),
-        (RiskTolerance.permissive, 2.0),
+        (RiskTolerance.high, 2.0),
     ],
 )
-def test_effective_threshold_per_tolerance(tolerance: RiskTolerance, expected: float) -> None:
+def test_repair_threshold_per_tolerance(tolerance: RiskTolerance, expected_threshold: float) -> None:
     criteria = EvaluationCriteria(risk_tolerance=tolerance)
-    assert criteria.get_effective_threshold() == expected
+    assert criteria.repair_threshold == expected_threshold
 
 
-def test_effective_threshold_auto_adjust_by_domain() -> None:
-    criteria = EvaluationCriteria(auto_adjust_by_domain=True)
-    assert criteria.get_effective_threshold(domain="medical") == 0.6  # strict
-    assert criteria.get_effective_threshold(domain="social_media") == 2.0  # permissive
+def test_default_is_low() -> None:
+    criteria = EvaluationCriteria()
+    assert criteria.risk_tolerance == RiskTolerance.low
+    assert criteria.repair_threshold == 1.0
+    assert criteria.max_repair_iterations == 2
 
 
-def test_effective_threshold_auto_adjust_unknown_domain_defaults_to_moderate() -> None:
-    criteria = EvaluationCriteria(auto_adjust_by_domain=True)
-    assert criteria.get_effective_threshold(domain="unknown_domain") == 1.5
+def test_minimal_bundles_aggressive_review_flags() -> None:
+    criteria = EvaluationCriteria(risk_tolerance=RiskTolerance.minimal)
+    assert criteria.flag_utility_below == 0.6
+    assert criteria.flag_leakage_above == 1.0
+    assert criteria.repair_any_high_leak is True
 
 
-def test_effective_threshold_auto_adjust_normalizes_domain_string() -> None:
-    """Hyphens, spaces, and case should be normalized."""
-    criteria = EvaluationCriteria(auto_adjust_by_domain=True)
-    assert criteria.get_effective_threshold(domain="Human Resources") == 1.0  # conservative
-    assert criteria.get_effective_threshold(domain="MEDICAL") == 0.6
+def test_high_does_not_repair_individual_high_leaks() -> None:
+    criteria = EvaluationCriteria(risk_tolerance=RiskTolerance.high)
+    assert criteria.repair_any_high_leak is False
 
 
-def test_effective_threshold_auto_adjust_ignored_without_domain() -> None:
-    criteria = EvaluationCriteria(auto_adjust_by_domain=True, risk_tolerance=RiskTolerance.permissive)
-    assert criteria.get_effective_threshold(domain=None) == 2.0
-
-
-def test_effective_threshold_manual_overrides_auto_adjust() -> None:
-    criteria = EvaluationCriteria(max_leakage_mass=0.8, auto_adjust_by_domain=True)
-    assert criteria.get_effective_threshold(domain="medical") == 0.8
-
-
-def test_sensitivity_weights_defaults() -> None:
+def test_sensitivity_weights_have_required_keys() -> None:
     criteria = EvaluationCriteria()
     assert set(criteria.sensitivity_weights.keys()) == {"high", "medium", "low"}
 
 
-def test_sensitivity_weights_rejects_missing_level() -> None:
-    with pytest.raises(ValueError, match="missing required levels"):
-        EvaluationCriteria(sensitivity_weights={"high": 1.0, "medium": 0.6})
-
-
-def test_sensitivity_weights_rejects_negative() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
-        EvaluationCriteria(sensitivity_weights={"high": 1.0, "medium": -0.5, "low": 0.3})
+def test_max_repair_iterations_rejects_negative() -> None:
+    with pytest.raises(ValueError):
+        EvaluationCriteria(max_repair_iterations=-1)

--- a/tests/engine/test_evaluate.py
+++ b/tests/engine/test_evaluate.py
@@ -181,7 +181,6 @@ class TestDetermineRepairNeeds:
         assert determine_repair_needs(
             any_high_leaked=True,
             leakage_mass=0.0,
-            auto_repair_privacy=True,
             repair_any_high_leak=True,
             effective_threshold=1.0,
         )
@@ -190,7 +189,6 @@ class TestDetermineRepairNeeds:
         assert determine_repair_needs(
             any_high_leaked=False,
             leakage_mass=1.5,
-            auto_repair_privacy=True,
             repair_any_high_leak=True,
             effective_threshold=1.0,
         )
@@ -199,16 +197,6 @@ class TestDetermineRepairNeeds:
         assert not determine_repair_needs(
             any_high_leaked=False,
             leakage_mass=0.3,
-            auto_repair_privacy=True,
-            repair_any_high_leak=True,
-            effective_threshold=1.0,
-        )
-
-    def test_auto_repair_disabled(self) -> None:
-        assert not determine_repair_needs(
-            any_high_leaked=True,
-            leakage_mass=5.0,
-            auto_repair_privacy=False,
             repair_any_high_leak=True,
             effective_threshold=1.0,
         )
@@ -217,26 +205,26 @@ class TestDetermineRepairNeeds:
         assert not determine_repair_needs(
             any_high_leaked=True,
             leakage_mass=0.3,
-            auto_repair_privacy=True,
             repair_any_high_leak=False,
             effective_threshold=1.0,
         )
 
-    def test_domain_adjusts_threshold(self) -> None:
-        evaluation = EvaluationCriteria(auto_adjust_by_domain=True, repair_any_high_leak=False)
+    def test_threshold_from_minimal_preset(self) -> None:
+        evaluation = EvaluationCriteria(risk_tolerance="minimal")
         assert determine_repair_needs(
             any_high_leaked=False,
             leakage_mass=0.8,
-            auto_repair_privacy=True,
-            repair_any_high_leak=False,
-            effective_threshold=evaluation.get_effective_threshold("medical"),
+            repair_any_high_leak=evaluation.repair_any_high_leak,
+            effective_threshold=evaluation.repair_threshold,
         )
+
+    def test_threshold_from_high_preset(self) -> None:
+        evaluation = EvaluationCriteria(risk_tolerance="high")
         assert not determine_repair_needs(
             any_high_leaked=False,
             leakage_mass=0.8,
-            auto_repair_privacy=True,
-            repair_any_high_leak=False,
-            effective_threshold=evaluation.get_effective_threshold("social_media"),
+            repair_any_high_leak=evaluation.repair_any_high_leak,
+            effective_threshold=evaluation.repair_threshold,
         )
 
 

--- a/tests/engine/test_final_judge.py
+++ b/tests/engine/test_final_judge.py
@@ -128,7 +128,7 @@ def test_needs_human_review_column_uses_evaluation_thresholds(
     stub_rewrite_model_selection: RewriteModelSelection,
 ) -> None:
     wf = FinalJudgeWorkflow()
-    evaluation = EvaluationCriteria(flag_utility_below=0.6, flag_leakage_mass_above=1.5)
+    evaluation = EvaluationCriteria(risk_tolerance="minimal")
     cols = wf.columns(
         selected_models=stub_rewrite_model_selection,
         privacy_goal=_STUB_PRIVACY_GOAL,
@@ -137,7 +137,7 @@ def test_needs_human_review_column_uses_evaluation_thresholds(
     custom_col = next(c for c in cols if isinstance(c, CustomColumnConfig))
     params = HumanReviewParams.model_validate(custom_col.generator_params)
     assert params.flag_utility_below == 0.6
-    assert params.flag_leakage_mass_above == 1.5
+    assert params.flag_leakage_above == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -161,69 +161,69 @@ def _make_row(
 
 def test_needs_human_review_flags_none_rewrite() -> None:
     row = _make_row(rewritten_text=None)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is True
 
 
 def test_needs_human_review_flags_low_utility() -> None:
     row = _make_row(utility_score=0.3)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is True
 
 
 def test_needs_human_review_flags_high_leakage() -> None:
     row = _make_row(leakage_mass=3.0)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is True
 
 
 def test_needs_human_review_flags_any_high_leaked() -> None:
     row = _make_row(any_high_leaked=True)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is True
 
 
 def test_needs_human_review_false_when_all_good() -> None:
     row = _make_row(utility_score=0.8, leakage_mass=0.5, any_high_leaked=False)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is False
 
 
 def test_needs_human_review_none_thresholds_skip_checks() -> None:
     row = _make_row(utility_score=0.1, leakage_mass=10.0)
-    params = HumanReviewParams(flag_utility_below=None, flag_leakage_mass_above=None)
+    params = HumanReviewParams(flag_utility_below=None, flag_leakage_above=None)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is False
 
 
 def test_needs_human_review_exact_threshold_utility() -> None:
     row = _make_row(utility_score=0.50)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is False
 
 
 def test_needs_human_review_exact_threshold_leakage() -> None:
     row = _make_row(leakage_mass=2.0)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     result = _determine_needs_human_review(row, generator_params=params)
     assert result[COL_NEEDS_HUMAN_REVIEW] is False
 
 
 def test_needs_human_review_raises_on_invalid_utility_score() -> None:
     row = _make_row(utility_score=None)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     with pytest.raises(TypeError):
         _determine_needs_human_review(row, generator_params=params)
 
 
 def test_needs_human_review_raises_on_invalid_leakage_mass() -> None:
     row = _make_row(leakage_mass=None)
-    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_mass_above=2.0)
+    params = HumanReviewParams(flag_utility_below=0.50, flag_leakage_above=2.0)
     with pytest.raises(TypeError):
         _determine_needs_human_review(row, generator_params=params)

--- a/tests/engine/test_rewrite_workflow.py
+++ b/tests/engine/test_rewrite_workflow.py
@@ -257,11 +257,6 @@ def test_has_entities_returns_false_for_none() -> None:
     assert _has_entities(None) is False
 
 
-def test_extract_domain_accepts_dict_payloads() -> None:
-    df = pd.DataFrame({COL_DOMAIN: [{"domain": "medical", "domain_confidence": 0.9}, {"domain": "medical"}]})
-    assert RewriteWorkflow._extract_domain(df) == "medical"
-
-
 # ---------------------------------------------------------------------------
 # Tests: full pipeline call order
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Simplify the user-facing rewrite config and rename risk tolerance levels for clarity.

### Config simplification

`risk_tolerance` and `max_repair_iterations` are now top-level fields on `Rewrite` instead of nested inside `EvaluationCriteria`:

```python
# Before
config = AnonymizerConfig(rewrite=Rewrite(
    evaluation=EvaluationCriteria(risk_tolerance=RiskTolerance.strict, max_repair_iterations=3)
))

# After
config = AnonymizerConfig(rewrite=Rewrite(risk_tolerance="minimal", max_repair_iterations=3))
```

### Risk tolerance rename

Enum values renamed to read naturally as tolerance levels:

| Old | New | Threshold |
|-----|-----|-----------|
| `strict` | `minimal` | 0.6 |
| `conservative` | `low` (default) | 1.0 |
| `moderate` | `moderate` | 1.5 |
| `permissive` | `high` | 2.0 |

### What changed per file

**`src/anonymizer/config/rewrite.py`**
- Rename enum values (`strict→minimal`, `conservative→low`, `permissive→high`)
- Replace flat `RISK_TOLERANCE_THRESHOLDS` dict and `DOMAIN_RISK_TOLERANCE` dict with `_RiskToleranceBundle` dataclass bundling all thresholds per preset
- Add `_RISK_TOLERANCE_BUNDLES` mapping
- `EvaluationCriteria`: remove `auto_repair_privacy`, `auto_adjust_by_domain`, `max_leakage_mass`, `flag_leakage_mass_above`, `get_effective_threshold()`. Add derived properties (`repair_threshold`, `repair_any_high_leak`, `flag_utility_below`, `flag_leakage_above`) from bundle
- Default changes from `conservative` to `low` (same numeric thresholds)

**`src/anonymizer/config/anonymizer_config.py`**
- `Rewrite`: replace `evaluation: EvaluationCriteria` field with top-level `risk_tolerance` and `max_repair_iterations` fields
- Add `Rewrite.evaluation` property that constructs `EvaluationCriteria` internally
- Re-export `RiskTolerance`

**`src/anonymizer/__init__.py`**
- Export `RiskTolerance` from top-level package

**`src/anonymizer/engine/rewrite/evaluate.py`**
- Remove `auto_repair_privacy` from `RepairNeedsParams` and `determine_repair_needs()`
- Remove `domain` param from `EvaluateWorkflow.columns()`
- Use `evaluation.repair_threshold` directly instead of `get_effective_threshold(domain)`

**`src/anonymizer/engine/rewrite/final_judge.py`**
- Rename `flag_leakage_mass_above` → `flag_leakage_above` in `HumanReviewParams` and usage

**`src/anonymizer/engine/rewrite/rewrite_workflow.py`**
- Remove `_extract_domain()` helper and `domain` plumbing through the evaluate-repair loop
- Use `evaluation.repair_threshold` directly

**Tests**: updated to match new enum values and removed params

## Test plan

- [x] 78 unit tests pass (config, evaluate, final judge, rewrite workflow)