### PR TITLE
fix: Input Error when duplicate columns in output data frame

### DIFF
--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -34,13 +34,26 @@ def read_input(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.D
     return dataframe
 
 
+_OUTPUT_COLUMN_SUFFIXES = ("_replaced", "_with_spans", "_rewritten")
+
+
 def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_text_column: str) -> None:
-    if COL_TEXT not in dataframe.columns or selected_text_column == COL_TEXT:
-        return
-    raise InvalidInputError(
-        f"Input contains reserved internal column {COL_TEXT!r} while text_column={selected_text_column!r}. "
-        f"Either set text_column={COL_TEXT!r} or remove/rename {COL_TEXT!r} from input."
-    )
+    if COL_TEXT in dataframe.columns and selected_text_column != COL_TEXT:
+        raise InvalidInputError(
+            f"Input contains reserved internal column {COL_TEXT!r} while text_column={selected_text_column!r}. "
+            f"Either set text_column={COL_TEXT!r} or remove/rename {COL_TEXT!r} from input."
+        )
+    collisions = [
+        f"{selected_text_column}{suffix}"
+        for suffix in _OUTPUT_COLUMN_SUFFIXES
+        if f"{selected_text_column}{suffix}" in dataframe.columns
+    ]
+    if collisions:
+        names = ", ".join(repr(c) for c in collisions)
+        raise InvalidInputError(
+            f"Input column(s) {names} collide with Anonymizer output column names. "
+            f"Please rename or remove these columns from your input data."
+        )
 
 
 def _read_parquet_partial(source: str, *, nrows: int | None = None) -> pd.DataFrame:

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -37,7 +37,9 @@ def read_input(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.D
     if selected_text_column not in dataframe.columns:
         raise InvalidInputError(f"Input text column '{selected_text_column}' not found.")
     _validate_internal_column_collision(dataframe, selected_text_column=selected_text_column)
-    dataframe = _resolve_output_column_collisions(dataframe, selected_text_column=selected_text_column)
+    dataframe, selected_text_column = _resolve_output_column_collisions(
+        dataframe, selected_text_column=selected_text_column
+    )
     dataframe = dataframe.rename(columns={selected_text_column: COL_TEXT})
     dataframe.attrs["original_text_column"] = selected_text_column
     return dataframe
@@ -72,7 +74,9 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
         )
 
 
-def _resolve_output_column_collisions(dataframe: pd.DataFrame, *, selected_text_column: str) -> pd.DataFrame:
+def _resolve_output_column_collisions(
+    dataframe: pd.DataFrame, *, selected_text_column: str
+) -> tuple[pd.DataFrame, str]:
     """Rename input columns whose names collide with Anonymizer output columns.
 
     The pipeline writes a known set of output columns derived from the text
@@ -83,16 +87,20 @@ def _resolve_output_column_collisions(dataframe: pd.DataFrame, *, selected_text_
     to avoid a secondary collision) and emit a warning. This matches how
     pandas disambiguates duplicate column names on read and keeps the
     pipeline runnable without forcing the user to edit their input file.
+
+    The selected text column itself is not special-cased: if the user picked a
+    text column whose name matches a fixed output column (e.g.
+    ``text_column='final_entities'``) it is renamed the same way, and the
+    returned ``selected_text_column`` reflects its new name so downstream
+    rename steps use the non-colliding identifier.
     """
     candidate_output_columns: list[str] = [f"{selected_text_column}{suffix}" for suffix in _OUTPUT_COLUMN_SUFFIXES]
-    for static_column in _STATIC_OUTPUT_COLUMNS:
-        if static_column != selected_text_column:
-            candidate_output_columns.append(static_column)
+    candidate_output_columns.extend(_STATIC_OUTPUT_COLUMNS)
 
     existing_columns: set[str] = set(dataframe.columns)
     collisions: list[str] = [name for name in candidate_output_columns if name in existing_columns]
     if not collisions:
