### PR TITLE
fix: docs link fixes and notebook validation for release

### DIFF
--- a/docs/notebook_source/01_your_first_anonymization.py
+++ b/docs/notebook_source/01_your_first_anonymization.py
@@ -116,9 +116,9 @@ result.dataframe.head()
 # %% [markdown]
 # ## ⏭️ Next steps
 #
-# - **[🔍 Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --
+# - **[🔍 Inspecting Detected Entities](../02_inspecting_detected_entities/)** --
 #   dig into what the detection pipeline found and debug quality.
-# - **[🎯 Choosing a Replacement Strategy](03_choosing_a_replacement_strategy.ipynb)** --
+# - **[🎯 Choosing a Replacement Strategy](../03_choosing_a_replacement_strategy/)** --
 #   compare Redact, Annotate, Hash, and Substitute side-by-side.
-# - **[✏️ Rewriting Biographies](04_rewriting_biographies.ipynb)** --
+# - **[✏️ Rewriting Biographies](../04_rewriting_biographies/)** --
 #   generate privacy-safe paraphrases instead of token-level replacements.

--- a/docs/notebook_source/02_inspecting_detected_entities.py
+++ b/docs/notebook_source/02_inspecting_detected_entities.py
@@ -189,9 +189,9 @@ else:
 # %% [markdown]
 # ## ⏭️ Next steps
 #
-# - **[🕵️ Your First Anonymization](01_your_first_anonymization.ipynb)** --
+# - **[🕵️ Your First Anonymization](../01_your_first_anonymization/)** --
 #   the simplest end-to-end replace workflow if you haven't run it yet.
-# - **[🎯 Choosing a Replacement Strategy](03_choosing_a_replacement_strategy.ipynb)** --
+# - **[🎯 Choosing a Replacement Strategy](../03_choosing_a_replacement_strategy/)** --
 #   compare Redact, Annotate, Hash, and Substitute side-by-side.
-# - **[✏️ Rewriting Biographies](04_rewriting_biographies.ipynb)** --
+# - **[✏️ Rewriting Biographies](../04_rewriting_biographies/)** --
 #   generate privacy-safe paraphrases instead of token-level replacements.

--- a/docs/notebook_source/03_choosing_a_replacement_strategy.py
+++ b/docs/notebook_source/03_choosing_a_replacement_strategy.py
@@ -17,7 +17,7 @@
 # %% [markdown]
 # # 🕵️ Choosing a Replacement Strategy
 #
-# Four [replace mode](../concepts/replace.md) strategies compared side-by-side on the same data.
+# Four [replace mode](../../concepts/replace/) strategies compared side-by-side on the same data.
 #
 # | Strategy | What it does |
 # |----------|-------------|
@@ -210,9 +210,9 @@ hash_custom_preview.display_record(0)
 # %% [markdown]
 # ## ⏭️ Next steps
 #
-# - **[🕵️ Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --
+# - **[🕵️ Inspecting Detected Entities](../02_inspecting_detected_entities/)** --
 #   dig into what the detection pipeline found and debug quality.
-# - **[✏️ Rewriting Biographies](04_rewriting_biographies.ipynb)** --
+# - **[✏️ Rewriting Biographies](../04_rewriting_biographies/)** --
 #   generate privacy-safe paraphrases instead of token-level replacements.
-# - **[⚖️ Rewriting Legal Documents](05_rewriting_legal_documents.ipynb)** --
+# - **[⚖️ Rewriting Legal Documents](../05_rewriting_legal_documents/)** --
 #   rewrite legal text with domain-specific privacy goals.

--- a/docs/notebook_source/04_rewriting_biographies.py
+++ b/docs/notebook_source/04_rewriting_biographies.py
@@ -85,7 +85,7 @@ input_data = AnonymizerInput(
 #   this gives the rewriter clear, domain-specific guidance.
 # - `risk_tolerance` (default `"low"`) and `max_repair_iterations` (default `3`)
 #   control the automated quality gate --
-#   see [Risk tolerance](../concepts/rewrite.md#risk-tolerance) for presets.
+#   see [Risk tolerance](../../concepts/rewrite/#risk-tolerance) for presets.
 
 # %%
 config = AnonymizerConfig(
@@ -137,7 +137,7 @@ result.trace_dataframe.columns.tolist()
 #
 # - Records where automated metrics exceed thresholds are flagged for manual review.
 # - Use this to prioritize human attention on the records that need it most.
-# - See [Working with flagged records](../concepts/rewrite.md#working-with-flagged-records)
+# - See [Working with flagged records](../../concepts/rewrite/#working-with-flagged-records)
 #   for guidance on diagnosing and resolving flagged records.
 
 # %%
@@ -149,9 +149,9 @@ flagged.head()
 # %% [markdown]
 # ## ⏭️ Next steps
 #
-# - **[⚖️ Rewriting Legal Documents](05_rewriting_legal_documents.ipynb)** --
+# - **[⚖️ Rewriting Legal Documents](../05_rewriting_legal_documents/)** --
 #   rewrite legal text with custom entity labels and domain-specific privacy goals.
-# - **[🎯 Choosing a Replacement Strategy](03_choosing_a_replacement_strategy.ipynb)** --
+# - **[🎯 Choosing a Replacement Strategy](../03_choosing_a_replacement_strategy/)** --
 #   compare Redact, Annotate, Hash, and Substitute if you prefer token-level replacement.
-# - **[🔍 Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --
+# - **[🔍 Inspecting Detected Entities](../02_inspecting_detected_entities/)** --
 #   debug what the detection pipeline found before rewriting.

--- a/docs/notebook_source/05_rewriting_legal_documents.py
+++ b/docs/notebook_source/05_rewriting_legal_documents.py
@@ -162,7 +162,7 @@ result.dataframe[["text_rewritten", "utility_score", "leakage_mass", "needs_huma
 #
 # - Records where automated metrics exceed thresholds are flagged for manual review.
 # - Use this to prioritize human attention on the records that need it most.
-# - See [Working with flagged records](../concepts/rewrite.md#working-with-flagged-records)
+# - See [Working with flagged records](../../concepts/rewrite/#working-with-flagged-records)
 #   for guidance on diagnosing and resolving flagged records.
 
 # %%
@@ -174,7 +174,7 @@ flagged.head()
 # %% [markdown]
 # ## ⏭️ Next steps
 #
-# - **[🔍 Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --
+# - **[🔍 Inspecting Detected Entities](../02_inspecting_detected_entities/)** --
 #   debug what the detection pipeline found before rewriting.
 # - **Try it on your own data!** Swap in your CSV, define entity labels for your
 #   domain, and set a `PrivacyGoal` that fits -- you've got all the building blocks.

--- a/docs/notebooks/01_your_first_anonymization.ipynb
+++ b/docs/notebooks/01_your_first_anonymization.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3a7ac61f",
    "metadata": {},
    "source": [
     "# 🕵️ Your First Anonymization\n",
@@ -19,11 +18,11 @@
     "\n",
     "> **Tip:** First time running notebooks? Start with\n",
     "> [setup instructions](https://nvidia-nemo.github.io/Anonymizer/latest/tutorials/)."
-   ]
+   ],
+   "id": "3a7ac61f"
   },
   {
    "cell_type": "markdown",
-   "id": "6868f72c",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -35,12 +34,11 @@
     "  - Request/token rate limits on `build.nvidia.com` vary by account and model access, and lower-volume development access can be slow for full runs. Start with `preview()` on a small sample.\n",
     "- Import the core Anonymizer classes: `Anonymizer`, `AnonymizerConfig`, `AnonymizerInput`, and `Substitute`.\n",
     "- `Anonymizer()` initializes with the default model provider -- no extra config needed."
-   ]
+   ],
+   "id": "6868f72c"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "dd76ccaa",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:31:08.289664Z",
@@ -49,7 +47,6 @@
      "shell.execute_reply": "2026-04-03T20:31:08.294250Z"
     }
    },
-   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -59,12 +56,13 @@
     "    if not key:\n",
     "        raise RuntimeError(\"NVIDIA_API_KEY is required to run these notebooks.\")\n",
     "    os.environ[\"NVIDIA_API_KEY\"] = key"
-   ]
+   ],
+   "execution_count": 1,
+   "outputs": [],
+   "id": "dd76ccaa"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "1ce0ce76",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:31:08.296388Z",
@@ -73,15 +71,15 @@
      "shell.execute_reply": "2026-04-03T20:31:16.247160Z"
     }
    },
-   "outputs": [],
    "source": [
     "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Substitute"
-   ]
+   ],
+   "execution_count": 2,
+   "outputs": [],
+   "id": "1ce0ce76"
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "8cf49866",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:31:16.248772Z",
@@ -90,43 +88,44 @@
      "shell.execute_reply": "2026-04-03T20:31:16.266462Z"
     }
    },
+   "source": [
+    "anonymizer = Anonymizer()"
+   ],
+   "execution_count": 3,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO] 🔧 Anonymizer initialized with 3 model configs\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO]   |-- 🔎 detector:  gliner-pii-detector\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO]   |-- ✅ validator: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO]   |-- 🧩 augmenter: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "anonymizer = Anonymizer()"
-   ]
+   "id": "8cf49866"
   },
   {
    "cell_type": "markdown",
-   "id": "9e6a4667",
    "metadata": {},
    "source": [
     "## 📦 Load data and configure\n",
@@ -136,12 +135,11 @@
     "- Records up to 2,000 tokens each work with the default model configs.\n",
     "- `AnonymizerConfig` with `Substitute()` tells Anonymizer to replace detected\n",
     "  entities with LLM-generated synthetic values for names, cities, dates, etc."
-   ]
+   ],
+   "id": "9e6a4667"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "de92b183",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:31:16.267973Z",
@@ -150,7 +148,6 @@
      "shell.execute_reply": "2026-04-03T20:31:16.269293Z"
     }
    },
