### PR TITLE
docs: update notebook csv inputs

### DIFF
--- a/docs/notebook_source/01_your_first_anonymization.py
+++ b/docs/notebook_source/01_your_first_anonymization.py
@@ -65,7 +65,7 @@ anonymizer = Anonymizer()
 
 # %%
 input_data = AnonymizerInput(
-    source="../data/NVIDIA_synthetic_biographies.csv",
+    source="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv",
     text_column="biography",
     data_summary="Biographical profiles of individuals",
 )

--- a/docs/notebook_source/02_inspecting_detected_entities.py
+++ b/docs/notebook_source/02_inspecting_detected_entities.py
@@ -74,7 +74,7 @@ anonymizer = Anonymizer()
 config = AnonymizerConfig(replace=Annotate())
 
 input_data = AnonymizerInput(
-    source="../data/NVIDIA_synthetic_biographies.csv",
+    source="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv",
     text_column="biography",
     data_summary="Biographical profiles",
 )

--- a/docs/notebook_source/03_choosing_a_replacement_strategy.py
+++ b/docs/notebook_source/03_choosing_a_replacement_strategy.py
@@ -66,7 +66,7 @@ anonymizer = Anonymizer()
 
 # %%
 input_data = AnonymizerInput(
-    source="../data/NVIDIA_synthetic_biographies.csv",
+    source="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv",
     text_column="biography",
     data_summary="Biographical profiles",
 )

--- a/docs/notebook_source/04_rewriting_biographies.py
+++ b/docs/notebook_source/04_rewriting_biographies.py
@@ -71,7 +71,7 @@ anonymizer = Anonymizer()
 
 # %%
 input_data = AnonymizerInput(
-    source="../data/NVIDIA_synthetic_biographies.csv",
+    source="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv",
     text_column="biography",
     data_summary="Biographical profiles",
 )

--- a/docs/notebook_source/05_rewriting_legal_documents.py
+++ b/docs/notebook_source/05_rewriting_legal_documents.py
@@ -96,7 +96,7 @@ LEGAL_ENTITY_LABELS = [
 ]
 
 input_data = AnonymizerInput(
-    source="../data/TAB_legal_sample25.csv",
+    source="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/TAB_legal_sample25.csv",
     text_column="text",
     data_summary="Legal court decisions containing personal identifiers, case numbers, and institutional references",
 )

--- a/docs/notebooks/01_your_first_anonymization.ipynb
+++ b/docs/notebooks/01_your_first_anonymization.ipynb
@@ -151,7 +151,7 @@
    "outputs": [],
    "source": [
     "input_data = AnonymizerInput(\n",
-    "    source=\"../data/NVIDIA_synthetic_biographies.csv\",\n",
+    "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
     "    text_column=\"biography\",\n",
     "    data_summary=\"Biographical profiles of individuals\",\n",
     ")\n",
@@ -188,7 +188,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:31:16] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:31:16] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -497,7 +497,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:32:20] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:32:20] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {

--- a/docs/notebooks/02_inspecting_detected_entities.ipynb
+++ b/docs/notebooks/02_inspecting_detected_entities.ipynb
@@ -159,7 +159,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:39:37] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:39:37] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -223,7 +223,7 @@
     "config = AnonymizerConfig(replace=Annotate())\n",
     "\n",
     "input_data = AnonymizerInput(\n",
-    "    source=\"../data/NVIDIA_synthetic_biographies.csv\",\n",
+    "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
     "    text_column=\"biography\",\n",
     "    data_summary=\"Biographical profiles\",\n",
     ")\n",

--- a/docs/notebooks/03_choosing_a_replacement_strategy.ipynb
+++ b/docs/notebooks/03_choosing_a_replacement_strategy.ipynb
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "input_data = AnonymizerInput(\n",
-    "    source=\"../data/NVIDIA_synthetic_biographies.csv\",\n",
+    "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
     "    text_column=\"biography\",\n",
     "    data_summary=\"Biographical profiles\",\n",
     ")"
