### PR TITLE
feat: make preview input loading lightweight

### DIFF
--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -51,6 +51,8 @@ def _load_dataframe(input_data: AnonymizerInput, *, nrows: int | None = None) ->
         if suffix == ".csv":
             df = pd.read_csv(source_str, nrows=nrows)
         else:
+            # TODO: pd.read_parquet loads the entire file; for a true partial
+            # read use pyarrow.parquet.ParquetFile(...).iter_batches(...).
             df = pd.read_parquet(source_str)
             if nrows is not None:
                 df = df.head(nrows)

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -44,9 +44,18 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
 
 
 def _read_parquet_partial(source: str, *, nrows: int | None = None) -> pd.DataFrame:
-    """Read a Parquet file, stopping early when *nrows* is set."""
+    """Read a Parquet file, stopping early when *nrows* is set.
+
+    Returns a schema-preserving empty DataFrame when *nrows* is zero or negative.
+    """
     if nrows is None:
         return pd.read_parquet(source)
+    if nrows <= 0:
+        schema = pq.ParquetFile(source).schema_arrow
+        empty = pa.table(
+            {name: pa.array([], type=field.type) for name, field in zip(schema.names, schema)},
+        )
+        return empty.to_pandas()
     pf = pq.ParquetFile(source)
     batches: list[pa.RecordBatch] = []
     rows_so_far = 0

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pandas as pd
 
 from anonymizer.config.anonymizer_config import AnonymizerInput, infer_input_source_suffix
@@ -10,10 +12,17 @@ from anonymizer.engine.constants import COL_TEXT
 from anonymizer.engine.io.constants import SUPPORTED_IO_FORMATS
 from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
 
+logger = logging.getLogger("anonymizer")
 
-def read_input(input_data: AnonymizerInput) -> pd.DataFrame:
-    """Load input into a normalized dataframe with canonical internal text column."""
-    dataframe = _load_dataframe(input_data)
+
+def read_input(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.DataFrame:
+    """Load input into a normalized dataframe with canonical internal text column.
+
+    Args:
+        input_data: Input source definition.
+        nrows: Maximum rows to read.  ``None`` reads the entire file.
+    """
+    dataframe = _load_dataframe(input_data, nrows=nrows)
     selected_text_column = input_data.text_column
     if selected_text_column not in dataframe.columns:
         raise InvalidInputError(f"Input text column '{selected_text_column}' not found.")
@@ -32,7 +41,7 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
     )
 
 
-def _load_dataframe(input_data: AnonymizerInput) -> pd.DataFrame:
+def _load_dataframe(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.DataFrame:
     source_str = str(input_data.source)
     suffix = infer_input_source_suffix(source_str)
     if suffix not in SUPPORTED_IO_FORMATS:
@@ -40,7 +49,20 @@ def _load_dataframe(input_data: AnonymizerInput) -> pd.DataFrame:
         raise InvalidInputError(f"Unsupported input format: {suffix}. Use {supported_formats}.")
     try:
         if suffix == ".csv":
-            return pd.read_csv(source_str)
-        return pd.read_parquet(source_str)
+            df = pd.read_csv(source_str, nrows=nrows)
+        else:
+            df = pd.read_parquet(source_str)
+            if nrows is not None:
+                df = df.head(nrows)
     except (OSError, pd.errors.ParserError, ValueError) as error:
         raise AnonymizerIOError(f"Failed to read input data from: {source_str}") from error
+    if nrows is not None:
+        logger.info(
+            "👀 Preview mode: 📂 Loaded %d records from %s (column: '%s')",
+            len(df),
+            source_str,
+            input_data.text_column,
+        )
+    else:
+        logger.info("📂 Loaded %d records from %s (column: '%s')", len(df), source_str, input_data.text_column)
+    return df

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -74,6 +74,8 @@ def _load_dataframe(input_data: AnonymizerInput, *, nrows: int | None = None) ->
     if suffix not in SUPPORTED_IO_FORMATS:
         supported_formats = " or ".join(SUPPORTED_IO_FORMATS)
         raise InvalidInputError(f"Unsupported input format: {suffix}. Use {supported_formats}.")
+    if nrows is not None and nrows <= 0:
+        logger.debug("nrows=%d; returning empty DataFrame for %s", nrows, source_str)
     try:
         if suffix == ".csv":
             df = pd.read_csv(source_str, nrows=nrows)

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import logging
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from anonymizer.config.anonymizer_config import AnonymizerInput, infer_input_source_suffix
 from anonymizer.engine.constants import COL_TEXT
@@ -41,6 +43,22 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
     )
 
 