-        return dataframe
+        return dataframe, selected_text_column
 
     rename_map: dict[str, str] = {}
     for original_name in collisions:
@@ -106,7 +114,8 @@ def _resolve_output_column_collisions(dataframe: pd.DataFrame, *, selected_text_
         "Update your input schema to remove this warning.",
         formatted,
     )
-    return dataframe.rename(columns=rename_map)
+    new_selected_text_column = rename_map.get(selected_text_column, selected_text_column)
+    return dataframe.rename(columns=rename_map), new_selected_text_column
 
 
 def _next_available_name(candidate: str, existing: set[str]) -> str:

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -10,7 +10,15 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from anonymizer.config.anonymizer_config import AnonymizerInput, infer_input_source_suffix
-from anonymizer.engine.constants import COL_TEXT
+from anonymizer.engine.constants import (
+    COL_ANY_HIGH_LEAKED,
+    COL_FINAL_ENTITIES,
+    COL_LEAKAGE_MASS,
+    COL_NEEDS_HUMAN_REVIEW,
+    COL_TEXT,
+    COL_UTILITY_SCORE,
+    COL_WEIGHTED_LEAKAGE_RATE,
+)
 from anonymizer.engine.io.constants import SUPPORTED_IO_FORMATS
 from anonymizer.interface.errors import AnonymizerIOError, InvalidInputError
 
@@ -29,31 +37,86 @@ def read_input(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.D
     if selected_text_column not in dataframe.columns:
         raise InvalidInputError(f"Input text column '{selected_text_column}' not found.")
     _validate_internal_column_collision(dataframe, selected_text_column=selected_text_column)
+    dataframe = _resolve_output_column_collisions(dataframe, selected_text_column=selected_text_column)
     dataframe = dataframe.rename(columns={selected_text_column: COL_TEXT})
     dataframe.attrs["original_text_column"] = selected_text_column
     return dataframe
 
 
-_OUTPUT_COLUMN_SUFFIXES = ("_replaced", "_with_spans", "_rewritten")
+# Suffixes appended to the user's text column to form per-mode output columns
+# (see ``_rename_output_columns`` in ``anonymizer.interface.anonymizer``).
+_OUTPUT_COLUMN_SUFFIXES: tuple[str, ...] = ("_replaced", "_with_spans", "_rewritten")
+
+# Fixed user-facing output column names that don't depend on the text column
+# (see ``_build_user_dataframe`` in ``anonymizer.interface.anonymizer``).
+_STATIC_OUTPUT_COLUMNS: tuple[str, ...] = (
+    COL_FINAL_ENTITIES,
+    COL_UTILITY_SCORE,
+    COL_LEAKAGE_MASS,
+    COL_WEIGHTED_LEAKAGE_RATE,
+    COL_ANY_HIGH_LEAKED,
+    COL_NEEDS_HUMAN_REVIEW,
+)
+
+# Suffix appended to input columns whose names collide with anonymizer output
+# columns; mirrors how pandas disambiguates duplicate column names on read.
+_INPUT_RENAME_SUFFIX = "__input"
 
 
 def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_text_column: str) -> None:
+    """Hard-error if the user's input contains the reserved internal text column."""
     if COL_TEXT in dataframe.columns and selected_text_column != COL_TEXT:
         raise InvalidInputError(
             f"Input contains reserved internal column {COL_TEXT!r} while text_column={selected_text_column!r}. "
             f"Either set text_column={COL_TEXT!r} or remove/rename {COL_TEXT!r} from input."
         )