-   "outputs": [],
    "source": [
     "input_data = AnonymizerInput(\n",
     "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
@@ -159,11 +156,13 @@
     ")\n",
     "\n",
     "config = AnonymizerConfig(replace=Substitute())"
-   ]
+   ],
+   "execution_count": 4,
+   "outputs": [],
+   "id": "de92b183"
   },
   {
    "cell_type": "markdown",
-   "id": "d05fae35",
    "metadata": {},
    "source": [
     "## 👁️ Preview\n",
@@ -171,12 +170,11 @@
     "- `preview()` runs on a small sample so you can iterate quickly.\n",
     "- Always preview before processing the full dataset -- it's the fastest way\n",
     "  to catch prompt or config issues early."
-   ]
+   ],
+   "id": "d05fae35"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "31d4683d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:31:16.270433Z",
@@ -185,78 +183,79 @@
      "shell.execute_reply": "2026-04-03T20:32:20.783709Z"
     }
    },
+   "source": [
+    "preview = anonymizer.preview(config=config, data=input_data, num_records=3)"
+   ],
+   "execution_count": 5,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:31:16] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:00] [INFO]   |-- 📋 Detection complete — 78 entities found across 3 records (0 failed) [44.7s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:00] [INFO]   |-- labels: first_name=22, organization_name=7, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, place_name=1, date_of_birth=1, project_name=1, employment_status=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:00] [INFO] 🔄 Running Substitute replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:20] [INFO]   |-- 📋 Replacement complete (0 failed) [19.8s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:20] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "preview = anonymizer.preview(config=config, data=input_data, num_records=3)"
-   ]
+   "id": "31d4683d"
   },
   {
    "cell_type": "markdown",
-   "id": "8b4845c5",
    "metadata": {},
    "source": [
     "## 🔍 Inspect\n",
@@ -264,12 +263,11 @@
     "- `display_record()` shows the original text with highlighted entities,\n",
     "  the replacement map, and the anonymized output -- all in one view.\n",
     "- The result dataframe has original and substituted text side-by-side."
-   ]
+   ],
+   "id": "8b4845c5"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "c12f9182",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:32:20.788372Z",
@@ -278,8 +276,13 @@
      "shell.execute_reply": "2026-04-03T20:32:20.791498Z"
     }
    },
+   "source": [
+    "preview.display_record(0)"
+   ],
+   "execution_count": 6,
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -312,18 +315,13 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "preview.display_record(0)"
-   ]
+   "id": "c12f9182"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "e6b79ca3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:32:20.792664Z",
@@ -332,8 +330,13 @@
      "shell.execute_reply": "2026-04-03T20:32:20.794440Z"
     }
    },
+   "source": [
+    "preview.display_record(1)"
+   ],
+   "execution_count": 7,
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -366,18 +369,13 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "preview.display_record(1)"
-   ]
+   "id": "e6b79ca3"
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a01c414a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:32:20.795511Z",
@@ -386,8 +384,13 @@
      "shell.execute_reply": "2026-04-03T20:32:20.825648Z"
     }
    },
+   "source": [
+    "preview.dataframe"
+   ],
+   "execution_count": 8,
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -462,30 +465,25 @@
        "2  Leah Keller, 42, lives at 317 Maplewood in Ale...  "
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 8
     }
    ],
-   "source": [
-    "preview.dataframe"
-   ]
+   "id": "a01c414a"
   },
   {
    "cell_type": "markdown",
-   "id": "51127c39",
    "metadata": {},
    "source": [
     "## 🚀 Full run\n",
     "\n",
     "- `run()` processes the entire dataset with the same config you previewed.\n",
     "- Access the output via `result.dataframe`."
-   ]
+   ],
+   "id": "51127c39"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "73a5f22b",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:32:20.826955Z",
@@ -494,82 +492,82 @@
      "shell.execute_reply": "2026-04-03T20:39:33.241758Z"
     }
    },
+   "source": [
+    "result = anonymizer.run(config=config, data=input_data)\n",
+    "print(result)"
+   ],
+   "execution_count": 9,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:20] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:20] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:32:20] [INFO] 🔍 Running entity detection on 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:37:23] [INFO]   |-- 📋 Detection complete — 666 entities found across 25 records (0 failed) [303.2s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:37:23] [INFO]   |-- labels: first_name=154, organization_name=62, occupation=47, city=41, university=36, field_of_study=34, race_ethnicity=30, last_name=27, state=27, age=26, degree=25, political_view=25, religious_belief=25, street_address=23, language=19, place_name=15, employment_status=11, county=11, date_of_birth=9, education_level=7, date=5, company_name=4, country=1, gender=1, postcode=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:37:23] [INFO] 🔄 Running Substitute replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "/Users/lramaswamy/Documents/github/Anonymizer/src/anonymizer/engine/row_partitioning.py:42: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
       "  pd.concat(list(parts), ignore_index=True)\n",
       "[13:39:33] [INFO]   |-- 📋 Replacement complete (0 failed) [129.3s]\n"
-     ]
+     ],
+     "name": "stderr"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:39:33] [INFO] 🎉 Pipeline complete — 25 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
      "text": [
       "AnonymizerResult(rows=25, columns=4, trace_columns=21, failed_records=0)\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "result = anonymizer.run(config=config, data=input_data)\n",
-    "print(result)"
-   ]
+   "id": "73a5f22b"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "c43fcb27",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:39:33.243851Z",
@@ -578,8 +576,13 @@
      "shell.execute_reply": "2026-04-03T20:39:33.247365Z"
     }
    },
+   "source": [
+    "result.dataframe.head()"
+   ],
+   "execution_count": 10,
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -676,34 +679,31 @@
        "4  Aisha Khan is a 22‑year‑old stock clerk who li...  "
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 10
     }
    ],
-   "source": [
-    "result.dataframe.head()"
-   ]
+   "id": "c43fcb27"
   },
   {
    "cell_type": "markdown",
-   "id": "3917007d",
    "metadata": {},
    "source": [
     "## ⏭️ Next steps\n",
     "\n",
-    "- **[🔍 Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --\n",
+    "- **[🔍 Inspecting Detected Entities](../02_inspecting_detected_entities/)** --\n",
     "  dig into what the detection pipeline found and debug quality.\n",
-    "- **[🎯 Choosing a Replacement Strategy](03_choosing_a_replacement_strategy.ipynb)** --\n",
+    "- **[🎯 Choosing a Replacement Strategy](../03_choosing_a_replacement_strategy/)** --\n",
     "  compare Redact, Annotate, Hash, and Substitute side-by-side.\n",
-    "- **[✏️ Rewriting Biographies](04_rewriting_biographies.ipynb)** --\n",
+    "- **[✏️ Rewriting Biographies](../04_rewriting_biographies/)** --\n",
     "  generate privacy-safe paraphrases instead of token-level replacements."
-   ]
+   ],
+   "id": "3917007d"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/docs/notebooks/02_inspecting_detected_entities.ipynb
+++ b/docs/notebooks/02_inspecting_detected_entities.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "68cc38df",
    "metadata": {},
    "source": [
     "# 🕵️ Inspecting Detected Entities\n",
@@ -25,11 +24,11 @@
     "\n",
     "> **Tip:** First time running notebooks? Start with\n",
     "> [setup instructions](https://nvidia-nemo.github.io/Anonymizer/latest/tutorials/)."
-   ]
+   ],
+   "id": "68cc38df"
   },
   {
    "cell_type": "markdown",
-   "id": "a66c7ea6",
    "metadata": {},
    "source": [
     "## ⚙️ Setup\n",
@@ -40,12 +39,11 @@
     "- Import the core classes -- this notebook uses `Annotate` to keep original values visible.\n",
     "- `Anonymizer()` initializes with the default model provider -- no extra config needed.\n",
     "- `Anonymizer.configure_logging()` controls verbosity -- switch to `Anonymizer.configure_logging(LoggingConfig.debug())` when troubleshooting."
-   ]
+   ],
+   "id": "a66c7ea6"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "2d308717",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:39:34.921938Z",
@@ -54,7 +52,6 @@
      "shell.execute_reply": "2026-04-03T20:39:35.350986Z"
     }
    },
-   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -67,12 +64,13 @@
     "    if not key:\n",
     "        raise RuntimeError(\"NVIDIA_API_KEY is required to run these notebooks.\")\n",
     "    os.environ[\"NVIDIA_API_KEY\"] = key"
-   ]
+   ],
+   "execution_count": 1,
+   "outputs": [],
+   "id": "2d308717"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "db1a2aa2",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:39:35.352676Z",
@@ -81,15 +79,15 @@
      "shell.execute_reply": "2026-04-03T20:39:37.184212Z"
     }
    },
-   "outputs": [],
    "source": [
     "from anonymizer import Annotate, Anonymizer, AnonymizerConfig, AnonymizerInput"
-   ]
+   ],
+   "execution_count": 2,
+   "outputs": [],
+   "id": "db1a2aa2"
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "646fa6cb",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:39:37.185794Z",
@@ -98,43 +96,44 @@
      "shell.execute_reply": "2026-04-03T20:39:37.192242Z"
     }
    },