+def _read_parquet_partial(source: str, *, nrows: int | None = None) -> pd.DataFrame:
+    """Read a Parquet file, stopping early when *nrows* is set."""
+    if nrows is None:
+        return pd.read_parquet(source)
+    pf = pq.ParquetFile(source)
+    batches: list[pa.RecordBatch] = []
+    rows_so_far = 0
+    for batch in pf.iter_batches(batch_size=nrows):
+        batches.append(batch)
+        rows_so_far += len(batch)
+        if rows_so_far >= nrows:
+            break
+    table = pa.Table.from_batches(batches, schema=pf.schema_arrow)
+    return table.slice(0, nrows).to_pandas()
+
+
 def _load_dataframe(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.DataFrame:
     source_str = str(input_data.source)
     suffix = infer_input_source_suffix(source_str)
@@ -51,11 +69,7 @@ def _load_dataframe(input_data: AnonymizerInput, *, nrows: int | None = None) ->
         if suffix == ".csv":
             df = pd.read_csv(source_str, nrows=nrows)
         else:
-            # TODO: pd.read_parquet loads the entire file; for a true partial
-            # read use pyarrow.parquet.ParquetFile(...).iter_batches(...).
-            df = pd.read_parquet(source_str)
-            if nrows is not None:
-                df = df.head(nrows)
+            df = _read_parquet_partial(source_str, nrows=nrows)
     except (OSError, pd.errors.ParserError, ValueError) as error:
         raise AnonymizerIOError(f"Failed to read input data from: {source_str}") from error
     if nrows is not None:

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -170,14 +170,18 @@ class Anonymizer:
             effective_records = min(preview_num_records, num_records)
             if effective_records < preview_num_records:
                 logger.info(
-                    LOG_INDENT + "👀 Preview mode: capped to %d records (requested %d, available %d)",
+                    LOG_INDENT + "🔍 Running entity detection on capped %d records (requested %d, available %d)",
                     effective_records,
                     preview_num_records,
                     num_records,
                 )
             else:
-                logger.info(LOG_INDENT + "👀 Preview mode: processing %d of %d records", effective_records, num_records)
+                logger.info(
+                    LOG_INDENT + "🔍 Running entity detection on %d of %d records", effective_records, num_records
+                )
             preview_num_records = effective_records
+        else:
+            logger.info("🔍 Running entity detection on %d records", num_records)
         if logger.isEnabledFor(logging.DEBUG):
             text_lengths = input_df[COL_TEXT].astype(str).str.len()
             logger.debug(
@@ -200,7 +204,6 @@ class Anonymizer:
                 or f"(default: {len(DEFAULT_ENTITY_LABELS)} labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)",
             )
 
-        logger.info("🔍 Running entity detection on %d records", num_records)
         t0 = time.perf_counter()
         detection_result = self._detection_workflow.run(
             input_df,

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -126,7 +126,8 @@ class Anonymizer:
             data: Input source with file path, text column, and optional data summary.
         """
         self._validate_preflight_config(config)
-        return self._run_internal(config=config, data=data, preview_num_records=None)
+        input_df = read_input(data)
+        return self._run_internal(config=config, data=data, input_df=input_df)
 
     def preview(
         self,
@@ -143,7 +144,8 @@ class Anonymizer:
             num_records: Maximum records to process (default 10).
         """
         self._validate_preflight_config(config)
-        result = self._run_internal(config=config, data=data, preview_num_records=num_records)
+        input_df = read_input(data, nrows=num_records)
+        result = self._run_internal(config=config, data=data, input_df=input_df)
         return PreviewResult(
             dataframe=result.dataframe,
             trace_dataframe=result.trace_dataframe,
@@ -160,11 +162,9 @@ class Anonymizer:
         *,
         config: AnonymizerConfig,
         data: AnonymizerInput,
-        preview_num_records: int | None,
+        input_df: pd.DataFrame,
     ) -> AnonymizerResult:
-        input_df = read_input(data)
         num_records = len(input_df)
-        logger.info("📂 Loaded %d records from %s (column: '%s')", num_records, data.source, data.text_column)
         if logger.isEnabledFor(logging.DEBUG):
             text_lengths = input_df[COL_TEXT].astype(str).str.len()
             logger.debug(
@@ -187,11 +187,7 @@ class Anonymizer:
                 or f"(default: {len(DEFAULT_ENTITY_LABELS)} labels; see anonymizer.DEFAULT_ENTITY_LABELS for list)",
             )
 
-        effective_records = num_records
-        if preview_num_records is not None:
-            effective_records = min(preview_num_records, num_records)
-            logger.info(LOG_INDENT + "👀 Preview mode: processing %d of %d records", effective_records, num_records)
-        logger.info("🔍 Running entity detection on %d records", effective_records)
+        logger.info("🔍 Running entity detection on %d records", num_records)
         t0 = time.perf_counter()
         detection_result = self._detection_workflow.run(
             input_df,
@@ -203,7 +199,6 @@ class Anonymizer:
             data_summary=data.data_summary,
             tag_latent_entities=config.rewrite is not None,
             compute_grouped_entities=config.replace is not None or config.rewrite is not None,
-            preview_num_records=preview_num_records,
         )
         detection_elapsed = time.perf_counter() - t0
         entity_count = _count_entities(detection_result.dataframe)
@@ -229,7 +224,6 @@ class Anonymizer:
                 replace_method=config.replace,
                 model_configs=self._model_configs,
                 selected_models=self._selected_models.replace,
-                preview_num_records=preview_num_records,
             )
             replace_elapsed = time.perf_counter() - t0
             final_df = replace_result.dataframe
@@ -250,7 +244,6 @@ class Anonymizer:
                 privacy_goal=config.rewrite.privacy_goal,
                 evaluation=config.rewrite.evaluation,
                 data_summary=data.data_summary,
-                preview_num_records=preview_num_records,
             )
             rewrite_elapsed = time.perf_counter() - t0
             final_df = rewrite_result.dataframe