-    collisions = [
-        f"{selected_text_column}{suffix}"
-        for suffix in _OUTPUT_COLUMN_SUFFIXES
-        if f"{selected_text_column}{suffix}" in dataframe.columns
-    ]
-    if collisions:
-        names = ", ".join(repr(c) for c in collisions)
-        raise InvalidInputError(
-            f"Input column(s) {names} collide with Anonymizer output column names. "
-            f"Please rename or remove these columns from your input data."
-        )
+
+
+def _resolve_output_column_collisions(dataframe: pd.DataFrame, *, selected_text_column: str) -> pd.DataFrame:
+    """Rename input columns whose names collide with Anonymizer output columns.
+
+    The pipeline writes a known set of output columns derived from the text
+    column (e.g. ``{text_col}_replaced``) plus a few fixed names such as
+    ``final_entities``. If the input already contains any of those names the
+    output would silently overwrite the user's data, so we rename the input
+    column in place by appending ``__input`` (with a numeric suffix if needed
+    to avoid a secondary collision) and emit a warning. This matches how
+    pandas disambiguates duplicate column names on read and keeps the
+    pipeline runnable without forcing the user to edit their input file.
+    """
+    candidate_output_columns: list[str] = [f"{selected_text_column}{suffix}" for suffix in _OUTPUT_COLUMN_SUFFIXES]
+    for static_column in _STATIC_OUTPUT_COLUMNS:
+        if static_column != selected_text_column:
+            candidate_output_columns.append(static_column)
+
+    existing_columns: set[str] = set(dataframe.columns)
+    collisions: list[str] = [name for name in candidate_output_columns if name in existing_columns]
+    if not collisions:
+        return dataframe
+
+    rename_map: dict[str, str] = {}
+    for original_name in collisions:
+        new_name = _next_available_name(f"{original_name}{_INPUT_RENAME_SUFFIX}", existing_columns)
+        rename_map[original_name] = new_name
+        existing_columns.add(new_name)
+
+    formatted = ", ".join(f"{old!r} -> {new!r}" for old, new in rename_map.items())
+    logger.warning(
+        "Renamed input column(s) that collide with Anonymizer output column names: %s. "
+        "Update your input schema to remove this warning.",
+        formatted,
+    )
+    return dataframe.rename(columns=rename_map)
+
+
+def _next_available_name(candidate: str, existing: set[str]) -> str:
+    """Return *candidate*, or ``candidate_2``/``_3``/... if it's already taken."""
+    if candidate not in existing:
+        return candidate
+    counter = 2
+    while f"{candidate}_{counter}" in existing:
+        counter += 1
+    return f"{candidate}_{counter}"
 
 
 def _read_parquet_partial(source: str, *, nrows: int | None = None) -> pd.DataFrame:

--- a/src/anonymizer/engine/io/reader.py
+++ b/src/anonymizer/engine/io/reader.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 import pandas as pd
 import pyarrow as pa
@@ -37,11 +38,9 @@ def read_input(input_data: AnonymizerInput, *, nrows: int | None = None) -> pd.D
     if selected_text_column not in dataframe.columns:
         raise InvalidInputError(f"Input text column '{selected_text_column}' not found.")
     _validate_internal_column_collision(dataframe, selected_text_column=selected_text_column)
-    dataframe, selected_text_column = _resolve_output_column_collisions(
-        dataframe, selected_text_column=selected_text_column
-    )
-    dataframe = dataframe.rename(columns={selected_text_column: COL_TEXT})
-    dataframe.attrs["original_text_column"] = selected_text_column
+    resolved = _resolve_output_column_collisions(dataframe, selected_text_column=selected_text_column)
+    dataframe = resolved.dataframe.rename(columns={resolved.selected_text_column: COL_TEXT})
+    dataframe.attrs["original_text_column"] = resolved.selected_text_column
     return dataframe
 
 
@@ -65,6 +64,18 @@ _STATIC_OUTPUT_COLUMNS: tuple[str, ...] = (
 _INPUT_RENAME_SUFFIX = "__input"
 
 
+@dataclass(frozen=True)
+class ResolvedInputColumns:
+    """Result of resolving input/output column name collisions.
+
+    ``selected_text_column`` reflects the (possibly renamed) identifier that
+    downstream steps should treat as the user's text column.
+    """
+
+    dataframe: pd.DataFrame
+    selected_text_column: str
+
+
 def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_text_column: str) -> None:
     """Hard-error if the user's input contains the reserved internal text column."""
     if COL_TEXT in dataframe.columns and selected_text_column != COL_TEXT:
@@ -74,9 +85,7 @@ def _validate_internal_column_collision(dataframe: pd.DataFrame, *, selected_tex
         )
 
 
-def _resolve_output_column_collisions(
-    dataframe: pd.DataFrame, *, selected_text_column: str
-) -> tuple[pd.DataFrame, str]:
+def _resolve_output_column_collisions(dataframe: pd.DataFrame, *, selected_text_column: str) -> ResolvedInputColumns:
     """Rename input columns whose names collide with Anonymizer output columns.
 
     The pipeline writes a known set of output columns derived from the text
@@ -90,9 +99,9 @@ def _resolve_output_column_collisions(
 
     The selected text column itself is not special-cased: if the user picked a
     text column whose name matches a fixed output column (e.g.
-    ``text_column='final_entities'``) it is renamed the same way, and the
-    returned ``selected_text_column`` reflects its new name so downstream
-    rename steps use the non-colliding identifier.
+    ``text_column='final_entities'``) it is renamed the same way, and
+    ``ResolvedInputColumns.selected_text_column`` reflects its new name so
+    downstream rename steps use the non-colliding identifier.
     """
     candidate_output_columns: list[str] = [f"{selected_text_column}{suffix}" for suffix in _OUTPUT_COLUMN_SUFFIXES]
     candidate_output_columns.extend(_STATIC_OUTPUT_COLUMNS)