+   "source": [
+    "anonymizer = Anonymizer()"
+   ],
+   "execution_count": 3,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:39:37] [INFO] 🔧 Anonymizer initialized with 3 model configs\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:39:37] [INFO]   |-- 🔎 detector:  gliner-pii-detector\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:39:37] [INFO]   |-- ✅ validator: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:39:37] [INFO]   |-- 🧩 augmenter: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "anonymizer = Anonymizer()"
-   ]
+   "id": "646fa6cb"
   },
   {
    "cell_type": "markdown",
-   "id": "dab1fef2",
    "metadata": {},
    "source": [
     "## 👁️ Preview\n",
@@ -142,12 +141,11 @@
     "- Detection runs as part of any strategy. `Annotate` keeps original text visible\n",
     "  alongside entity labels -- ideal for debugging.\n",
     "- `trace_dataframe` exposes every internal pipeline column; that's what we explore below."
-   ]
+   ],
+   "id": "dab1fef2"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "51a288a9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:39:37.193425Z",
@@ -156,71 +154,6 @@
      "shell.execute_reply": "2026-04-03T20:40:17.314288Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:39:37] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:39:37] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:39:37] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:39:37] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:17] [INFO]   |-- 📋 Detection complete — 79 entities found across 3 records (0 failed) [40.1s]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:17] [INFO]   |-- labels: first_name=22, organization_name=6, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, education_level=1, age_group=1, place_name=1, date_of_birth=1, employment_status=1, company_name=1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:17] [INFO] 🔄 Running Annotate replacement\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:17] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:17] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
-    }
-   ],
    "source": [
     "config = AnonymizerConfig(replace=Annotate())\n",
     "\n",
@@ -235,22 +168,87 @@
     "    data=input_data,\n",
     "    num_records=3,\n",
     ")"
-   ]
+   ],
+   "execution_count": 4,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:39:37] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:39:37] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:39:37] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:39:37] [INFO] 🔍 Running entity detection on 3 records\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:17] [INFO]   |-- 📋 Detection complete — 79 entities found across 3 records (0 failed) [40.1s]\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:17] [INFO]   |-- labels: first_name=22, organization_name=6, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, education_level=1, age_group=1, place_name=1, date_of_birth=1, employment_status=1, company_name=1\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:17] [INFO] 🔄 Running Annotate replacement\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:17] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:17] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
+     ],
+     "name": "stdout"
+    }
+   ],
+   "id": "51a288a9"
   },
   {
    "cell_type": "markdown",
-   "id": "0aa7c4ce",
    "metadata": {},
    "source": [
     "## 🔍 Inspect\n",
     "\n",
     "- `display_record()` renders an interactive view with entity highlights."
-   ]
+   ],
+   "id": "0aa7c4ce"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "aa8f74d9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.320300Z",
@@ -259,8 +257,13 @@
      "shell.execute_reply": "2026-04-03T20:40:17.323244Z"
     }
    },
+   "source": [
+    "result.display_record(0)"
+   ],
+   "execution_count": 5,
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -293,29 +296,24 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "result.display_record(0)"
-   ]
+   "id": "aa8f74d9"
   },
   {
    "cell_type": "markdown",
-   "id": "24896f46",
    "metadata": {},
    "source": [
     "## 📋 Columns\n",
     "\n",
     "- `trace_dataframe` contains all internal columns from the pipeline\n",
     "  (detection, validation, replacement, etc.)."
-   ]
+   ],
+   "id": "24896f46"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "a2f917a3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.324439Z",
@@ -324,37 +322,37 @@
      "shell.execute_reply": "2026-04-03T20:40:17.325810Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Records: 3\n",
-      "Columns: ['biography', '_anonymizer_record_id', '_raw_detected_entities', '_seed_entities', '_initial_tagged_text', '_seed_entities_json', '_tag_notation', '_merged_tagged_text', '_validation_candidates', '_validated_entities', '_augmented_entities', '_merged_entities', '_detected_entities', 'biography_with_spans', 'final_entities', '_entities_by_value', '_replacement_map', 'biography_replaced']\n"
-     ]
-    }
-   ],
    "source": [
     "df = result.trace_dataframe\n",
     "print(f\"Records: {len(df)}\")\n",
     "print(f\"Columns: {list(df.columns)}\")"
-   ]
+   ],
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "Records: 3\n",
+      "Columns: ['biography', '_anonymizer_record_id', '_raw_detected_entities', '_seed_entities', '_initial_tagged_text', '_seed_entities_json', '_tag_notation', '_merged_tagged_text', '_validation_candidates', '_validated_entities', '_augmented_entities', '_merged_entities', '_detected_entities', 'biography_with_spans', 'final_entities', '_entities_by_value', '_replacement_map', 'biography_replaced']\n"
+     ],
+     "name": "stdout"
+    }
+   ],
+   "id": "a2f917a3"
   },
   {
    "cell_type": "markdown",
-   "id": "e92471c1",
    "metadata": {},
    "source": [
     "## 🎯 Detected entities\n",
     "\n",
     "- Final entity list after validation. Each entity has `value`, `label`,\n",
     "  positions, `score`, and `source` (detector / augmenter / name_split / propagation)."
-   ]
+   ],
+   "id": "e92471c1"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "cc4b610c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.326912Z",
@@ -363,9 +361,20 @@
      "shell.execute_reply": "2026-04-03T20:40:17.330801Z"
     }
    },
+   "source": [
+    "row_idx = 0\n",
+    "raw = df.loc[row_idx, \"_detected_entities\"]\n",
+    "entities = raw[\"entities\"] if isinstance(raw, dict) else raw\n",
+    "print(f\"Record {row_idx}: {len(entities)} entities detected\\n\")\n",
+    "\n",
+    "entity_df = pd.DataFrame(entities)\n",
+    "if not entity_df.empty:\n",
+    "    cols = [c for c in [\"value\", \"label\", \"start_position\", \"end_position\", \"source\"] if c in entity_df.columns]\n",
+    "    print(entity_df[cols].to_string())"
+   ],
+   "execution_count": 7,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Record 0: 22 entities detected\n",
@@ -393,35 +402,24 @@
       "19                    Aria and Leo         first_name             836           848   detector\n",
       "20                           Bobby         first_name             870           875   detector\n",
       "21                         Rockies         place_name             894           901   detector\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "row_idx = 0\n",
-    "raw = df.loc[row_idx, \"_detected_entities\"]\n",
-    "entities = raw[\"entities\"] if isinstance(raw, dict) else raw\n",
-    "print(f\"Record {row_idx}: {len(entities)} entities detected\\n\")\n",
-    "\n",
-    "entity_df = pd.DataFrame(entities)\n",
-    "if not entity_df.empty:\n",
-    "    cols = [c for c in [\"value\", \"label\", \"start_position\", \"end_position\", \"source\"] if c in entity_df.columns]\n",
-    "    print(entity_df[cols].to_string())"
-   ]
+   "id": "cc4b610c"
   },
   {
    "cell_type": "markdown",
-   "id": "36fd7761",
    "metadata": {},
    "source": [
     "## 🏷️ Labels\n",
     "\n",
     "- Entity label distribution across all records -- which types are most common."
-   ]
+   ],
+   "id": "36fd7761"
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "f2896ce9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.331850Z",
@@ -430,9 +428,19 @@
      "shell.execute_reply": "2026-04-03T20:40:17.333161Z"
     }
    },
+   "source": [
+    "label_counts = Counter()\n",
+    "for raw in df[\"_detected_entities\"]:\n",
+    "    entity_list = raw[\"entities\"] if isinstance(raw, dict) else raw\n",
+    "    for entity in entity_list:\n",
+    "        label_counts[entity[\"label\"]] += 1\n",
+    "\n",
+    "for label, count in label_counts.most_common():\n",
+    "    print(f\"  {label}: {count}\")"
+   ],
+   "execution_count": 8,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
      "text": [
       "  first_name: 22\n",
@@ -456,23 +464,14 @@
       "  date_of_birth: 1\n",
       "  employment_status: 1\n",
       "  company_name: 1\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "label_counts = Counter()\n",
-    "for raw in df[\"_detected_entities\"]:\n",
-    "    entity_list = raw[\"entities\"] if isinstance(raw, dict) else raw\n",
-    "    for entity in entity_list:\n",
-    "        label_counts[entity[\"label\"]] += 1\n",
-    "\n",
-    "for label, count in label_counts.most_common():\n",
-    "    print(f\"  {label}: {count}\")"
-   ]
+   "id": "f2896ce9"
   },
   {
    "cell_type": "markdown",
-   "id": "f7f1352b",
    "metadata": {},
    "source": [
     "## 📡 Sources\n",
@@ -483,12 +482,11 @@
     "    - `validator` -- LLM decision step over detector-seed entities (keep/reclass/drop); does not emit a separate source value\n",
     "    - `name_split` -- derived from splitting full names\n",
     "    - `propagation` -- expanded from validated entities to all text occurrences"
-   ]
+   ],
+   "id": "f7f1352b"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "e56e0bce",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.334182Z",
@@ -497,16 +495,6 @@
      "shell.execute_reply": "2026-04-03T20:40:17.335644Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  detector: 78\n",
-      "  augmenter: 1\n"
-     ]
-    }
-   ],
    "source": [
     "source_counts = Counter()\n",
     "for raw in df[\"_detected_entities\"]:\n",
@@ -516,23 +504,33 @@
     "\n",
     "for source, count in source_counts.most_common():\n",
     "    print(f\"  {source}: {count}\")"
-   ]
+   ],
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "  detector: 78\n",
+      "  augmenter: 1\n"
+     ],
+     "name": "stdout"
+    }
+   ],
+   "id": "e56e0bce"
   },
   {
    "cell_type": "markdown",
-   "id": "37b42067",
    "metadata": {},
    "source": [
     "## 📊 By value\n",
     "\n",
     "- Entities grouped by unique value -- this is what drives consistent replacement\n",
     "  downstream (same name always maps to the same substitute)."
-   ]
+   ],
+   "id": "37b42067"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "129fe07c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.336731Z",
@@ -541,9 +539,18 @@
      "shell.execute_reply": "2026-04-03T20:40:17.338176Z"
     }
    },
