### PR TITLE
docs: clarify standard vs latent entity example

### DIFF
--- a/docs/concepts/detection.md
+++ b/docs/concepts/detection.md
@@ -21,8 +21,8 @@ Consider this short passage:
 
 | Type | Value | Description |
 | --- | --- | --- |
-| Standard entity | Sarah | first_name |
-| Latent entity | ringing the bell | Reveals something sensitive - nearing the end of cancer treatment. It is only inferable from surrounding context (e.g. the passage never says "cancer"). |
+| Standard entity | Sarah | A directly stated first name. |
+| Latent entity | cancer treatment | Inferred from context. The passage never explicitly says "cancer," but "ringing the bell" can imply nearing the end of cancer treatment. |
 
 ---
 


### PR DESCRIPTION
## Summary

Clarifies the latent-entity example in the detection docs by distinguishing the inferred sensitive concept from the textual clue that reveals it. The example table now uses plain-language descriptions so the standard and latent entity rows read more clearly.

## Documentation
- [x] If docs changed: `make docs-build` passes locally
- [ ] 
<img width="932" height="472" alt="image" src="https://github.com/user-attachments/assets/4148e029-d2c0-494e-b62f-26f1c64a6bed" />