@@ -270,9 +263,7 @@ class Anonymizer:
             for f in all_failures:
                 logger.debug("  %s (%s: %s)", f.record_id, f.step, f.reason)
         renamed_trace = _rename_output_columns(final_df)
-        logger.info(
-            "🎉 Pipeline complete — %d records processed, %d total failures", effective_records, len(all_failures)
-        )
+        logger.info("🎉 Pipeline complete — %d records processed, %d total failures", num_records, len(all_failures))
         return AnonymizerResult(
             dataframe=_build_user_dataframe(renamed_trace),
             trace_dataframe=renamed_trace,

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -166,6 +166,18 @@ class Anonymizer:
         preview_num_records: int | None,
     ) -> AnonymizerResult:
         num_records = len(input_df)
+        if preview_num_records is not None and preview_num_records != num_records:
+            effective_records = min(preview_num_records, num_records)
+            if effective_records < preview_num_records:
+                logger.info(
+                    LOG_INDENT + "👀 Preview mode: capped to %d records (requested %d, available %d)",
+                    effective_records,
+                    preview_num_records,
+                    num_records,
+                )
+            else:
+                logger.info(LOG_INDENT + "👀 Preview mode: processing %d of %d records", effective_records, num_records)
+            preview_num_records = effective_records
         if logger.isEnabledFor(logging.DEBUG):
             text_lengths = input_df[COL_TEXT].astype(str).str.len()
             logger.debug(

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -127,7 +127,7 @@ class Anonymizer:
         """
         self._validate_preflight_config(config)
         input_df = read_input(data)
-        return self._run_internal(config=config, data=data, input_df=input_df)
+        return self._run_internal(config=config, data=data, input_df=input_df, preview_num_records=None)
 
     def preview(
         self,
@@ -145,7 +145,7 @@ class Anonymizer:
         """
         self._validate_preflight_config(config)
         input_df = read_input(data, nrows=num_records)
-        result = self._run_internal(config=config, data=data, input_df=input_df)
+        result = self._run_internal(config=config, data=data, input_df=input_df, preview_num_records=num_records)
         return PreviewResult(
             dataframe=result.dataframe,
             trace_dataframe=result.trace_dataframe,
@@ -163,6 +163,7 @@ class Anonymizer:
         config: AnonymizerConfig,
         data: AnonymizerInput,
         input_df: pd.DataFrame,
+        preview_num_records: int | None,
     ) -> AnonymizerResult:
         num_records = len(input_df)
         if logger.isEnabledFor(logging.DEBUG):
@@ -199,6 +200,7 @@ class Anonymizer:
             data_summary=data.data_summary,
             tag_latent_entities=config.rewrite is not None,
             compute_grouped_entities=config.replace is not None or config.rewrite is not None,
+            preview_num_records=preview_num_records,
         )
         detection_elapsed = time.perf_counter() - t0
         entity_count = _count_entities(detection_result.dataframe)
@@ -224,6 +226,7 @@ class Anonymizer:
                 replace_method=config.replace,
                 model_configs=self._model_configs,
                 selected_models=self._selected_models.replace,
+                preview_num_records=preview_num_records,
             )
             replace_elapsed = time.perf_counter() - t0
             final_df = replace_result.dataframe
@@ -244,6 +247,7 @@ class Anonymizer:
                 privacy_goal=config.rewrite.privacy_goal,
                 evaluation=config.rewrite.evaluation,
                 data_summary=data.data_summary,
+                preview_num_records=preview_num_records,
             )
             rewrite_elapsed = time.perf_counter() - t0
             final_df = rewrite_result.dataframe

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -15,6 +15,23 @@ from anonymizer.engine.io.reader import read_input
 from anonymizer.engine.io.writer import write_output
 from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
 
+_WRITERS = {
+    ".csv": lambda df, p: df.to_csv(p, index=False),
+    ".parquet": lambda df, p: df.to_parquet(p, index=False),
+}
+
+
+def _write_input(
+    df: pd.DataFrame,
+    tmp_path: Path,
+    suffix: str = ".csv",
+    **input_kwargs: object,
+) -> AnonymizerInput:
+    """Write *df* to a temp file and return a ready-to-use ``AnonymizerInput``."""
+    file_path = tmp_path / f"data{suffix}"
+    _WRITERS[suffix](df, file_path)
+    return AnonymizerInput(source=str(file_path), **input_kwargs)
+
 
 def test_write_output_csv_roundtrips(stub_dataframe: pd.DataFrame, tmp_path: Path) -> None:
     out_path = tmp_path / "out.csv"
@@ -100,29 +117,20 @@ def test_read_input_remote_url_with_unsupported_format_raises() -> None:
 
 
 def test_read_input_renames_text_column(tmp_path: Path) -> None:
-    df = pd.DataFrame({"content": ["hello world"]})
-    file_path = tmp_path / "data.csv"
-    df.to_csv(file_path, index=False)
-    inp = AnonymizerInput(source=str(file_path), text_column="content")
+    inp = _write_input(pd.DataFrame({"content": ["hello world"]}), tmp_path, text_column="content")
     result = read_input(inp)
     assert COL_TEXT in result.columns
     assert result.attrs["original_text_column"] == "content"
 
 
 def test_read_input_missing_text_column_raises(tmp_path: Path) -> None:
-    df = pd.DataFrame({"other": ["hello"]})
-    file_path = tmp_path / "data.csv"
-    df.to_csv(file_path, index=False)
-    inp = AnonymizerInput(source=str(file_path), text_column="missing_col")
+    inp = _write_input(pd.DataFrame({"other": ["hello"]}), tmp_path, text_column="missing_col")
     with pytest.raises(InvalidInputError, match="Input text column 'missing_col' not found"):
         read_input(inp)
 
 
 def test_read_input_internal_text_collision_raises(tmp_path: Path) -> None:
-    df = pd.DataFrame({COL_TEXT: ["hello"], "bio": ["other"]})
-    file_path = tmp_path / "data.csv"
-    df.to_csv(file_path, index=False)
-    inp = AnonymizerInput(source=str(file_path), text_column="bio")
+    inp = _write_input(pd.DataFrame({COL_TEXT: ["hello"], "bio": ["other"]}), tmp_path, text_column="bio")
     with pytest.raises(InvalidInputError, match="reserved internal column"):
         read_input(inp)
 
@@ -136,10 +144,7 @@ def test_read_input_unsupported_format_raises(tmp_path: Path) -> None:
 
 
 def test_read_input_preserves_text_attr_when_column_exists(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": ["hello"]})
-    file_path = tmp_path / "data.csv"
-    df.to_csv(file_path, index=False)
-    inp = AnonymizerInput(source=str(file_path))
+    inp = _write_input(pd.DataFrame({"text": ["hello"]}), tmp_path)
     result = read_input(inp)
     assert result.attrs["original_text_column"] == "text"
 
@@ -164,14 +169,12 @@ def test_anonymizer_input_directory_path_raises_validation_error(tmp_path: Path)
 
 
 def test_read_input_pandas_failure_raises_anonymizer_io_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    file_path = tmp_path / "data.csv"
-    file_path.write_text("text\nhello\n")
+    inp = _write_input(pd.DataFrame({"text": ["hello"]}), tmp_path)
 
     def _raise_read_error(*args: object, **kwargs: object) -> None:
         raise OSError("permission denied")
 
     monkeypatch.setattr(pd, "read_csv", _raise_read_error)
-    inp = AnonymizerInput(source=str(file_path))
     with pytest.raises(AnonymizerIOError, match="Failed to read input data"):
         read_input(inp)
 
@@ -207,49 +210,34 @@ def test_write_output_unwritable_path_raises_anonymizer_io_error(
 
 
 def test_read_input_nrows_truncates_csv(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": [f"row {i}" for i in range(20)]})
-    file_path = tmp_path / "big.csv"
-    df.to_csv(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=5)
+    inp = _write_input(pd.DataFrame({"text": [f"row {i}" for i in range(20)]}), tmp_path)
+    result = read_input(inp, nrows=5)
     assert len(result) == 5
     assert result[COL_TEXT].tolist() == [f"row {i}" for i in range(5)]
 
 
 def test_read_input_nrows_truncates_parquet(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": [f"row {i}" for i in range(20)]})
-    file_path = tmp_path / "big.parquet"
-    df.to_parquet(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=5)
+    inp = _write_input(pd.DataFrame({"text": [f"row {i}" for i in range(20)]}), tmp_path, suffix=".parquet")
+    result = read_input(inp, nrows=5)
     assert len(result) == 5
     assert result[COL_TEXT].tolist() == [f"row {i}" for i in range(5)]
 
 
 def test_read_input_nrows_larger_than_file_returns_all(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": ["a", "b", "c"]})
-    file_path = tmp_path / "small.csv"
-    df.to_csv(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=100)
+    inp = _write_input(pd.DataFrame({"text": ["a", "b", "c"]}), tmp_path)
+    result = read_input(inp, nrows=100)
     assert len(result) == 3
 
 
 def test_read_input_nrows_none_returns_all(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": [f"row {i}" for i in range(20)]})
-    file_path = tmp_path / "full.csv"
-    df.to_csv(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=None)
+    inp = _write_input(pd.DataFrame({"text": [f"row {i}" for i in range(20)]}), tmp_path)
+    result = read_input(inp, nrows=None)
     assert len(result) == 20
 
 
 def test_read_input_nrows_preserves_attrs(tmp_path: Path) -> None:
-    df = pd.DataFrame({"bio": [f"row {i}" for i in range(10)]})
-    file_path = tmp_path / "data.csv"
-    df.to_csv(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path), text_column="bio"), nrows=3)
+    inp = _write_input(pd.DataFrame({"bio": [f"row {i}" for i in range(10)]}), tmp_path, text_column="bio")
+    result = read_input(inp, nrows=3)
     assert len(result) == 3
     assert result.attrs["original_text_column"] == "bio"
     assert COL_TEXT in result.columns
@@ -276,40 +264,28 @@ def test_read_input_nrows_remote_csv(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_read_input_nrows_zero_returns_empty_parquet(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": ["a", "b", "c"]})
-    file_path = tmp_path / "data.parquet"
-    df.to_parquet(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=0)
+    inp = _write_input(pd.DataFrame({"text": ["a", "b", "c"]}), tmp_path, suffix=".parquet")
+    result = read_input(inp, nrows=0)
     assert len(result) == 0
     assert COL_TEXT in result.columns
 
 
 def test_read_input_nrows_zero_returns_empty_csv(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": ["a", "b", "c"]})
-    file_path = tmp_path / "data.csv"
-    df.to_csv(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=0)
+    inp = _write_input(pd.DataFrame({"text": ["a", "b", "c"]}), tmp_path)
+    result = read_input(inp, nrows=0)
     assert len(result) == 0
     assert COL_TEXT in result.columns
 
 
 def test_read_input_nrows_negative_returns_empty_parquet(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": ["a", "b", "c"]})
-    file_path = tmp_path / "data.parquet"
-    df.to_parquet(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=-5)
+    inp = _write_input(pd.DataFrame({"text": ["a", "b", "c"]}), tmp_path, suffix=".parquet")
+    result = read_input(inp, nrows=-5)
     assert len(result) == 0
     assert COL_TEXT in result.columns
 
 
 def test_read_input_empty_parquet_returns_empty(tmp_path: Path) -> None:
-    df = pd.DataFrame({"text": pd.Series([], dtype="object")})
-    file_path = tmp_path / "empty.parquet"
-    df.to_parquet(file_path, index=False)
-
-    result = read_input(AnonymizerInput(source=str(file_path)), nrows=5)
+    inp = _write_input(pd.DataFrame({"text": pd.Series([], dtype="object")}), tmp_path, suffix=".parquet")
+    result = read_input(inp, nrows=5)
     assert len(result) == 0
     assert COL_TEXT in result.columns

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -268,3 +268,48 @@ def test_read_input_nrows_remote_csv(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pd, "read_csv", _read_csv)
     result = read_input(AnonymizerInput(source=source), nrows=5)
     assert len(result) == 5
+
+
+# ---------------------------------------------------------------------------
+# nrows edge-cases: zero, negative, and empty input
+# ---------------------------------------------------------------------------
+
+
+def test_read_input_nrows_zero_returns_empty_parquet(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    file_path = tmp_path / "data.parquet"
+    df.to_parquet(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=0)
+    assert len(result) == 0
+    assert COL_TEXT in result.columns
+
+
+def test_read_input_nrows_zero_returns_empty_csv(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    file_path = tmp_path / "data.csv"
+    df.to_csv(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=0)
+    assert len(result) == 0
+    assert COL_TEXT in result.columns
+
+
+def test_read_input_nrows_negative_returns_empty_parquet(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    file_path = tmp_path / "data.parquet"
+    df.to_parquet(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=-5)
+    assert len(result) == 0
+    assert COL_TEXT in result.columns
+
+
+def test_read_input_empty_parquet_returns_empty(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": pd.Series([], dtype="object")})
+    file_path = tmp_path / "empty.parquet"
+    df.to_parquet(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=5)
+    assert len(result) == 0
+    assert COL_TEXT in result.columns

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -199,3 +199,72 @@ def test_write_output_unwritable_path_raises_anonymizer_io_error(
     monkeypatch.setattr(pd.DataFrame, "to_csv", _raise_write_error)
     with pytest.raises(AnonymizerIOError, match="Failed to write output data"):
         write_output(stub_dataframe, out_path)
+
+
+# ---------------------------------------------------------------------------
+# nrows (preview row limit) tests
+# ---------------------------------------------------------------------------
+
+
+def test_read_input_nrows_truncates_csv(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": [f"row {i}" for i in range(20)]})
+    file_path = tmp_path / "big.csv"
+    df.to_csv(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=5)
+    assert len(result) == 5
+    assert result[COL_TEXT].tolist() == [f"row {i}" for i in range(5)]
+
+
+def test_read_input_nrows_truncates_parquet(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": [f"row {i}" for i in range(20)]})
+    file_path = tmp_path / "big.parquet"
+    df.to_parquet(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=5)
+    assert len(result) == 5
+    assert result[COL_TEXT].tolist() == [f"row {i}" for i in range(5)]
+
+
+def test_read_input_nrows_larger_than_file_returns_all(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    file_path = tmp_path / "small.csv"
+    df.to_csv(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=100)
+    assert len(result) == 3
+
+
+def test_read_input_nrows_none_returns_all(tmp_path: Path) -> None:
+    df = pd.DataFrame({"text": [f"row {i}" for i in range(20)]})
+    file_path = tmp_path / "full.csv"
+    df.to_csv(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path)), nrows=None)
+    assert len(result) == 20
+
+
+def test_read_input_nrows_preserves_attrs(tmp_path: Path) -> None:
+    df = pd.DataFrame({"bio": [f"row {i}" for i in range(10)]})
+    file_path = tmp_path / "data.csv"
+    df.to_csv(file_path, index=False)
+
+    result = read_input(AnonymizerInput(source=str(file_path), text_column="bio"), nrows=3)
+    assert len(result) == 3
+    assert result.attrs["original_text_column"] == "bio"
+    assert COL_TEXT in result.columns
+
+
+def test_read_input_nrows_remote_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    full_df = pd.DataFrame({"text": [f"row {i}" for i in range(50)]})
+    source = "https://example.com/data.csv"
+
+    def _read_csv(url: str, *args: object, **kwargs: object) -> pd.DataFrame:
+        nrows = kwargs.get("nrows")
+        if nrows is not None:
+            return full_df.head(nrows)
+        return full_df
+
+    monkeypatch.setattr(pd, "read_csv", _read_csv)
+    result = read_input(AnonymizerInput(source=source), nrows=5)
+    assert len(result) == 5

--- a/tests/interface/test_anonymizer_logging.py
+++ b/tests/interface/test_anonymizer_logging.py
@@ -157,6 +157,34 @@ def test_preview_logs_preview_mode(stub_input: AnonymizerInput, caplog: pytest.L
     assert "👀 Preview mode: 📂 Loaded 2 records" in messages
 
 
+def test_preview_passes_preview_num_records_to_workflows(stub_input: AnonymizerInput) -> None:
+    """preview() must propagate preview_num_records so downstream workflows use DataDesigner.preview()."""
+    anonymizer = _make_logging_anonymizer()
+    config = AnonymizerConfig(replace=Redact())
+
+    anonymizer.preview(config=config, data=stub_input, num_records=5)
+
+    det_call_kwargs = anonymizer._detection_workflow.run.call_args.kwargs
+    assert det_call_kwargs["preview_num_records"] == 5
+
+    rep_call_kwargs = anonymizer._replace_runner.run.call_args.kwargs
+    assert rep_call_kwargs["preview_num_records"] == 5
+
+
+def test_run_skips_preview_num_records_to_workflows(stub_input: AnonymizerInput) -> None:
+    """run() must pass preview_num_records=None so workflows use full execution."""
+    anonymizer = _make_logging_anonymizer()
+    config = AnonymizerConfig(replace=Redact())
+
+    anonymizer.run(config=config, data=stub_input)
+
+    det_call_kwargs = anonymizer._detection_workflow.run.call_args.kwargs
+    assert det_call_kwargs["preview_num_records"] is None
+
+    rep_call_kwargs = anonymizer._replace_runner.run.call_args.kwargs
+    assert rep_call_kwargs["preview_num_records"] is None
+
+
 def test_configure_logging_with_config_object() -> None:
     from anonymizer.logging import LoggingConfig, configure_logging
 

--- a/tests/interface/test_anonymizer_logging.py
+++ b/tests/interface/test_anonymizer_logging.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import re
-import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -208,13 +207,13 @@ def test_configure_logging_with_config_object() -> None:
     assert logging.getLogger("data_designer").level == logging.INFO
 
 
-def _create_csv(num_records: int, *, tmp_dir: str | None = None) -> str:
-    path = tempfile.mktemp(suffix=".csv", dir=tmp_dir)
+def _create_csv(num_records: int, tmp_path: Path) -> str:
+    path = tmp_path / "input.csv"
     pd.DataFrame({"text": [f"Name{i} works here" for i in range(num_records)]}).to_csv(path, index=False)
-    return path
+    return str(path)
 
 
-def test_preview_with_large_input_only_loads_preview_rows(caplog: pytest.LogCaptureFixture) -> None:
+def test_preview_with_large_input_only_loads_preview_rows(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """preview() should truncate during input loading, not after."""
     num_total = 100
     num_preview = 5
@@ -244,7 +243,7 @@ def test_preview_with_large_input_only_loads_preview_rows(caplog: pytest.LogCapt
     anonymizer = Anonymizer(detection_workflow=detection_workflow, replace_runner=replace_runner)
     config = AnonymizerConfig(replace=Redact())
 
-    csv_path = _create_csv(num_total)
+    csv_path = _create_csv(num_total, tmp_path)
     input_data = AnonymizerInput(source=csv_path)
 
     with caplog.at_level(logging.INFO, logger="anonymizer"):
@@ -257,7 +256,7 @@ def test_preview_with_large_input_only_loads_preview_rows(caplog: pytest.LogCapt
     assert f"Running entity detection on {num_preview} records" in messages
 
 
-def test_local_replace_logs_progress_for_large_datasets(caplog: pytest.LogCaptureFixture) -> None:
+def test_local_replace_logs_progress_for_large_datasets(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """When record count >= 50, ProgressTracker emits interval logs."""
     num_records = 100
     entities = [
@@ -278,7 +277,7 @@ def test_local_replace_logs_progress_for_large_datasets(caplog: pytest.LogCaptur
     anonymizer = Anonymizer(detection_workflow=detection_workflow, replace_runner=replace_runner)
     config = AnonymizerConfig(replace=Redact())
 
-    csv_path = _create_csv(num_records)
+    csv_path = _create_csv(num_records, tmp_path)
     input_data = AnonymizerInput(source=csv_path)
 
     with caplog.at_level(logging.INFO, logger="anonymizer"):

--- a/tests/interface/test_anonymizer_logging.py
+++ b/tests/interface/test_anonymizer_logging.py
@@ -154,7 +154,7 @@ def test_preview_logs_preview_mode(stub_input: AnonymizerInput, caplog: pytest.L
         anonymizer.preview(config=config, data=stub_input, num_records=5)
 
     messages = caplog.text
-    assert "👀 Preview mode: processing 2 of 2 records" in messages
+    assert "👀 Preview mode: 📂 Loaded 2 records" in messages
 
 
 def test_configure_logging_with_config_object() -> None:
@@ -164,10 +164,53 @@ def test_configure_logging_with_config_object() -> None:
     assert logging.getLogger("data_designer").level == logging.INFO
 
 
-def _create_csv(num_records: int) -> str:
-    path = tempfile.mktemp(suffix=".csv")
+def _create_csv(num_records: int, *, tmp_dir: str | None = None) -> str:
+    path = tempfile.mktemp(suffix=".csv", dir=tmp_dir)
     pd.DataFrame({"text": [f"Name{i} works here" for i in range(num_records)]}).to_csv(path, index=False)
     return path
+
+
+def test_preview_with_large_input_only_loads_preview_rows(caplog: pytest.LogCaptureFixture) -> None:
+    """preview() should truncate during input loading, not after."""
+    num_total = 100
+    num_preview = 5
+    entities = [
+        [{"value": f"Name{i}", "label": "first_name", "start_position": 0, "end_position": 5}]
+        for i in range(num_preview)
+    ]
+    det_df = pd.DataFrame(
+        {
+            COL_TEXT: [f"Name{i} works here" for i in range(num_preview)],
+            COL_DETECTED_ENTITIES: entities,
+            COL_FINAL_ENTITIES: entities,
+        }
+    )
+    det_df.attrs["original_text_column"] = "text"
+    detection_workflow = Mock(spec=EntityDetectionWorkflow)
+    detection_workflow.run.return_value = EntityDetectionResult(dataframe=det_df, failed_records=[])
+    _replace_df = pd.DataFrame(
+        {
+            COL_TEXT: [f"Name{i} works here" for i in range(num_preview)],
+            COL_REPLACED_TEXT: ["[REDACTED] works here" for _ in range(num_preview)],
+        }
+    )
+    _replace_df.attrs["original_text_column"] = "text"
+    replace_runner = Mock(spec=ReplacementWorkflow)
+    replace_runner.run.return_value = ReplacementResult(dataframe=_replace_df, failed_records=[])
+    anonymizer = Anonymizer(detection_workflow=detection_workflow, replace_runner=replace_runner)
+    config = AnonymizerConfig(replace=Redact())
+
+    csv_path = _create_csv(num_total)
+    input_data = AnonymizerInput(source=csv_path)
+
+    with caplog.at_level(logging.INFO, logger="anonymizer"):
+        anonymizer.preview(config=config, data=input_data, num_records=num_preview)
+
+    messages = caplog.text
+    assert "Preview mode:" in messages
+    assert f"Loaded {num_preview} records" in messages
+    assert f"Loaded {num_total} records" not in messages
+    assert f"Running entity detection on {num_preview} records" in messages
 
 
 def test_local_replace_logs_progress_for_large_datasets(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/interface/test_anonymizer_logging.py
+++ b/tests/interface/test_anonymizer_logging.py
@@ -157,21 +157,37 @@ def test_preview_logs_preview_mode(stub_input: AnonymizerInput, caplog: pytest.L
     assert "👀 Preview mode: 📂 Loaded 2 records" in messages
 
 
-def test_preview_passes_preview_num_records_to_workflows(stub_input: AnonymizerInput) -> None:
+def test_preview_set_preview_num_records_capped(stub_input: AnonymizerInput) -> None:
     """preview() must propagate preview_num_records so downstream workflows use DataDesigner.preview()."""
     anonymizer = _make_logging_anonymizer()
     config = AnonymizerConfig(replace=Redact())
 
+    # stub_input has 2 rows; num_records=5 is clamped to min(5, 2) = 2
     anonymizer.preview(config=config, data=stub_input, num_records=5)
 
     det_call_kwargs = anonymizer._detection_workflow.run.call_args.kwargs
-    assert det_call_kwargs["preview_num_records"] == 5
+    assert det_call_kwargs["preview_num_records"] == 2
 
     rep_call_kwargs = anonymizer._replace_runner.run.call_args.kwargs
-    assert rep_call_kwargs["preview_num_records"] == 5
+    assert rep_call_kwargs["preview_num_records"] == 2
 
 
-def test_run_skips_preview_num_records_to_workflows(stub_input: AnonymizerInput) -> None:
+def test_preview_set_preview_num_records_not_capped(stub_input: AnonymizerInput) -> None:
+    """When num_records < available rows, preview_num_records is forwarded as-is."""
+    anonymizer = _make_logging_anonymizer()
+    config = AnonymizerConfig(replace=Redact())
+
+    # stub_input has 2 rows; num_records=1 fits, so no clamping
+    anonymizer.preview(config=config, data=stub_input, num_records=1)
+
+    det_call_kwargs = anonymizer._detection_workflow.run.call_args.kwargs
+    assert det_call_kwargs["preview_num_records"] == 1
+
+    rep_call_kwargs = anonymizer._replace_runner.run.call_args.kwargs
+    assert rep_call_kwargs["preview_num_records"] == 1
+
+
+def test_run_set_preview_num_records(stub_input: AnonymizerInput) -> None:
     """run() must pass preview_num_records=None so workflows use full execution."""
     anonymizer = _make_logging_anonymizer()
     config = AnonymizerConfig(replace=Redact())


### PR DESCRIPTION
## Summary

- **Lightweight preview reads:** Move row-limiting (`nrows`) from `_run_internal` into `read_input` so that `preview()` reads only the requested number of rows from disk instead of loading the full dataset and truncating afterward. For CSV this uses `pd.read_csv(nrows=…)` natively; for Parquet it uses `pyarrow.parquet.ParquetFile.iter_batches()` to read only the necessary row batches, avoiding full-file deserialization. Handles `nrows ≤ 0` gracefully by returning a schema-preserving empty DataFrame for both formats.
- **Preserve downstream preview signal**: Keep `preview_num_records` threaded through `_run_internal` into detection, replacement, and rewrite workflows so that `NddAdapter` still routes to `DataDesigner.preview()` (in-memory execution) rather than `DataDesigner.create()` (artifact-backed execution). `run()` passes `None` to use full execution.
- **Clamp preview to available rows**: When `preview_num_records` exceeds the actual number of loaded rows, cap it to the available count and log a "capped" message. When it fits, log the processing count. This prevents downstream workflows from receiving a row count larger than the dataframe.
- **Simplify `_run_internal`**: Remove the old `effective_records` / `min(preview_num_records, num_records)` logic that lived further down the method — the dataframe is now already the right size on entry, and clamping happens up front if necessarily.
- **Move loading logs into `reader.py`**: The "Loaded N records" log now lives in `_load_dataframe`, with a "Preview mode" prefix when `nrows` is set.
- **Add unit tests**:
  - `read_input` `nrows` behavior: CSV truncation, Parquet truncation, `nrows > len`, `nrows=None`, attribute preservation, and remote-CSV forwarding.
  - Workflow-boundary tests: `preview_num_records` is capped and forwarded in `preview()`, forwarded as-is when smaller than available rows, and `None` in `run()`.
  - Logging assertions: verify preview-mode log appears, large-input preview only loads requested rows, and existing logging tests updated to match the new log format.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->
