### PR TITLE
fix: register ipykernel before jupytext notebook execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ docs-build:
 convert-notebooks:
 	@echo "Converting Python tutorials to notebooks and executing..."
 	@mkdir -p docs/notebooks
+	uv run --group notebooks python -m ipykernel install --user --name anonymizer-venv
 	uv run --group notebooks --group docs jupytext --to ipynb --execute docs/notebook_source/*.py
 	mv docs/notebook_source/*.ipynb docs/notebooks/
 	@echo "Notebooks created in docs/notebooks/"


### PR DESCRIPTION
## Summary
Jupytext requires a registered Jupyter kernel matching the current Python executable. CI runners have none by default, causing `No kernel found` errors during notebook builds.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
Successful run with `make convert-notebooks` after clearing all old virtual environments. 