### PR TITLE
test: clean up e2e smoke test and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test:
 
 test-e2e:
 	@echo "Running end-to-end tests..."
-	uv run --group dev pytest -m e2e
+	uv run python tests_e2e/test_e2e.py
 
 coverage:
 	@echo "Running tests with coverage analysis..."

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test:
 
 test-e2e:
 	@echo "Running end-to-end tests..."
-	uv run python tests_e2e/test_e2e.py
+	uv run --group dev pytest -m e2e tests_e2e/test_e2e.py
 
 coverage:
 	@echo "Running tests with coverage analysis..."

--- a/docs/concepts/detection.md
+++ b/docs/concepts/detection.md
@@ -21,8 +21,8 @@ Consider this short passage:
 
 | Type | Value | Description |
 | --- | --- | --- |
-| Standard entity | Sarah | first_name |
-| Latent entity | ringing the bell | Reveals something sensitive - nearing the end of cancer treatment. It is only inferable from surrounding context (e.g. the passage never says "cancer"). |
+| Standard entity | Sarah | A directly stated first name. |
+| Latent entity | cancer treatment | Inferred from context. The passage never explicitly says "cancer," but "ringing the bell" can imply nearing the end of cancer treatment. |
 
 ---
 

--- a/tests_e2e/test_e2e.py
+++ b/tests_e2e/test_e2e.py
@@ -6,10 +6,13 @@
 Hits real LLM APIs - expects NVIDIA_API_KEY in the environment.
 
 Usage:
-    python tests_e2e/test_e2e.py
+    pytest -m e2e tests_e2e/test_e2e.py
 """
 
+import os
 from pathlib import Path
+
+import pytest
 
 from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Rewrite, configure_logging
 
@@ -25,20 +28,24 @@ EXPECTED_REWRITE_COLUMNS = {
     "needs_human_review",
 }
 
-configure_logging()
 
-anonymizer = Anonymizer()
-input_data = AnonymizerInput(
-    source=str(DATA_DIR / "NVIDIA_synthetic_biographies.csv"),
-    text_column="biography",
-    data_summary="Biographical profiles",
-)
-config = AnonymizerConfig(rewrite=Rewrite())
+@pytest.mark.e2e
+def test_rewrite_preview_smoke() -> None:
+    if not os.getenv("NVIDIA_API_KEY"):
+        pytest.skip("NVIDIA_API_KEY is required for e2e tests")
 
-result = anonymizer.preview(config=config, data=input_data, num_records=3)
+    configure_logging()
 
-assert len(result.dataframe) > 0, "Preview returned no records"
-missing = EXPECTED_REWRITE_COLUMNS - set(result.dataframe.columns)
-assert not missing, f"Missing columns: {missing}"
+    anonymizer = Anonymizer()
+    input_data = AnonymizerInput(
+        source=str(DATA_DIR / "NVIDIA_synthetic_biographies.csv"),
+        text_column="biography",
+        data_summary="Biographical profiles",
+    )
+    config = AnonymizerConfig(rewrite=Rewrite())
 
-print(f"\nPASS - {len(result.dataframe)} records, all expected columns present")
+    result = anonymizer.preview(config=config, data=input_data, num_records=3)
+
+    assert len(result.dataframe) > 0, "Preview returned no records"
+    missing = EXPECTED_REWRITE_COLUMNS - set(result.dataframe.columns)
+    assert not missing, f"Missing columns: {missing}"

--- a/tests_e2e/test_e2e.py
+++ b/tests_e2e/test_e2e.py
@@ -1,14 +1,31 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""End-to-end smoke test for the Anonymizer rewrite pipeline.
+
+Hits real LLM APIs - expects NVIDIA_API_KEY in the environment.
+
+Usage:
+    python tests_e2e/test_e2e.py
+"""
+
 from pathlib import Path
 
-from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, LoggingConfig, Rewrite, configure_logging
+from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Rewrite, configure_logging
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DATA_DIR = REPO_ROOT / "docs" / "notebook_source" / "data"
+DATA_DIR = REPO_ROOT / "docs" / "data"
 
-configure_logging(LoggingConfig.debug())
+EXPECTED_REWRITE_COLUMNS = {
+    "biography_rewritten",
+    "utility_score",
+    "leakage_mass",
+    "weighted_leakage_rate",
+    "any_high_leaked",
+    "needs_human_review",
+}
+
+configure_logging()
 
 anonymizer = Anonymizer()
 input_data = AnonymizerInput(
@@ -18,18 +35,10 @@ input_data = AnonymizerInput(
 )
 config = AnonymizerConfig(rewrite=Rewrite())
 
-preview = anonymizer.preview(
-    config=config,
-    data=input_data,
-    num_records=3,
-)
+result = anonymizer.preview(config=config, data=input_data, num_records=3)
 
-result = anonymizer.run(config=config, data=input_data)
+assert len(result.dataframe) > 0, "Preview returned no records"
+missing = EXPECTED_REWRITE_COLUMNS - set(result.dataframe.columns)
+assert not missing, f"Missing columns: {missing}"
 
-print(result)
-result.dataframe.head()
-
-
-result.dataframe[["biography_rewritten", "utility_score", "leakage_mass", "needs_human_review"]].head()
-
-print(result.trace_dataframe.columns.tolist())
+print(f"\nPASS - {len(result.dataframe)} records, all expected columns present")


### PR DESCRIPTION
## Summary
Cleans up the end-to-end smoke test so it runs as a real pytest e2e test again, with make test-e2e invoking pytest directly. This keeps the e2e path consistent with the project’s test conventions while preserving the lightweight preview-based smoke coverage.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test-e2e` passes locally
- [x] `make check` passes locally (format + lint + typecheck + lock-check)