### PR TITLE
fix: remove stale substitution in detection workflow 

### DIFF
--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -535,7 +535,6 @@ Already-detected entities: <<SEED_ENTITIES>>
         {
             "<<LABEL_BLOCK>>": label_block,
             "<<EXAMPLE_BLOCK>>": example_block,
-            "<<TAG_NOTATION>>": COL_TAG_NOTATION,
             "<<TAGGED_TEXT>>": _jinja(COL_INITIAL_TAGGED_TEXT),
             "<<SEED_ENTITIES>>": _jinja(COL_SEED_ENTITIES_JSON),
             "<<DATA_SUMMARY>>": context_section,


### PR DESCRIPTION
## Summary
Fixes a stale prompt placeholder substitution in detection augmentation. `_get_augment_prompt()` was still passing <<TAG_NOTATION>> into `substitute_placeholders()` after that placeholder had already been pre-substituted inside the example block, which caused noisy warning logs in every run.

## Testing

  - Re-ran the e2e flow and confirmed the warning no longer appears.
  - Verified augmentation still runs normally and `_augmented_entities` completes successfully.