+   "source": [
+    "row_idx = 0\n",
+    "raw_bv = df.loc[row_idx, \"_entities_by_value\"]\n",
+    "by_value = raw_bv[\"entities_by_value\"] if isinstance(raw_bv, dict) else raw_bv\n",
+    "print(f\"Record {row_idx}: {len(by_value)} unique entity values\\n\")\n",
+    "\n",
+    "for entry in by_value:\n",
+    "    print(f\"  {entry['value']!r} -> labels: {entry['labels']}\")"
+   ],
+   "execution_count": 10,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Record 0: 19 unique entity values\n",
@@ -567,34 +574,25 @@
       "  'teenage' -> labels: ['age_group']\n",
       "  'veterinarian' -> labels: ['occupation']\n",
       "  'wildlife health' -> labels: ['field_of_study']\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "row_idx = 0\n",
-    "raw_bv = df.loc[row_idx, \"_entities_by_value\"]\n",
-    "by_value = raw_bv[\"entities_by_value\"] if isinstance(raw_bv, dict) else raw_bv\n",
-    "print(f\"Record {row_idx}: {len(by_value)} unique entity values\\n\")\n",
-    "\n",
-    "for entry in by_value:\n",
-    "    print(f\"  {entry['value']!r} -> labels: {entry['labels']}\")"
-   ]
+   "id": "129fe07c"
   },
   {
    "cell_type": "markdown",
-   "id": "7cad52b1",
    "metadata": {},
    "source": [
     "## ❌ Failures\n",
     "\n",
     "- Records dropped during detection (LLM timeout, parse error, etc.).\n",
     "- Check this to understand data loss in your pipeline."
-   ]
+   ],
+   "id": "7cad52b1"
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "5cc09572",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:17.339234Z",
@@ -603,37 +601,39 @@
      "shell.execute_reply": "2026-04-03T20:40:17.340609Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No failed records.\n"
-     ]
-    }
-   ],
    "source": [
     "if result.failed_records:\n",
     "    for fr in result.failed_records:\n",
     "        print(f\"  record_id={fr.record_id}, step={fr.step}, reason={fr.reason}\")\n",
     "else:\n",
     "    print(\"No failed records.\")"
-   ]
+   ],
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "No failed records.\n"
+     ],
+     "name": "stdout"
+    }
+   ],
+   "id": "5cc09572"
   },
   {
    "cell_type": "markdown",
-   "id": "7c778bc9",
    "metadata": {},
    "source": [
     "## ⏭️ Next steps\n",
     "\n",
-    "- **[🕵️ Your First Anonymization](01_your_first_anonymization.ipynb)** --\n",
+    "- **[🕵️ Your First Anonymization](../01_your_first_anonymization/)** --\n",
     "  the simplest end-to-end replace workflow if you haven't run it yet.\n",
-    "- **[🎯 Choosing a Replacement Strategy](03_choosing_a_replacement_strategy.ipynb)** --\n",
+    "- **[🎯 Choosing a Replacement Strategy](../03_choosing_a_replacement_strategy/)** --\n",
     "  compare Redact, Annotate, Hash, and Substitute side-by-side.\n",
-    "- **[✏️ Rewriting Biographies](04_rewriting_biographies.ipynb)** --\n",
+    "- **[✏️ Rewriting Biographies](../04_rewriting_biographies/)** --\n",
     "  generate privacy-safe paraphrases instead of token-level replacements."
-   ]
+   ],
+   "id": "7c778bc9"
   }
  ],
  "metadata": {

--- a/docs/notebooks/03_choosing_a_replacement_strategy.ipynb
+++ b/docs/notebooks/03_choosing_a_replacement_strategy.ipynb
@@ -2,12 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8d080723",
    "metadata": {},
    "source": [
     "# 🕵️ Choosing a Replacement Strategy\n",
     "\n",
-    "Four [replace mode](../concepts/replace.md) strategies compared side-by-side on the same data.\n",
+    "Four [replace mode](../../concepts/replace/) strategies compared side-by-side on the same data.\n",
     "\n",
     "| Strategy | What it does |\n",
     "|----------|-------------|\n",
@@ -24,11 +23,11 @@
     "\n",
     "> **Tip:** First time running notebooks? Start with\n",
     "> [setup instructions](https://nvidia-nemo.github.io/Anonymizer/latest/tutorials/)."
-   ]
+   ],
+   "id": "8d080723"
   },
   {
    "cell_type": "markdown",
-   "id": "d17aa3ee",
    "metadata": {},
    "source": [
     "## ⚙️ Setup\n",
@@ -39,12 +38,11 @@
     "- Import all four strategy classes: `Redact`, `Annotate`, `Hash`, `Substitute`.\n",
     "- `Anonymizer()` initializes with the default model provider -- no extra config needed.\n",
     "- `Anonymizer.configure_logging()` controls verbosity -- switch to `Anonymizer.configure_logging(LoggingConfig.debug())` when troubleshooting."
-   ]
+   ],
+   "id": "d17aa3ee"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "dbea2bdd",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:18.738675Z",
@@ -53,7 +51,6 @@
      "shell.execute_reply": "2026-04-03T20:40:18.741704Z"
     }
    },
-   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -63,12 +60,13 @@
     "    if not key:\n",
     "        raise RuntimeError(\"NVIDIA_API_KEY is required to run these notebooks.\")\n",
     "    os.environ[\"NVIDIA_API_KEY\"] = key"
-   ]
+   ],
+   "execution_count": 1,
+   "outputs": [],
+   "id": "dbea2bdd"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "d409e62b",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:18.743845Z",
@@ -77,15 +75,15 @@
      "shell.execute_reply": "2026-04-03T20:40:20.944918Z"
     }
    },
-   "outputs": [],
    "source": [
     "from anonymizer import Annotate, Anonymizer, AnonymizerConfig, AnonymizerInput, Hash, Redact, Substitute"
-   ]
+   ],
+   "execution_count": 2,
+   "outputs": [],
+   "id": "d409e62b"
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "08060e6f",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:20.946338Z",
@@ -94,55 +92,55 @@
      "shell.execute_reply": "2026-04-03T20:40:20.952398Z"
     }
    },
+   "source": [
+    "anonymizer = Anonymizer()"
+   ],
+   "execution_count": 3,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:40:20] [INFO] 🔧 Anonymizer initialized with 3 model configs\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:40:20] [INFO]   |-- 🔎 detector:  gliner-pii-detector\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:40:20] [INFO]   |-- ✅ validator: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:40:20] [INFO]   |-- 🧩 augmenter: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "anonymizer = Anonymizer()"
-   ]
+   "id": "08060e6f"
   },
   {
    "cell_type": "markdown",
-   "id": "1799ebc0",
    "metadata": {},
    "source": [
     "## 📦 Input data\n",
     "\n",
     "- We use the same biographies dataset throughout so each strategy is compared\n",
     "  on identical input."
-   ]
+   ],
+   "id": "1799ebc0"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "aabef9e5",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:20.953566Z",
@@ -151,18 +149,19 @@
      "shell.execute_reply": "2026-04-03T20:40:20.954839Z"
     }
    },
-   "outputs": [],
    "source": [
     "input_data = AnonymizerInput(\n",
     "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
     "    text_column=\"biography\",\n",
     "    data_summary=\"Biographical profiles\",\n",
     ")"
-   ]
+   ],
+   "execution_count": 4,
+   "outputs": [],
+   "id": "aabef9e5"
   },
   {
    "cell_type": "markdown",
-   "id": "b0bd1f83",
    "metadata": {},
    "source": [
     "## 🔄 Substitute\n",
@@ -170,12 +169,11 @@
     "- Uses an LLM to generate contextually appropriate synthetic replacements.\n",
     "  - The LLM considers the full document context matching names with emails, cities to states, etc.\n",
     "- Customize with `instructions` to steer the LLM's replacement choices."
-   ]
+   ],
+   "id": "b0bd1f83"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "8a04f424",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:40:20.955954Z",
@@ -184,71 +182,6 @@
      "shell.execute_reply": "2026-04-03T20:41:18.480354Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:20] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:20] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:20] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:40:20] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:41:02] [INFO]   |-- 📋 Detection complete — 79 entities found across 3 records (0 failed) [41.5s]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:41:02] [INFO]   |-- labels: first_name=22, organization_name=8, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, political_view=4, last_name=3, race_ethnicity=3, language=2, street_address=2, place_name=1, date_of_birth=1, device_identifier=1, employment_status=1, religious_belief=1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:41:02] [INFO] 🔄 Running Substitute replacement\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:41:18] [INFO]   |-- 📋 Replacement complete (0 failed) [16.0s]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[13:41:18] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
-    }
-   ],
    "source": [
     "substitute_config = AnonymizerConfig(replace=Substitute())\n",
     "\n",
@@ -257,12 +190,77 @@
     "    data=input_data,\n",
     "    num_records=3,\n",
     ")"
-   ]
+   ],
+   "execution_count": 5,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:20] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:20] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:20] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:40:20] [INFO] 🔍 Running entity detection on 3 records\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:41:02] [INFO]   |-- 📋 Detection complete — 79 entities found across 3 records (0 failed) [41.5s]\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:41:02] [INFO]   |-- labels: first_name=22, organization_name=8, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, political_view=4, last_name=3, race_ethnicity=3, language=2, street_address=2, place_name=1, date_of_birth=1, device_identifier=1, employment_status=1, religious_belief=1\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:41:02] [INFO] 🔄 Running Substitute replacement\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:41:18] [INFO]   |-- 📋 Replacement complete (0 failed) [16.0s]\n"
+     ],
+     "name": "stdout"
+    },
+    {
+     "output_type": "stream",
+     "text": [
+      "[13:41:18] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
+     ],
+     "name": "stdout"
+    }
+   ],
+   "id": "8a04f424"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "bd541bd3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:41:18.483475Z",
@@ -271,8 +269,13 @@
      "shell.execute_reply": "2026-04-03T20:41:18.486825Z"
     }
    },
