### PR TITLE
chore: fix stale package name in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -153,78 +153,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anonymizer"
-source = { editable = "." }
-dependencies = [
-    { name = "cryptography" },
-    { name = "cyclopts" },
-    { name = "data-designer" },
-    { name = "pydantic" },
-    { name = "pygments" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-docs = [
-    { name = "griffe-pydantic" },
-    { name = "jupytext" },
-    { name = "mike" },
-    { name = "mkdocs-gen-files" },
-    { name = "mkdocs-jupyter" },
-    { name = "mkdocs-literate-nav" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-]
-notebooks = [
-    { name = "datasets" },
-    { name = "ipykernel" },
-    { name = "jupyter" },
-    { name = "jupytext" },
-    { name = "pillow" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "cryptography", specifier = ">=46.0.6" },
-    { name = "cyclopts", specifier = ">=3" },
-    { name = "data-designer", specifier = "==0.5.0" },
-    { name = "pydantic", specifier = ">=2.9,<3" },
-    { name = "pygments", specifier = ">=2.20.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pre-commit", specifier = ">=4.0.0,<5" },
-    { name = "pytest", specifier = ">=8.0,<9" },
-    { name = "pytest-cov", specifier = ">=7.0,<8" },
-    { name = "ruff", specifier = ">=0.12.3,<1" },
-    { name = "ty", specifier = ">=0.0.23,<0.1" },
-]
-docs = [
-    { name = "griffe-pydantic" },
-    { name = "jupytext" },
-    { name = "mike", specifier = ">=2.1.3,<3" },
-    { name = "mkdocs-gen-files" },
-    { name = "mkdocs-jupyter" },
-    { name = "mkdocs-literate-nav" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extras = ["python"] },
-]
-notebooks = [
-    { name = "datasets", specifier = ">=4.0.0,<5" },
-    { name = "ipykernel", specifier = ">=6.29.0,<7" },
-    { name = "jupyter", specifier = ">=1.0.0,<2" },
-    { name = "jupytext", specifier = ">=1.16.0,<2" },
-    { name = "pillow", specifier = ">=12.0.0,<13" },
-]
-
-[[package]]
 name = "anyascii"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2708,6 +2636,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nemo-anonymizer"
+source = { editable = "." }
+dependencies = [
+    { name = "cryptography" },
+    { name = "cyclopts" },
+    { name = "data-designer" },
+    { name = "pydantic" },
+    { name = "pygments" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+docs = [
+    { name = "griffe-pydantic" },
+    { name = "jupytext" },
+    { name = "mike" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-jupyter" },
+    { name = "mkdocs-literate-nav" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
+notebooks = [
+    { name = "datasets" },
+    { name = "ipykernel" },
+    { name = "jupyter" },
+    { name = "jupytext" },
+    { name = "pillow" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cryptography", specifier = ">=46.0.6" },
+    { name = "cyclopts", specifier = ">=3" },
+    { name = "data-designer", specifier = "==0.5.0" },
+    { name = "pydantic", specifier = ">=2.9,<3" },
+    { name = "pygments", specifier = ">=2.20.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.0.0,<5" },
+    { name = "pytest", specifier = ">=8.0,<9" },
+    { name = "pytest-cov", specifier = ">=7.0,<8" },
+    { name = "ruff", specifier = ">=0.12.3,<1" },
+    { name = "ty", specifier = ">=0.0.23,<0.1" },
+]
+docs = [
+    { name = "griffe-pydantic" },
+    { name = "jupytext" },
+    { name = "mike", specifier = ">=2.1.3,<3" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-jupyter" },
+    { name = "mkdocs-literate-nav" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extras = ["python"] },
+]
+notebooks = [
+    { name = "datasets", specifier = ">=4.0.0,<5" },
+    { name = "ipykernel", specifier = ">=6.29.0,<7" },
+    { name = "jupyter", specifier = ">=1.0.0,<2" },
+    { name = "jupytext", specifier = ">=1.16.0,<2" },
+    { name = "pillow", specifier = ">=12.0.0,<13" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Regenerate `uv.lock` to match the `nemo-anonymizer` package name in `pyproject.toml`. The lockfile still referenced the old `anonymizer` name, causing `make lock-check` to fail.
## Test plan
- [x] `uv lock` completes without error
- [x] `make lock-check` passes