@@ -187,7 +187,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:40:20] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:40:20] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -340,7 +340,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:41:18] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:41:18] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -476,7 +476,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:42:12] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:42:12] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -611,7 +611,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:43:00] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:43:00] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -749,7 +749,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:43:41] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:43:41] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -884,7 +884,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:44:26] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:44:26] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -1019,7 +1019,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:45:13] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:45:13] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {
@@ -1155,7 +1155,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[13:45:56] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+      "[13:45:56] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
      ]
     },
     {

--- a/docs/notebooks/04_rewriting_biographies.ipynb
+++ b/docs/notebooks/04_rewriting_biographies.ipynb
@@ -133,7 +133,7 @@
    "outputs": [],
    "source": [
     "input_data = AnonymizerInput(\n",
-    "    source=\"../data/NVIDIA_synthetic_biographies.csv\",\n",
+    "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
     "    text_column=\"biography\",\n",
     "    data_summary=\"Biographical profiles\",\n",
     ")"
@@ -205,7 +205,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[16:16:07] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n",
+      "[16:16:07] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n",
       "[16:16:07] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n",
       "[16:16:07] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n",
       "[16:16:07] [INFO] 🔍 Running entity detection on 3 records\n"
@@ -360,7 +360,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[16:22:12] [INFO] 📂 Loaded 25 records from ../data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n",
+      "[16:22:12] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n",
       "[16:22:12] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n",
       "[16:22:12] [INFO] 🔍 Running entity detection on 25 records\n",
       "[16:29:31] [INFO]   |-- 📋 Detection complete — 667 entities found across 25 records (0 failed) [438.9s]\n",

--- a/docs/notebooks/05_rewriting_legal_documents.ipynb
+++ b/docs/notebooks/05_rewriting_legal_documents.ipynb
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "315bca05",
    "metadata": {
     "execution": {
@@ -163,7 +163,7 @@
     "]\n",
     "\n",
     "input_data = AnonymizerInput(\n",
-    "    source=\"../data/TAB_legal_sample25.csv\",\n",
+    "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/TAB_legal_sample25.csv\",\n",
     "    text_column=\"text\",\n",
     "    data_summary=\"Legal court decisions containing personal identifiers, case numbers, and institutional references\",\n",
     ")"
@@ -239,7 +239,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[16:41:39] [INFO] 📂 Loaded 25 records from ../data/TAB_legal_sample25.csv (column: 'text')\n",
+      "[16:41:39] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/TAB_legal_sample25.csv (column: 'text')\n",
       "[16:41:39] [INFO] detection labels in scope: ['age', 'application_number', 'case_number', 'city', 'company_name', 'country', 'court_name', 'date', 'date_of_birth', 'date_time', 'email', 'first_name', 'last_name', 'legal_role', 'monetary_amount', 'nationality', 'organization_name', 'phone_number', 'prison_detention_facility', 'sentence_duration', 'ssn', 'state', 'street_address', 'time', 'unique_id']\n",
       "[16:41:39] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n",
       "[16:41:39] [INFO] 🔍 Running entity detection on 3 records\n",
@@ -529,7 +529,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[16:47:13] [INFO] 📂 Loaded 25 records from ../data/TAB_legal_sample25.csv (column: 'text')\n",
+      "[16:47:13] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/TAB_legal_sample25.csv (column: 'text')\n",
       "[16:47:13] [INFO] detection labels in scope: ['age', 'application_number', 'case_number', 'city', 'company_name', 'country', 'court_name', 'date', 'date_of_birth', 'date_time', 'email', 'first_name', 'last_name', 'legal_role', 'monetary_amount', 'nationality', 'organization_name', 'phone_number', 'prison_detention_facility', 'sentence_duration', 'ssn', 'state', 'street_address', 'time', 'unique_id']\n",
       "[16:47:13] [INFO] 🔍 Running entity detection on 25 records\n",
       "[16:51:28] [INFO]   |-- 📋 Detection complete — 1285 entities found across 25 records (0 failed) [254.7s]\n",

--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -20,13 +21,26 @@ from anonymizer.config.rewrite import (
 logger = logging.getLogger(__name__)
 
 
+def is_remote_input_source(value: str) -> bool:
+    """Return True when the input source is an HTTP(S) URL."""
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"}
+
+
+def infer_input_source_suffix(value: str) -> str:
+    """Infer the lowercase file suffix from a local path or remote URL path."""
+    if is_remote_input_source(value):
+        return Path(urlparse(value).path).suffix.lower()
+    return Path(value).suffix.lower()
+
+
 class AnonymizerInput(BaseModel):
     """Input source definition for the anonymizer pipeline.
 
-    Format is inferred from file extension (.csv or .parquet).
+    Format is inferred from the file extension of a local path or HTTP(S) URL.
     """
 
-    source: str = Field(description="Path to input file (.csv or .parquet).")
+    source: str = Field(description="Local path or HTTP(S) URL for a .csv or .parquet input file.")
     text_column: str = Field(default="text", min_length=1, description="Column containing the text to anonymize.")
     id_column: str | None = Field(default=None, description="Optional column to use as record identifier.")
     data_summary: str | None = Field(
@@ -36,6 +50,8 @@ class AnonymizerInput(BaseModel):
     @field_validator("source")
     @classmethod
     def validate_source_path(cls, value: str) -> str:
+        if is_remote_input_source(value):
+            return value
         source = Path(value)
         if not source.exists():
             raise ValueError(f"Input path does not exist: {source}")

--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -27,6 +27,12 @@ def is_remote_input_source(value: str) -> bool:
     return parsed.scheme in {"http", "https"}
 
 
+def has_unsupported_url_scheme(value: str) -> bool:
+    """Return True when the input looks like a URL but uses an unsupported scheme."""
+    parsed = urlparse(value)
+    return "://" in value and bool(parsed.scheme) and parsed.scheme not in {"http", "https"}
+
+
 def infer_input_source_suffix(value: str) -> str:
     """Infer the lowercase file suffix from a local path or remote URL path."""
     if is_remote_input_source(value):
@@ -52,6 +58,9 @@ class AnonymizerInput(BaseModel):
     def validate_source_path(cls, value: str) -> str:
         if is_remote_input_source(value):
             return value
+        if has_unsupported_url_scheme(value):
+            scheme = urlparse(value).scheme
+            raise ValueError(f"Unsupported input URL scheme: {scheme!r}. Use http:// or https:// URLs.")
         source = Path(value)
         if not source.exists():
             raise ValueError(f"Input path does not exist: {source}")

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pandas as pd
 
-from anonymizer.config.anonymizer_config import AnonymizerInput
+from anonymizer.config.anonymizer_config import AnonymizerInput, infer_input_source_suffix
 from anonymizer.engine.constants import COL_TEXT
 from anonymizer.engine.io.constants import SUPPORTED_IO_FORMATS
 from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
@@ -35,14 +33,14 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
 
 
 def _load_dataframe(input_data: AnonymizerInput) -> pd.DataFrame:
-    source = Path(str(input_data.source))
-    suffix = source.suffix.lower()
+    source_str = str(input_data.source)
+    suffix = infer_input_source_suffix(source_str)
     if suffix not in SUPPORTED_IO_FORMATS:
         supported_formats = " or ".join(SUPPORTED_IO_FORMATS)
         raise InvalidInputError(f"Unsupported input format: {suffix}. Use {supported_formats}.")
     try:
         if suffix == ".csv":
-            return pd.read_csv(source)
-        return pd.read_parquet(source)
+            return pd.read_csv(source_str)
+        return pd.read_parquet(source_str)
     except (OSError, pd.errors.ParserError, ValueError) as error:
-        raise AnonymizerIOError(f"Failed to read input data from path: {source}") from error
+        raise AnonymizerIOError(f"Failed to read input data from: {source_str}") from error

--- a/tests/config/test_anonymizer_config.py
+++ b/tests/config/test_anonymizer_config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Rewrite
+from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Rewrite, infer_input_source_suffix
 from anonymizer.config.replace_strategies import (
     Annotate,
     Hash,
@@ -46,6 +46,10 @@ def test_input_source_accepts_http_url_without_local_path_check() -> None:
 def test_input_source_accepts_http_url_with_fragment() -> None:
     inp = AnonymizerInput(source="https://example.com/data.csv#preview")
     assert inp.source == "https://example.com/data.csv#preview"
+
+
+def test_infer_input_source_suffix_ignores_url_fragment() -> None:
+    assert infer_input_source_suffix("https://example.com/data.csv#preview") == ".csv"
 
 
 def test_input_source_rejects_unsupported_url_scheme() -> None:

--- a/tests/config/test_anonymizer_config.py
+++ b/tests/config/test_anonymizer_config.py
@@ -38,6 +38,16 @@ def test_data_summary_on_input(tmp_path: Path) -> None:
     assert inp.data_summary is not None
 
 
+def test_input_source_accepts_http_url_without_local_path_check() -> None:
+    inp = AnonymizerInput(source="https://example.com/data.csv")
+    assert inp.source == "https://example.com/data.csv"
+
+
+def test_input_source_accepts_http_url_with_fragment() -> None:
+    inp = AnonymizerInput(source="https://example.com/data.csv#preview")
+    assert inp.source == "https://example.com/data.csv#preview"
+
+
 def test_replace_and_rewrite_together_raises() -> None:
     with pytest.raises(ValueError, match="Cannot use both replace and rewrite"):
         AnonymizerConfig(replace=Redact(), rewrite=Rewrite())

--- a/tests/config/test_anonymizer_config.py
+++ b/tests/config/test_anonymizer_config.py
@@ -48,6 +48,11 @@ def test_input_source_accepts_http_url_with_fragment() -> None:
     assert inp.source == "https://example.com/data.csv#preview"
 
 
+def test_input_source_rejects_unsupported_url_scheme() -> None:
+    with pytest.raises(ValidationError, match="Unsupported input URL scheme"):
+        AnonymizerInput(source="ftp://example.com/data.csv")
+
+
 def test_replace_and_rewrite_together_raises() -> None:
     with pytest.raises(ValueError, match="Cannot use both replace and rewrite"):
         AnonymizerConfig(replace=Redact(), rewrite=Rewrite())

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -93,6 +93,12 @@ def test_read_input_from_remote_csv_url_with_fragment(monkeypatch: pytest.Monkey
     assert result.attrs["original_text_column"] == "text"
 
 
+def test_read_input_remote_url_with_unsupported_format_raises() -> None:
+    inp = AnonymizerInput(source="https://example.com/data.json")
+    with pytest.raises(InvalidInputError, match="Unsupported input format"):
+        read_input(inp)
+
+
 def test_read_input_renames_text_column(tmp_path: Path) -> None:
     df = pd.DataFrame({"content": ["hello world"]})
     file_path = tmp_path / "data.csv"
@@ -166,6 +172,18 @@ def test_read_input_pandas_failure_raises_anonymizer_io_error(tmp_path: Path, mo
 
     monkeypatch.setattr(pd, "read_csv", _raise_read_error)
     inp = AnonymizerInput(source=str(file_path))
+    with pytest.raises(AnonymizerIOError, match="Failed to read input data"):
+        read_input(inp)
+
+
+def test_read_input_remote_csv_failure_raises_anonymizer_io_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = "https://example.com/data.csv"
+
+    def _raise_read_error(*args: object, **kwargs: object) -> None:
+        raise OSError("network failure")
+
+    monkeypatch.setattr(pd, "read_csv", _raise_read_error)
+    inp = AnonymizerInput(source=source)
     with pytest.raises(AnonymizerIOError, match="Failed to read input data"):
         read_input(inp)
 

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -51,6 +51,48 @@ def test_read_input_from_file(suffix: str, writer: object, tmp_path: Path) -> No
     assert COL_TEXT in result.columns
 
 
+def test_read_input_from_remote_csv_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    input_df = pd.DataFrame({"text": ["Alice works at Acme"]})
+    source = "https://example.com/data.csv"
+
+    def _read_csv(url: str, *args: object, **kwargs: object) -> pd.DataFrame:
+        assert url == source
+        return input_df
+
+    monkeypatch.setattr(pd, "read_csv", _read_csv)
+    result = read_input(AnonymizerInput(source=source))
+    assert result[COL_TEXT].tolist() == ["Alice works at Acme"]
+    assert result.attrs["original_text_column"] == "text"
+
+
+def test_read_input_from_remote_parquet_url_with_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    input_df = pd.DataFrame({"text": ["Alice works at Acme"]})
+    source = "https://example.com/data.parquet?download=1"
+
+    def _read_parquet(url: str, *args: object, **kwargs: object) -> pd.DataFrame:
+        assert url == source
+        return input_df
+
+    monkeypatch.setattr(pd, "read_parquet", _read_parquet)
+    result = read_input(AnonymizerInput(source=source))
+    assert result[COL_TEXT].tolist() == ["Alice works at Acme"]
+    assert result.attrs["original_text_column"] == "text"
+
+
+def test_read_input_from_remote_csv_url_with_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
+    input_df = pd.DataFrame({"text": ["Alice works at Acme"]})
+    source = "https://example.com/data.csv#section-1"
+
+    def _read_csv(url: str, *args: object, **kwargs: object) -> pd.DataFrame:
+        assert url == source
+        return input_df
+
+    monkeypatch.setattr(pd, "read_csv", _read_csv)
+    result = read_input(AnonymizerInput(source=source))
+    assert result[COL_TEXT].tolist() == ["Alice works at Acme"]
+    assert result.attrs["original_text_column"] == "text"
+
+
 def test_read_input_renames_text_column(tmp_path: Path) -> None:
     df = pd.DataFrame({"content": ["hello world"]})
     file_path = tmp_path / "data.csv"


### PR DESCRIPTION
## Summary
Updates the docs notebooks to load sample datasets from GitHub raw URLs instead of repo-relative paths, so they work outside a local checkout. Also updates input validation and reader logic to accept HTTP(S) CSV and Parquet sources, with focused tests covering the new behavior.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [x] `make check` passes locally (format + lint + typecheck + lock-check) - except ty 
- [x] Added/updated tests for changes

## Documentation
- [x] If docs changed: `make docs-build` passes locally