+   "source": [
+    "substitute_preview.display_record(0)"
+   ],
+   "execution_count": 6,
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -305,29 +308,24 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "substitute_preview.display_record(0)"
-   ]
+   "id": "bd541bd3"
   },
   {
    "cell_type": "markdown",
-   "id": "3a512eeb",
    "metadata": {},
    "source": [
     "### Custom instructions\n",
     "\n",
     "- Pass `instructions` to guide the LLM -- e.g. keep replacements within\n",
     "  a specific region, culture, or naming convention."
-   ]
+   ],
+   "id": "3a512eeb"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "d2fb3b5b",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:41:18.488348Z",
@@ -337,71 +335,84 @@
     },
     "lines_to_next_cell": 0
    },
+   "source": [
+    "substitute_custom_config = AnonymizerConfig(\n",
+    "    replace=Substitute(instructions=\"Use only Japanese names and locations for all replacements.\")\n",
+    ")\n",
+    "substitute_custom_preview = anonymizer.preview(\n",
+    "    config=substitute_custom_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "substitute_custom_preview.display_record(0)"
+   ],
+   "execution_count": 7,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:18] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:18] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:18] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:18] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:53] [INFO]   |-- 📋 Detection complete — 77 entities found across 3 records (0 failed) [34.7s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:53] [INFO]   |-- labels: first_name=22, organization_name=7, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, place_name=1, date_of_birth=1, employment_status=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:41:53] [INFO] 🔄 Running Substitute replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:42:12] [INFO]   |-- 📋 Replacement complete (0 failed) [19.5s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:42:12] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -434,37 +445,24 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "substitute_custom_config = AnonymizerConfig(\n",
-    "    replace=Substitute(instructions=\"Use only Japanese names and locations for all replacements.\")\n",
-    ")\n",
-    "substitute_custom_preview = anonymizer.preview(\n",
-    "    config=substitute_custom_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "substitute_custom_preview.display_record(0)"
-   ]
+   "id": "d2fb3b5b"
   },
   {
    "cell_type": "markdown",
-   "id": "4b4ab562",
    "metadata": {},
    "source": [
     "## 🚫 Redact\n",
     "\n",
     "- Replaces each entity with a label-based marker. Default: `[REDACTED_FIRST_NAME]`.\n",
     "- Customize with `Redact(format_template=...)`."
-   ]
+   ],
+   "id": "4b4ab562"
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "3281e1f9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:42:12.636234Z",
@@ -473,71 +471,84 @@
      "shell.execute_reply": "2026-04-03T20:43:00.269277Z"
     }
    },
+   "source": [
+    "redact_config = AnonymizerConfig(replace=Redact())\n",
+    "\n",
+    "redact_preview = anonymizer.preview(\n",
+    "    config=redact_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "\n",
+    "redact_preview.display_record(0)"
+   ],
+   "execution_count": 8,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:42:12] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:42:12] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:42:12] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:42:12] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO]   |-- 📋 Detection complete — 78 entities found across 3 records (0 failed) [47.6s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO]   |-- labels: first_name=23, organization_name=7, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, place_name=1, date_of_birth=1, employment_status=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO] 🔄 Running Redact replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -570,36 +581,23 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "redact_config = AnonymizerConfig(replace=Redact())\n",
-    "\n",
-    "redact_preview = anonymizer.preview(\n",
-    "    config=redact_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "\n",
-    "redact_preview.display_record(0)"
-   ]
+   "id": "3281e1f9"
   },
   {
    "cell_type": "markdown",
-   "id": "420b6341",
    "metadata": {},
    "source": [
     "### Custom template\n",
     "\n",
     "- `format_template=\"***\"` replaces every entity with the same constant."
-   ]
+   ],
+   "id": "420b6341"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "9f526a73",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:43:00.272970Z",
@@ -608,71 +606,84 @@
      "shell.execute_reply": "2026-04-03T20:43:41.994444Z"
     }
    },
+   "source": [
+    "custom_config = AnonymizerConfig(replace=Redact(format_template=\"***\"))\n",
+    "\n",
+    "custom_preview = anonymizer.preview(\n",
+    "    config=custom_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "\n",
+    "custom_preview.display_record(0)"
+   ],
+   "execution_count": 9,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:00] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO]   |-- 📋 Detection complete — 77 entities found across 3 records (0 failed) [41.7s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO]   |-- labels: first_name=22, organization_name=8, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, language=2, political_view=2, religious_belief=2, street_address=2, place_name=1, date_of_birth=1, employment_status=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO] 🔄 Running Redact replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -705,25 +716,13 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "custom_config = AnonymizerConfig(replace=Redact(format_template=\"***\"))\n",
-    "\n",
-    "custom_preview = anonymizer.preview(\n",
-    "    config=custom_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "\n",
-    "custom_preview.display_record(0)"
-   ]
+   "id": "9f526a73"
   },
   {
    "cell_type": "markdown",
-   "id": "04d6606c",
    "metadata": {},
    "source": [
     "## 🏷️ Annotate\n",
@@ -732,12 +731,11 @@
     "  Default: `<Alice, first_name>`.\n",
     "- Customize with `format_template` -- must include `{text}` and `{label}`,\n",
     "  e.g. `Annotate(format_template=\"<{text}-|-{label}>\")`."
-   ]
+   ],
+   "id": "04d6606c"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "d3ccdb91",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:43:41.996547Z",
@@ -746,71 +744,84 @@
      "shell.execute_reply": "2026-04-03T20:44:26.441403Z"
     }
    },
+   "source": [
+    "annotate_config = AnonymizerConfig(replace=Annotate())\n",
+    "\n",
+    "annotate_preview = anonymizer.preview(\n",
+    "    config=annotate_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "\n",
+    "annotate_preview.display_record(0)"
+   ],
+   "execution_count": 10,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:43:41] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO]   |-- 📋 Detection complete — 79 entities found across 3 records (0 failed) [44.4s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO]   |-- labels: first_name=22, organization_name=7, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, place_name=1, date_of_birth=1, project_name=1, employment_status=1, company_name=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO] 🔄 Running Annotate replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -843,36 +854,23 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "annotate_config = AnonymizerConfig(replace=Annotate())\n",
-    "\n",
-    "annotate_preview = anonymizer.preview(\n",
-    "    config=annotate_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "\n",
-    "annotate_preview.display_record(0)"
-   ]
+   "id": "d3ccdb91"
   },
   {
    "cell_type": "markdown",
-   "id": "0f5ba191",
    "metadata": {},
    "source": [
     "### Custom template\n",
     "\n",
     "- Override the default format with any string containing `{text}` and `{label}`."
-   ]
+   ],
+   "id": "0f5ba191"
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "63549fdd",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:44:26.442771Z",
@@ -881,71 +879,82 @@
      "shell.execute_reply": "2026-04-03T20:45:13.011059Z"
     }
    },
+   "source": [
+    "annotate_custom_config = AnonymizerConfig(replace=Annotate(format_template=\"<{text}-|-{label}>\"))\n",
+    "annotate_custom_preview = anonymizer.preview(\n",
+    "    config=annotate_custom_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "annotate_custom_preview.display_record(0)"
+   ],
+   "execution_count": 11,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:44:26] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO]   |-- 📋 Detection complete — 78 entities found across 3 records (0 failed) [46.6s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO]   |-- labels: first_name=22, organization_name=7, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, religious_belief=2, street_address=2, place_name=1, date_of_birth=1, telescope_name=1, employment_status=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO] 🔄 Running Annotate replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -978,23 +987,13 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "annotate_custom_config = AnonymizerConfig(replace=Annotate(format_template=\"<{text}-|-{label}>\"))\n",
-    "annotate_custom_preview = anonymizer.preview(\n",
-    "    config=annotate_custom_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "annotate_custom_preview.display_record(0)"
-   ]
+   "id": "63549fdd"
   },
   {
    "cell_type": "markdown",
-   "id": "52224246",
    "metadata": {},
    "source": [
     "## #️⃣ Hash\n",
@@ -1002,12 +1001,11 @@
     "- Deterministic -- same input always produces the same hash.\n",
     "- Customize with `format_template` (must include `{digest}`),\n",
     "  `algorithm` (`sha256`/`sha1`/`md5`), and `digest_length` (6-64 characters)."
-   ]
+   ],
+   "id": "52224246"
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "0a891057",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:45:13.013664Z",
@@ -1016,71 +1014,84 @@
      "shell.execute_reply": "2026-04-03T20:45:56.367376Z"
     }
    },
+   "source": [
+    "hash_config = AnonymizerConfig(replace=Hash())\n",
+    "\n",
+    "hash_preview = anonymizer.preview(\n",
+    "    config=hash_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "\n",
+    "hash_preview.display_record(0)"
+   ],
+   "execution_count": 12,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:13] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO]   |-- 📋 Detection complete — 77 entities found across 3 records (0 failed) [43.3s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO]   |-- labels: first_name=21, organization_name=8, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, political_view=3, last_name=2, race_ethnicity=2, language=2, religious_belief=2, street_address=2, place_name=1, full_name=1, date_of_birth=1, nationality=1, employment_status=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO] 🔄 Running Hash replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -1113,36 +1124,23 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "hash_config = AnonymizerConfig(replace=Hash())\n",
-    "\n",
-    "hash_preview = anonymizer.preview(\n",
-    "    config=hash_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "\n",
-    "hash_preview.display_record(0)"
-   ]
+   "id": "0a891057"
   },
   {
    "cell_type": "markdown",
-   "id": "c8d62ef2",
    "metadata": {},
    "source": [
     "### Custom template\n",
     "\n",
     "- Override the algorithm, digest length, and output format."
-   ]
+   ],
+   "id": "c8d62ef2"
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "de493049",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:45:56.368786Z",
@@ -1152,71 +1150,82 @@
     },
     "lines_to_next_cell": 2
    },
+   "source": [
+    "hash_custom_config = AnonymizerConfig(replace=Hash(algorithm=\"md5\", digest_length=8, format_template=\"[{digest}]\"))\n",
+    "hash_custom_preview = anonymizer.preview(\n",
+    "    config=hash_custom_config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "hash_custom_preview.display_record(0)"
+   ],
+   "execution_count": 13,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:45:56] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:46:37] [INFO]   |-- 📋 Detection complete — 77 entities found across 3 records (0 failed) [41.4s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:46:37] [INFO]   |-- labels: first_name=23, organization_name=7, age=5, occupation=5, city=4, state=4, degree=4, university=4, field_of_study=4, last_name=3, race_ethnicity=3, political_view=3, language=2, street_address=2, place_name=1, date_of_birth=1, employment_status=1, religious_belief=1\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:46:37] [INFO] 🔄 Running Hash replacement\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:46:37] [INFO]   |-- 📋 Replacement complete (0 failed) [0.0s]\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[13:46:37] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -1249,34 +1258,25 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "hash_custom_config = AnonymizerConfig(replace=Hash(algorithm=\"md5\", digest_length=8, format_template=\"[{digest}]\"))\n",
-    "hash_custom_preview = anonymizer.preview(\n",
-    "    config=hash_custom_config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "hash_custom_preview.display_record(0)"
-   ]
+   "id": "de493049"
   },
   {
    "cell_type": "markdown",
-   "id": "2eb7656f",
    "metadata": {},
    "source": [
     "## ⏭️ Next steps\n",
     "\n",
-    "- **[🕵️ Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --\n",
+    "- **[🕵️ Inspecting Detected Entities](../02_inspecting_detected_entities/)** --\n",
     "  dig into what the detection pipeline found and debug quality.\n",
-    "- **[✏️ Rewriting Biographies](04_rewriting_biographies.ipynb)** --\n",
+    "- **[✏️ Rewriting Biographies](../04_rewriting_biographies/)** --\n",
     "  generate privacy-safe paraphrases instead of token-level replacements.\n",
-    "- **[⚖️ Rewriting Legal Documents](05_rewriting_legal_documents.ipynb)** --\n",
+    "- **[⚖️ Rewriting Legal Documents](../05_rewriting_legal_documents/)** --\n",
     "  rewrite legal text with domain-specific privacy goals."
-   ]
+   ],
+   "id": "2eb7656f"
   }
  ],
  "metadata": {

--- a/docs/notebooks/04_rewriting_biographies.ipynb
+++ b/docs/notebooks/04_rewriting_biographies.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "77da6ea6",
    "metadata": {},
    "source": [
     "# 🕵️ Rewriting Biographies\n",
@@ -25,11 +24,11 @@
     "\n",
     "> **Tip:** First time running notebooks? Start with\n",
     "> [setup instructions](https://nvidia-nemo.github.io/Anonymizer/latest/tutorials/)."
-   ]
+   ],
+   "id": "77da6ea6"
   },
   {
    "cell_type": "markdown",
-   "id": "d3035c6c",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -42,14 +41,12 @@
     "- Import `Rewrite` and `PrivacyGoal`.\n",
     "- `Anonymizer()` initializes with the default model provider -- no extra config needed.\n",
     "- `Anonymizer.configure_logging()` controls verbosity -- switch to `Anonymizer.configure_logging(LoggingConfig.debug())` when troubleshooting.\n"
-   ]
+   ],
+   "id": "d3035c6c"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4f1bc6fa",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -59,12 +56,13 @@
     "    if not key:\n",
     "        raise RuntimeError(\"NVIDIA_API_KEY is required to run these notebooks.\")\n",
     "    os.environ[\"NVIDIA_API_KEY\"] = key"
-   ]
+   ],
+   "execution_count": 1,
+   "outputs": [],
+   "id": "4f1bc6fa"
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "d90c1cab",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:46:41.243043Z",
@@ -73,18 +71,18 @@
      "shell.execute_reply": "2026-04-03T20:46:53.000061Z"
     }
    },
-   "outputs": [],
    "source": [
     "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Rewrite, configure_logging, LoggingConfig\n",
     "from anonymizer.config.rewrite import PrivacyGoal\n",
     "\n",
     "configure_logging(LoggingConfig.default())"
-   ]
+   ],
+   "execution_count": 2,
+   "outputs": [],
+   "id": "d90c1cab"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "818ee820",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:46:53.004480Z",
@@ -93,37 +91,37 @@
      "shell.execute_reply": "2026-04-03T20:46:53.045508Z"
     }
    },
+   "source": [
+    "anonymizer = Anonymizer()"
+   ],
+   "execution_count": 3,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:15:48] [INFO] 🔧 Anonymizer initialized with 3 model configs\n",
       "[16:15:48] [INFO]   |-- 🔎 detector:  gliner-pii-detector\n",
       "[16:15:48] [INFO]   |-- ✅ validator: gpt-oss-120b\n",
       "[16:15:48] [INFO]   |-- 🧩 augmenter: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "anonymizer = Anonymizer()"
-   ]
+   "id": "818ee820"
   },
   {
    "cell_type": "markdown",
-   "id": "0506e3ae",
    "metadata": {},
    "source": [
     "## 📦 Input data\n",
     "\n",
     "- Same biographies dataset used in earlier notebooks -- familiar data makes it\n",
     "  easy to compare rewrite output against replace output."
-   ]
+   ],
+   "id": "0506e3ae"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "f340b90c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:46:53.048813Z",
@@ -132,18 +130,19 @@
      "shell.execute_reply": "2026-04-03T20:46:53.051217Z"
     }
    },
-   "outputs": [],
    "source": [
     "input_data = AnonymizerInput(\n",
     "    source=\"https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv\",\n",
     "    text_column=\"biography\",\n",
     "    data_summary=\"Biographical profiles\",\n",
     ")"
-   ]
+   ],
+   "execution_count": 4,
+   "outputs": [],
+   "id": "f340b90c"
   },
   {
    "cell_type": "markdown",
-   "id": "a54f59db",
    "metadata": {},
    "source": [
     "## 🎛️ Configure\n",
@@ -152,13 +151,12 @@
     "  this gives the rewriter clear, domain-specific guidance.\n",
     "- `risk_tolerance` (default `\"low\"`) and `max_repair_iterations` (default `3`)\n",
     "  control the automated quality gate --\n",
-    "  see [Risk tolerance](../concepts/rewrite.md#risk-tolerance) for presets."
-   ]
+    "  see [Risk tolerance](../../concepts/rewrite/#risk-tolerance) for presets."
+   ],
+   "id": "a54f59db"
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "48052047",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:46:53.053443Z",
@@ -167,7 +165,6 @@
      "shell.execute_reply": "2026-04-03T20:46:53.055274Z"
     }
    },
-   "outputs": [],
    "source": [
     "config = AnonymizerConfig(\n",
     "    rewrite=Rewrite(\n",
@@ -177,23 +174,24 @@
     "        ),\n",
     "    ),\n",
     ")"
-   ]
+   ],
+   "execution_count": 5,
+   "outputs": [],
+   "id": "48052047"
   },
   {
    "cell_type": "markdown",
-   "id": "cb1b413f",
    "metadata": {},
    "source": [
     "## 👁️ Preview\n",
     "\n",
     "- `preview()` runs on a small sample so you can iterate on privacy goals\n",
     "  and evaluation criteria before committing to a full run."
-   ]
+   ],
+   "id": "cb1b413f"
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "151d4872",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:46:53.057242Z",
@@ -202,19 +200,28 @@
      "shell.execute_reply": "2026-04-03T20:52:04.704823Z"
     }
    },
+   "source": [
+    "preview = anonymizer.preview(\n",
+    "    config=config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "\n",
+    "preview.display_record(0)"
+   ],
+   "execution_count": 6,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:16:07] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n",
       "[16:16:07] [INFO] detection labels in scope: (default: 65 labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)\n",
       "[16:16:07] [INFO]   |-- 👀 Preview mode: processing 3 of 25 records\n",
       "[16:16:07] [INFO] 🔍 Running entity detection on 3 records\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:17:53] [INFO]   |-- 📋 Detection complete — 80 entities found across 3 records (0 failed) [105.8s]\n",
@@ -223,9 +230,11 @@
       "[16:21:15] [INFO] Evaluate-repair loop: all rows pass at iteration 0\n",
       "[16:21:41] [INFO]   |-- 📋 Rewrite complete (0 failed) [228.2s]\n",
       "[16:21:41] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -262,24 +271,13 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "preview = anonymizer.preview(\n",
-    "    config=config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "\n",
-    "preview.display_record(0)"
-   ]
+   "id": "151d4872"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "919d1149",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:52:04.706776Z",
@@ -288,8 +286,13 @@
      "shell.execute_reply": "2026-04-03T20:52:04.709116Z"
     }
    },
+   "source": [
+    "preview.display_record(1)"
+   ],
+   "execution_count": 7,
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -326,29 +329,24 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "preview.display_record(1)"
-   ]
+   "id": "919d1149"
   },
   {
    "cell_type": "markdown",
-   "id": "b54ec902",
    "metadata": {},
    "source": [
     "## 🚀 Full run\n",
     "\n",
     "- `result.dataframe` has user-facing columns: rewritten text, scores, and the review flag.\n",
     "- `result.trace_dataframe` has every intermediate column for debugging."
-   ]
+   ],
+   "id": "b54ec902"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "89ec3704",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T20:52:04.710490Z",
@@ -357,9 +355,14 @@
      "shell.execute_reply": "2026-04-03T21:20:17.171990Z"
     }
    },
+   "source": [
+    "result = anonymizer.run(config=config, data=input_data)\n",
+    "\n",
+    "result.dataframe.head()"
+   ],
+   "execution_count": 8,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:22:12] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv (column: 'biography')\n",
@@ -372,9 +375,11 @@
       "[16:52:53] [INFO] Evaluate-repair loop iteration 1: 1/25 rows need repair\n",
       "[16:54:14] [INFO]   |-- 📋 Rewrite complete (0 failed) [1482.5s]\n",
       "[16:54:14] [INFO] 🎉 Pipeline complete — 25 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -482,21 +487,14 @@
        "4           0.6               0.055046           False              False  "
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 8
     }
    ],
-   "source": [
-    "result = anonymizer.run(config=config, data=input_data)\n",
-    "\n",
-    "result.dataframe.head()"
-   ]
+   "id": "89ec3704"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "810b4598",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:17.173631Z",
@@ -505,8 +503,13 @@
      "shell.execute_reply": "2026-04-03T21:20:17.176356Z"
     }
    },
+   "source": [
+    "result.dataframe[[\"biography_rewritten\", \"utility_score\", \"leakage_mass\", \"needs_human_review\"]].head()"
+   ],
+   "execution_count": 9,
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -589,22 +592,22 @@
        "4           0.6              False  "
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 9
     }
    ],
-   "source": [
-    "result.dataframe[[\"biography_rewritten\", \"utility_score\", \"leakage_mass\", \"needs_human_review\"]].head()"
-   ]
+   "id": "810b4598"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "6efb03d3",
    "metadata": {},
+   "source": [
+    "result.trace_dataframe.columns.tolist()"
+   ],
+   "execution_count": 10,
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['biography',\n",
@@ -655,32 +658,27 @@
        " 'needs_human_review']"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 10
     }
    ],
-   "source": [
-    "result.trace_dataframe.columns.tolist()"
-   ]
+   "id": "6efb03d3"
   },
   {
    "cell_type": "markdown",
-   "id": "55798fd4",
    "metadata": {},
    "source": [
     "## 🚩 Filter by review flag\n",
     "\n",
     "- Records where automated metrics exceed thresholds are flagged for manual review.\n",
     "- Use this to prioritize human attention on the records that need it most.\n",
-    "- See [Working with flagged records](../concepts/rewrite.md#working-with-flagged-records)\n",
+    "- See [Working with flagged records](../../concepts/rewrite/#working-with-flagged-records)\n",
     "  for guidance on diagnosing and resolving flagged records."
-   ]
+   ],
+   "id": "55798fd4"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "f5b4c953",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:17.180368Z",
@@ -689,15 +687,23 @@
      "shell.execute_reply": "2026-04-03T21:20:17.184127Z"
     }
    },
+   "source": [
+    "df = result.dataframe\n",
+    "flagged = df[df[\"needs_human_review\"] == True]  # noqa: E712\n",
+    "print(f\"{len(flagged)} of {len(df)} records flagged for human review\")\n",
+    "flagged.head()"
+   ],
+   "execution_count": 11,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
      "text": [
       "0 of 25 records flagged for human review\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -738,32 +744,26 @@
        "Index: []"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 11
     }
    ],
-   "source": [
-    "df = result.dataframe\n",
-    "flagged = df[df[\"needs_human_review\"] == True]  # noqa: E712\n",
-    "print(f\"{len(flagged)} of {len(df)} records flagged for human review\")\n",
-    "flagged.head()"
-   ]
+   "id": "f5b4c953"
   },
   {
    "cell_type": "markdown",
-   "id": "e601cc9d",
    "metadata": {},
    "source": [
     "## ⏭️ Next steps\n",
     "\n",
-    "- **[⚖️ Rewriting Legal Documents](05_rewriting_legal_documents.ipynb)** --\n",
+    "- **[⚖️ Rewriting Legal Documents](../05_rewriting_legal_documents/)** --\n",
     "  rewrite legal text with custom entity labels and domain-specific privacy goals.\n",
-    "- **[🎯 Choosing a Replacement Strategy](03_choosing_a_replacement_strategy.ipynb)** --\n",
+    "- **[🎯 Choosing a Replacement Strategy](../03_choosing_a_replacement_strategy/)** --\n",
     "  compare Redact, Annotate, Hash, and Substitute if you prefer token-level replacement.\n",
-    "- **[🔍 Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --\n",
+    "- **[🔍 Inspecting Detected Entities](../02_inspecting_detected_entities/)** --\n",
     "  debug what the detection pipeline found before rewriting."
-   ]
+   ],
+   "id": "e601cc9d"
   }
  ],
  "metadata": {

--- a/docs/notebooks/05_rewriting_legal_documents.ipynb
+++ b/docs/notebooks/05_rewriting_legal_documents.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1f41c65c",
    "metadata": {},
    "source": [
     "# 🕵️ Rewriting Legal Documents\n",
@@ -19,11 +18,11 @@
     "\n",
     "> **Tip:** First time running notebooks? Start with\n",
     "> [setup instructions](https://nvidia-nemo.github.io/Anonymizer/latest/tutorials/)."
-   ]
+   ],
+   "id": "1f41c65c"
   },
   {
    "cell_type": "markdown",
-   "id": "817a7a24",
    "metadata": {},
    "source": [
     "## ⚙️ Setup\n",
@@ -35,12 +34,11 @@
     "- `Anonymizer()` initializes with the default model provider -- no extra config needed.\n",
     "- `configure_logging(enabled=False)` suppresses pipeline logs for cleaner output.\n",
     "  Switch to `configure_logging(LoggingConfig.debug())` when troubleshooting."
-   ]
+   ],
+   "id": "817a7a24"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "793e653d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:21.055638Z",
@@ -49,7 +47,6 @@
      "shell.execute_reply": "2026-04-03T21:20:21.059020Z"
     }
    },
-   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -59,12 +56,13 @@
     "    if not key:\n",
     "        raise RuntimeError(\"NVIDIA_API_KEY is required to run these notebooks.\")\n",
     "    os.environ[\"NVIDIA_API_KEY\"] = key"
-   ]
+   ],
+   "execution_count": 1,
+   "outputs": [],
+   "id": "793e653d"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "14b32183",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:21.062154Z",
@@ -73,18 +71,18 @@
      "shell.execute_reply": "2026-04-03T21:20:38.271979Z"
     }
    },
-   "outputs": [],
    "source": [
     "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Detect, Rewrite, configure_logging, LoggingConfig\n",
     "from anonymizer.config.rewrite import PrivacyGoal\n",
     "\n",
     "configure_logging(LoggingConfig.default())"
-   ]
+   ],
+   "execution_count": 2,
+   "outputs": [],
+   "id": "14b32183"
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "b98cf6d9",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:38.274388Z",
@@ -93,25 +91,26 @@
      "shell.execute_reply": "2026-04-03T21:20:38.306750Z"
     }
    },
+   "source": [
+    "anonymizer = Anonymizer()"
+   ],
+   "execution_count": 3,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:41:39] [INFO] 🔧 Anonymizer initialized with 3 model configs\n",
       "[16:41:39] [INFO]   |-- 🔎 detector:  gliner-pii-detector\n",
       "[16:41:39] [INFO]   |-- ✅ validator: gpt-oss-120b\n",
       "[16:41:39] [INFO]   |-- 🧩 augmenter: gpt-oss-120b\n"
-     ]
+     ],
+     "name": "stdout"
     }
    ],
-   "source": [
-    "anonymizer = Anonymizer()"
-   ]
+   "id": "b98cf6d9"
   },
   {
    "cell_type": "markdown",
-   "id": "0b18d6f8",
    "metadata": {},
    "source": [
     "## 📦 Input data\n",
@@ -120,12 +119,11 @@
     "  legal documents -- court decisions containing names, dates, case numbers, and other legal identifiers.\n",
     "- `LEGAL_ENTITY_LABELS` defines the domain-specific entity types to detect.\n",
     "  This replaces the default label set with one tailored to legal text."
-   ]
+   ],
+   "id": "0b18d6f8"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "315bca05",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:38.308283Z",
@@ -134,7 +132,6 @@
      "shell.execute_reply": "2026-04-03T21:20:38.310357Z"
     }
    },
-   "outputs": [],
    "source": [
     "LEGAL_ENTITY_LABELS = [\n",
     "    \"first_name\",\n",
@@ -169,11 +166,13 @@
     "    text_column=\"text\",\n",
     "    data_summary=\"Legal court decisions containing personal identifiers, case numbers, and institutional references\",\n",
     ")"
-   ]
+   ],
+   "execution_count": 4,
+   "outputs": [],
+   "id": "315bca05"
   },
   {
    "cell_type": "markdown",
-   "id": "08cfa358",
    "metadata": {},
    "source": [
     "## 🎛️ Configure\n",
@@ -182,12 +181,11 @@
     "- `PrivacyGoal` tells the rewriter what to **protect** (identifiers, case numbers,\n",
     "  institutional references) and what to **preserve** (legal reasoning, statutory references,\n",
     "  ruling structure)."
-   ]
+   ],
+   "id": "08cfa358"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "9a38c30b",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:38.311740Z",
@@ -196,7 +194,6 @@
      "shell.execute_reply": "2026-04-03T21:20:38.313292Z"
     }
    },
-   "outputs": [],
    "source": [
     "config = AnonymizerConfig(\n",
     "    detect=Detect(\n",
@@ -211,23 +208,24 @@
     "        max_repair_iterations=3,\n",
     "    ),\n",
     ")"
-   ]
+   ],
+   "execution_count": 5,
+   "outputs": [],
+   "id": "9a38c30b"
   },
   {
    "cell_type": "markdown",
-   "id": "767d9254",
    "metadata": {},
    "source": [
     "## 👁️ Preview\n",
     "\n",
     "- Preview on a few records to check that legal entities are detected\n",
     "  and the rewrite preserves the ruling's structure."
-   ]
+   ],
+   "id": "767d9254"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "55e1c86a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:20:38.314571Z",
@@ -236,9 +234,18 @@
      "shell.execute_reply": "2026-04-03T21:33:42.622355Z"
     }
    },
+   "source": [
+    "preview = anonymizer.preview(\n",
+    "    config=config,\n",
+    "    data=input_data,\n",
+    "    num_records=3,\n",
+    ")\n",
+    "\n",
+    "preview.display_record(0)"
+   ],
+   "execution_count": 6,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:41:39] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/TAB_legal_sample25.csv (column: 'text')\n",
@@ -253,9 +260,11 @@
       "[16:46:56] [INFO] Evaluate-repair loop: all rows pass at iteration 2\n",
       "[16:47:13] [INFO]   |-- 📋 Rewrite complete (0 failed) [296.2s]\n",
       "[16:47:13] [INFO] 🎉 Pipeline complete — 3 records processed, 0 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -344,24 +353,13 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "preview = anonymizer.preview(\n",
-    "    config=config,\n",
-    "    data=input_data,\n",
-    "    num_records=3,\n",
-    ")\n",
-    "\n",
-    "preview.display_record(0)"
-   ]
+   "id": "55e1c86a"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "ce1514da",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:33:42.624465Z",
@@ -370,8 +368,13 @@
      "shell.execute_reply": "2026-04-03T21:33:42.626916Z"
     }
    },
+   "source": [
+    "preview.display_record(1)"
+   ],
+   "execution_count": 7,
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div style=\"font-family:system-ui,-apple-system,sans-serif;max-width:960px;margin:12px 0\">\n",
@@ -496,28 +499,23 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "preview.display_record(1)"
-   ]
+   "id": "ce1514da"
   },
   {
    "cell_type": "markdown",
-   "id": "a1ce53af",
    "metadata": {},
    "source": [
     "## 🚀 Full run\n",
     "\n",
     "- `result.dataframe` has user-facing columns: rewritten text, scores, and the review flag."
-   ]
+   ],
+   "id": "a1ce53af"
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "777731f3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T21:33:42.628227Z",
@@ -526,9 +524,14 @@
      "shell.execute_reply": "2026-04-03T22:24:06.256334Z"
     }
    },
+   "source": [
+    "result = anonymizer.run(config=config, data=input_data)\n",
+    "\n",
+    "result.dataframe.head()"
+   ],
+   "execution_count": 8,
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[16:47:13] [INFO] 📂 Loaded 25 records from https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/TAB_legal_sample25.csv (column: 'text')\n",
@@ -544,9 +547,11 @@
       "[17:11:39] [INFO]   |-- 📋 Rewrite complete (1 failed) [1211.3s]\n",
       "[17:11:39] [WARNING] 1 record(s) failed during pipeline processing.\n",
       "[17:11:39] [INFO] 🎉 Pipeline complete — 25 records processed, 1 total failures\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -694,21 +699,14 @@
        "4          0.57               0.033529           False              False  "
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 8
     }
    ],
-   "source": [
-    "result = anonymizer.run(config=config, data=input_data)\n",
-    "\n",
-    "result.dataframe.head()"
-   ]
+   "id": "777731f3"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "53db201a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T22:24:06.257957Z",
@@ -717,8 +715,13 @@
      "shell.execute_reply": "2026-04-03T22:24:06.260455Z"
     }
    },
+   "source": [
+    "result.dataframe[[\"text_rewritten\", \"utility_score\", \"leakage_mass\", \"needs_human_review\"]].head()"
+   ],
+   "execution_count": 9,
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -821,32 +824,27 @@
        "4          0.57              False  "
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 9
     }
    ],
-   "source": [
-    "result.dataframe[[\"text_rewritten\", \"utility_score\", \"leakage_mass\", \"needs_human_review\"]].head()"
-   ]
+   "id": "53db201a"
   },
   {
    "cell_type": "markdown",
-   "id": "d36e1053",
    "metadata": {},
    "source": [
     "## 🚩 Filter by review flag\n",
     "\n",
     "- Records where automated metrics exceed thresholds are flagged for manual review.\n",
     "- Use this to prioritize human attention on the records that need it most.\n",
-    "- See [Working with flagged records](../concepts/rewrite.md#working-with-flagged-records)\n",
+    "- See [Working with flagged records](../../concepts/rewrite/#working-with-flagged-records)\n",
     "  for guidance on diagnosing and resolving flagged records."
-   ]
+   ],
+   "id": "d36e1053"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "2875d21c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-03T22:24:06.261580Z",
@@ -855,15 +853,23 @@
      "shell.execute_reply": "2026-04-03T22:24:06.265491Z"
     }
    },
+   "source": [
+    "df = result.dataframe\n",
+    "flagged = df[df[\"needs_human_review\"] == True]  # noqa: E712\n",
+    "print(f\"{len(flagged)} of {len(df)} records flagged for human review\")\n",
+    "flagged.head()"
+   ],
+   "execution_count": 10,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
      "text": [
       "7 of 24 records flagged for human review\n"
-     ]
+     ],
+     "name": "stdout"
     },
     {
+     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -1011,30 +1017,24 @@
        "18          4.38               0.183264            True               True  "
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 10
     }
    ],
-   "source": [
-    "df = result.dataframe\n",
-    "flagged = df[df[\"needs_human_review\"] == True]  # noqa: E712\n",
-    "print(f\"{len(flagged)} of {len(df)} records flagged for human review\")\n",
-    "flagged.head()"
-   ]
+   "id": "2875d21c"
   },
   {
    "cell_type": "markdown",
-   "id": "31bd00f6",
    "metadata": {},
    "source": [
     "## ⏭️ Next steps\n",
     "\n",
-    "- **[🔍 Inspecting Detected Entities](02_inspecting_detected_entities.ipynb)** --\n",
+    "- **[🔍 Inspecting Detected Entities](../02_inspecting_detected_entities/)** --\n",
     "  debug what the detection pipeline found before rewriting.\n",
     "- **Try it on your own data!** Swap in your CSV, define entity labels for your\n",
     "  domain, and set a `PrivacyGoal` that fits -- you've got all the building blocks."
-   ]
+   ],
+   "id": "31bd00f6"
   }
  ],
  "metadata": {

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -67,22 +67,22 @@ Set your `NVIDIA_API_KEY` in the same shell where you launch Jupyter. If `NVIDIA
 
 ## 📚 Tutorial Series
 
-### 1. [Your First Anonymization](../notebooks/02_inspecting_detected_entities.ipynb)
+### 1. [Your First Anonymization](../notebooks/01_your_first_anonymization/)
 
 Learn the basic end-to-end flow: load data, configure replace mode, preview, inspect, and run.
 
-### 2. [Inspecting Detected Entities](../notebooks/02_inspecting_detected_entities.ipynb)
+### 2. [Inspecting Detected Entities](../notebooks/02_inspecting_detected_entities/)
 
 Understand what detection produced, how entities are labeled, and where they came from.
 
-### 3. [Choosing a Replacement Strategy](../notebooks/03_choosing_a_replacement_strategy.ipynb)
+### 3. [Choosing a Replacement Strategy](../notebooks/03_choosing_a_replacement_strategy/)
 
 Compare replace mode options -- Redact, Annotate, Hash, and Substitute -- side by side, including custom templates.
 
-### 4. [Rewriting Biographies](../notebooks/04_rewriting_biographies.ipynb)
+### 4. [Rewriting Biographies](../notebooks/04_rewriting_biographies/)
 
 Use rewrite mode with privacy goals, evaluation criteria, and review-flag triage.
 
-### 5. [Rewriting Legal Documents](../notebooks/05_rewriting_legal_documents.ipynb)
+### 5. [Rewriting Legal Documents](../notebooks/05_rewriting_legal_documents/)
 
 Apply rewrite mode to legal-domain text with custom entity labels and stricter protection goals.


### PR DESCRIPTION
## Summary
- Fix all broken cross-notebook links in tutorials (bare `.ipynb` → MkDocs directory URLs)
- Fix broken concept page links from notebooks (`../concepts/` → `../../concepts/`)
- Fix stale link in tutorials overview (Tutorial 1 pointed to wrong notebook)
- Fix CI workflow: remove undefined `matrix.python-version` from lint/typecheck jobs
- Fix nbformat validation errors across all 5 notebooks (missing `name`, `metadata`, `execution_count`)

## Test plan
- [x] `mkdocs serve` builds without errors
- [x] All 5 notebooks pass `nbformat.validate()`
- [x] Spot-check cross-notebook and concept links on local docs site