@@ -100,7 +109,7 @@ def _resolve_output_column_collisions(
     existing_columns: set[str] = set(dataframe.columns)
     collisions: list[str] = [name for name in candidate_output_columns if name in existing_columns]
     if not collisions:
-        return dataframe, selected_text_column
+        return ResolvedInputColumns(dataframe=dataframe, selected_text_column=selected_text_column)
 
     rename_map: dict[str, str] = {}
     for original_name in collisions:
@@ -115,7 +124,10 @@ def _resolve_output_column_collisions(
         formatted,
     )
     new_selected_text_column = rename_map.get(selected_text_column, selected_text_column)
-    return dataframe.rename(columns=rename_map), new_selected_text_column
+    return ResolvedInputColumns(
+        dataframe=dataframe.rename(columns=rename_map),
+        selected_text_column=new_selected_text_column,
+    )
 
 
 def _next_available_name(candidate: str, existing: set[str]) -> str:

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -135,6 +135,39 @@ def test_read_input_internal_text_collision_raises(tmp_path: Path) -> None:
         read_input(inp)
 
 
+@pytest.mark.parametrize("suffix", ["_replaced", "_with_spans", "_rewritten"])
+def test_read_input_output_column_collision_raises(tmp_path: Path, suffix: str) -> None:
+    colliding_col = f"bio{suffix}"
+    inp = _write_input(
+        pd.DataFrame({"bio": ["hello"], colliding_col: ["existing"]}),
+        tmp_path,
+        text_column="bio",
+    )
+    with pytest.raises(InvalidInputError, match="collide with Anonymizer output column names"):
+        read_input(inp)
+
+
+def test_read_input_output_column_collision_lists_all(tmp_path: Path) -> None:
+    inp = _write_input(
+        pd.DataFrame({"bio": ["hello"], "bio_replaced": ["x"], "bio_rewritten": ["y"]}),
+        tmp_path,
+        text_column="bio",
+    )
+    with pytest.raises(InvalidInputError, match="'bio_replaced'.*'bio_rewritten'"):
+        read_input(inp)
+
+
+def test_read_input_non_colliding_columns_pass(tmp_path: Path) -> None:
+    inp = _write_input(
+        pd.DataFrame({"bio": ["hello"], "other_replaced": ["x"], "score": [0.5]}),
+        tmp_path,
+        text_column="bio",
+    )
+    result = read_input(inp)
+    assert COL_TEXT in result.columns
+    assert "other_replaced" in result.columns
+
+
 def test_read_input_unsupported_format_raises(tmp_path: Path) -> None:
     file_path = tmp_path / "data.json"
     file_path.write_text('{"a":[1]}')

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -171,6 +171,69 @@ def test_read_input_static_output_column_collision_renames_with_warning(
     assert any("collide with Anonymizer output column names" in rec.message for rec in caplog.records)
 
 
+@pytest.mark.parametrize(
+    "static_column",
+    [
+        "final_entities",
+        "utility_score",
+        "leakage_mass",
+        "weighted_leakage_rate",
+        "any_high_leaked",
+        "needs_human_review",
+    ],
+)
+def test_read_input_text_column_equal_to_static_output_renames_with_warning(
+    tmp_path: Path, static_column: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Selecting a text column whose name matches a fixed output column is treated
+    like any other collision: the input column is renamed with the ``__input``
+    suffix and ``original_text_column`` reflects the renamed identifier so the
+    end-of-pipeline rename does not clash with the pipeline's own output column.
+    """
+    inp = _write_input(
+        pd.DataFrame({static_column: ["hello"]}),
+        tmp_path,
+        text_column=static_column,
+    )
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = read_input(inp)
+    assert COL_TEXT in result.columns
+    assert static_column not in result.columns
+    renamed = f"{static_column}__input"
+    assert result.attrs["original_text_column"] == renamed
+    assert list(result.columns).count(COL_TEXT) == 1
+    assert any("collide with Anonymizer output column names" in rec.message for rec in caplog.records)
+
+
+def test_read_input_text_column_is_static_plus_other_static_collision(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A static-name text column coexisting with other static collisions: each
+    input column gets its own ``__input`` rename, independent of whether it is
+    the selected text column.
+    """
+    inp = _write_input(
+        pd.DataFrame(
+            {
+                "final_entities": ["hello"],
+                "utility_score": [0.9],
+                "needs_human_review": [False],
+            }
+        ),
+        tmp_path,
+        text_column="final_entities",
+    )
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = read_input(inp)
+    assert result.attrs["original_text_column"] == "final_entities__input"
+    assert {"utility_score__input", "needs_human_review__input"}.issubset(result.columns)
+    assert "final_entities" not in result.columns
+    assert "utility_score" not in result.columns
+    assert "needs_human_review" not in result.columns
+    assert result["utility_score__input"].iloc[0] == 0.9
+    assert bool(result["needs_human_review__input"].iloc[0]) is False
+
+
 def test_read_input_output_column_collision_renames_all(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     inp = _write_input(
         pd.DataFrame(

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -136,25 +136,82 @@ def test_read_input_internal_text_collision_raises(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("suffix", ["_replaced", "_with_spans", "_rewritten"])
-def test_read_input_output_column_collision_raises(tmp_path: Path, suffix: str) -> None:
+def test_read_input_output_column_collision_renames_with_warning(
+    tmp_path: Path, suffix: str, caplog: pytest.LogCaptureFixture
+) -> None:
     colliding_col = f"bio{suffix}"
     inp = _write_input(
         pd.DataFrame({"bio": ["hello"], colliding_col: ["existing"]}),
         tmp_path,
         text_column="bio",
     )
-    with pytest.raises(InvalidInputError, match="collide with Anonymizer output column names"):
-        read_input(inp)
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = read_input(inp)
+    assert COL_TEXT in result.columns
+    assert colliding_col not in result.columns
+    renamed = f"{colliding_col}__input"
+    assert renamed in result.columns
+    assert result[renamed].tolist() == ["existing"]
+    assert any("collide with Anonymizer output column names" in rec.message for rec in caplog.records)
 
 
-def test_read_input_output_column_collision_lists_all(tmp_path: Path) -> None:
+@pytest.mark.parametrize("static_column", ["final_entities", "utility_score", "needs_human_review"])
+def test_read_input_static_output_column_collision_renames_with_warning(
+    tmp_path: Path, static_column: str, caplog: pytest.LogCaptureFixture
+) -> None:
     inp = _write_input(
-        pd.DataFrame({"bio": ["hello"], "bio_replaced": ["x"], "bio_rewritten": ["y"]}),
+        pd.DataFrame({"bio": ["hello"], static_column: ["existing"]}),
         tmp_path,
         text_column="bio",
     )
-    with pytest.raises(InvalidInputError, match="'bio_replaced'.*'bio_rewritten'"):
-        read_input(inp)
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = read_input(inp)
+    assert static_column not in result.columns
+    assert f"{static_column}__input" in result.columns
+    assert any("collide with Anonymizer output column names" in rec.message for rec in caplog.records)
+
+
+def test_read_input_output_column_collision_renames_all(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    inp = _write_input(
+        pd.DataFrame(
+            {
+                "bio": ["hello"],
+                "bio_replaced": ["x"],
+                "bio_rewritten": ["y"],
+                "final_entities": ["z"],
+            }
+        ),
+        tmp_path,
+        text_column="bio",
+    )
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = read_input(inp)
+    assert {"bio_replaced__input", "bio_rewritten__input", "final_entities__input"}.issubset(result.columns)
+    warning = next(
+        rec.message for rec in caplog.records if "collide with Anonymizer output column names" in rec.message
+    )
+    for original in ("bio_replaced", "bio_rewritten", "final_entities"):
+        assert f"'{original}'" in warning
+
+
+def test_read_input_output_column_collision_disambiguates_when_input_suffix_taken(
+    tmp_path: Path,
+) -> None:
+    inp = _write_input(
+        pd.DataFrame(
+            {
+                "bio": ["hello"],
+                "bio_replaced": ["new"],
+                "bio_replaced__input": ["already_renamed"],
+            }
+        ),
+        tmp_path,
+        text_column="bio",
+    )
+    result = read_input(inp)
+    assert "bio_replaced" not in result.columns
+    assert result["bio_replaced__input"].tolist() == ["already_renamed"]
+    assert result["bio_replaced__input_2"].tolist() == ["new"]
 
 
 def test_read_input_non_colliding_columns_pass(tmp_path: Path) -> None:
@@ -166,6 +223,7 @@ def test_read_input_non_colliding_columns_pass(tmp_path: Path) -> None:
     result = read_input(inp)
     assert COL_TEXT in result.columns
     assert "other_replaced" in result.columns
+    assert "score" in result.columns
 
 
 def test_read_input_unsupported_format_raises(tmp_path: Path) -> None:

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -278,6 +278,52 @@ def test_run_with_colliding_output_column_renames_input_and_warns(
     assert result.trace_dataframe["bio_replaced__input"].iloc[0] == "pre-existing"
 
 
+def test_run_with_text_column_matching_static_output_preserves_both_columns(
+    stub_anonymizer_config: AnonymizerConfig,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Setting ``text_column`` to a fixed output name (e.g. ``final_entities``)
+    must not produce duplicate columns in the trace/user dataframes.
+
+    The reader renames the input column to ``final_entities__input`` so the
+    pipeline's own ``final_entities`` output (the detected entities dict) and
+    the user's original text live side-by-side as distinct columns.
+    """
+    input_csv = tmp_path / "input.csv"
+    pd.DataFrame({"final_entities": ["Alice bio text"]}).to_csv(input_csv, index=False)
+
+    entities_payload = {"entities": [{"value": "Alice", "label": "first_name"}]}
+    replace_df = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice bio text"],
+            COL_REPLACED_TEXT: ["[REDACTED] bio text"],
+            COL_TAGGED_TEXT: ["<first_name>Alice</first_name> bio text"],
+            COL_FINAL_ENTITIES: [entities_payload],
+        }
+    )
+    replace_df.attrs["original_text_column"] = "final_entities__input"
+    anonymizer, _, _, _ = _make_anonymizer(
+        replace_return=ReplacementResult(dataframe=replace_df, failed_records=[]),
+    )
+
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = anonymizer.run(
+            config=stub_anonymizer_config,
+            data=AnonymizerInput(source=str(input_csv), text_column="final_entities"),
+        )
+
+    assert any("collide with Anonymizer output column names" in rec.message for rec in caplog.records)
+
+    for frame_name, frame in (("dataframe", result.dataframe), ("trace_dataframe", result.trace_dataframe)):
+        assert list(frame.columns).count("final_entities") == 1, (
+            f"{frame_name} has duplicate 'final_entities' columns: {list(frame.columns)}"
+        )
+        assert "final_entities__input" in frame.columns, f"{frame_name} missing renamed user text column"
+        assert frame["final_entities__input"].iloc[0] == "Alice bio text"
+        assert frame["final_entities"].iloc[0] == entities_payload
+
+
 def test_validate_config_passes_for_valid_replace_config(stub_anonymizer_config: AnonymizerConfig) -> None:
     anonymizer, _, _, _ = _make_anonymizer()
     anonymizer.validate_config(stub_anonymizer_config)

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -239,6 +239,21 @@ def test_run_with_colliding_internal_text_column_raises(
         )
 
 
+def test_run_with_colliding_output_column_raises(
+    stub_anonymizer_config: AnonymizerConfig,
+    tmp_path: Path,
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    pd.DataFrame({"bio": ["Alice bio text"], "bio_replaced": ["pre-existing"]}).to_csv(input_csv, index=False)
+    anonymizer, _, _, _ = _make_anonymizer()
+
+    with pytest.raises(InvalidInputError, match="collide with Anonymizer output column names"):
+        anonymizer.run(
+            config=stub_anonymizer_config,
+            data=AnonymizerInput(source=str(input_csv), text_column="bio"),
+        )
+
+
 def test_validate_config_passes_for_valid_replace_config(stub_anonymizer_config: AnonymizerConfig) -> None:
     anonymizer, _, _, _ = _make_anonymizer()
     anonymizer.validate_config(stub_anonymizer_config)

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -239,19 +239,43 @@ def test_run_with_colliding_internal_text_column_raises(
         )
 
 
-def test_run_with_colliding_output_column_raises(
+def test_run_with_colliding_output_column_renames_input_and_warns(
     stub_anonymizer_config: AnonymizerConfig,
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Colliding input columns are renamed (not blocked) and a warning is logged.
+
+    We use a custom ``replace_return`` that propagates the renamed input column
+    so we can verify that it survives into the trace dataframe alongside the
+    fresh pipeline output. This documents the lossless behaviour: the user's
+    original ``bio_replaced`` data ends up under ``bio_replaced__input`` while
+    the pipeline writes its own ``bio_replaced``.
+    """
     input_csv = tmp_path / "input.csv"
     pd.DataFrame({"bio": ["Alice bio text"], "bio_replaced": ["pre-existing"]}).to_csv(input_csv, index=False)
-    anonymizer, _, _, _ = _make_anonymizer()
 
-    with pytest.raises(InvalidInputError, match="collide with Anonymizer output column names"):
-        anonymizer.run(
+    replace_df = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice bio text"],
+            COL_REPLACED_TEXT: ["[REDACTED] bio text"],
+            "bio_replaced__input": ["pre-existing"],
+        }
+    )
+    replace_df.attrs["original_text_column"] = "bio"
+    anonymizer, _, _, _ = _make_anonymizer(
+        replace_return=ReplacementResult(dataframe=replace_df, failed_records=[]),
+    )
+
+    with caplog.at_level("WARNING", logger="anonymizer"):
+        result = anonymizer.run(
             config=stub_anonymizer_config,
             data=AnonymizerInput(source=str(input_csv), text_column="bio"),
         )
+
+    assert any("collide with Anonymizer output column names" in rec.message for rec in caplog.records)
+    assert result.dataframe["bio_replaced"].iloc[0] == "[REDACTED] bio text"
+    assert result.trace_dataframe["bio_replaced__input"].iloc[0] == "pre-existing"
 
 
 def test_validate_config_passes_for_valid_replace_config(stub_anonymizer_config: AnonymizerConfig) -> None:


### PR DESCRIPTION
## Summary

Detects and handles input columns whose names would collide with user facing columns the
Anonymizer pipeline writes, so the user's data is never silently overwritten
and the trace/user dataframes never contain duplicate column names.

- **Collision detection in `read_input`**: input columns matching any of the
  pipeline's output names are detected up front, covering both
  text-column-derived names (`{text_col}_replaced`, `_with_spans`, `_rewritten`)
  and fixed output names (`final_entities`, `utility_score`, `leakage_mass`,
  `weighted_leakage_rate`, `any_high_leaked`, `needs_human_review`).
- **Lossless auto-rename (not a hard error)**: colliding input columns are
  renamed by appending `__input` (e.g. `bio_replaced` → `bio_replaced__input`),
  with a `WARNING` log listing each rename. This mirrors pandas' behaviour for
  duplicate column names and means the pipeline always runs; the user's
  original data is preserved under the new name.
- **`text_column` can itself be a fixed output name**: if the user selects
  `text_column="final_entities"` (or any of the other static output names), the
  input column is renamed the same way (`final_entities → final_entities__input`)
  and `original_text_column` is updated to track the renamed identifier. This
  prevents the end-of-pipeline rename from clashing with the pipeline's own
  `final_entities` output, which previously produced duplicate
  `final_entities` columns in the trace/user dataframes.
- **Type-agnostic rename**: the `__input` suffix is applied to any colliding
  column regardless of dtype — text, numeric (`utility_score`, `leakage_mass`,
  `weighted_leakage_rate`), or boolean (`any_high_leaked`, `needs_human_review`).
- **Secondary-collision fallback**: if `{name}__input` is already taken, the
  column is named `{name}__input_2`, `_3`, etc., so the rename can never
  clobber another input column.
- **Reserved internal column still errors**: the existing hard-error for the
  reserved internal sentinel (`__nemo_anonymizer_text_input__`) is unchanged;
  only user-facing output columns are auto-renamed.

## Tests

- Parametrized per-suffix rename-with-warning tests (`_replaced`, `_with_spans`,
  `_rewritten`).
- Parametrized per-static-column rename-with-warning tests when `text_column`
  is unrelated to the collision.
-  Parametrized test (all six static names) for the
  `text_column == fixed output column` case, asserting the rename happens,
  `original_text_column` reflects the renamed identifier, and no duplicate
  `text` column appears.
- Combined test where `text_column` is a static name *and* other
  static columns collide in the same input, asserting each colliding column
  gets its own independent `__input` rename.
- Multi-collision test asserting all renames happen and each name appears
  in the warning (order-independent).
- Disambiguation test covering the `__input_2` fallback.
- Passthrough test confirming non-colliding columns (e.g. `score`,
  `other_replaced`) are untouched.
- End-to-end integration test verifying the renamed input column survives
  into `trace_dataframe` while the pipeline's own output occupies
  `bio_replaced`.
- End-to-end integration test running `anonymizer.run(...)` with
  `text_column="final_entities"` and asserting that neither `result.dataframe`
  nor `result.trace_dataframe` contains duplicate `final_entities` columns —
  the user's text lives under `final_entities__input` and the pipeline's
  entities payload lives under `final_entities`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally


