### PR TITLE
fix(cli): model config file paths and flag fixes

### DIFF
--- a/src/anonymizer/engine/ndd/model_loader.py
+++ b/src/anonymizer/engine/ndd/model_loader.py
@@ -212,7 +212,7 @@ def _parse_yaml_string(raw: str) -> dict[str, Any]:
 
 
 def _load_yaml_dict(path: Path) -> dict[str, Any]:
-    if not path.exists():
+    if not path.is_file():
         raise FileNotFoundError(f"Config file not found: {path}")
     data = load_config_file(path)
     if not isinstance(data, dict):

--- a/src/anonymizer/engine/ndd/model_loader.py
+++ b/src/anonymizer/engine/ndd/model_loader.py
@@ -52,7 +52,11 @@ def parse_model_configs(raw: str | Path | None) -> ParsedModelConfigs:
     if isinstance(raw, Path):
         parsed = _load_yaml_dict(raw)
     else:
-        parsed = _parse_yaml_string(raw)
+        candidate = Path(raw.strip())
+        if "\n" not in raw and candidate.suffix in (".yaml", ".yml"):
+            parsed = _load_yaml_dict(candidate)
+        else:
+            parsed = _parse_yaml_string(raw)
 
     user_selections = parsed.pop("selected_models", None)
     return ParsedModelConfigs(

--- a/src/anonymizer/engine/ndd/model_loader.py
+++ b/src/anonymizer/engine/ndd/model_loader.py
@@ -52,7 +52,7 @@ def parse_model_configs(raw: str | Path | None) -> ParsedModelConfigs:
     if isinstance(raw, Path):
         parsed = _load_yaml_dict(raw)
     else:
-        candidate = Path(raw.strip())
+        candidate = Path(raw.strip()).expanduser()
         if "\n" not in raw and candidate.suffix in (".yaml", ".yml"):
             parsed = _load_yaml_dict(candidate)
         else:

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -345,6 +345,12 @@ def _resolve_model_providers(
         return None
     if isinstance(model_providers, list):
         return model_providers
+    if isinstance(model_providers, str) and "\n" not in model_providers:
+        candidate = Path(model_providers.strip())
+        if candidate.suffix in (".yaml", ".yml"):
+            if not candidate.exists():
+                raise FileNotFoundError(f"Providers config file not found: {candidate}")
+            model_providers = candidate
     config_dict = load_config_file(model_providers)
     raw_providers = config_dict.get("providers")
     if not isinstance(raw_providers, list):

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -346,7 +346,7 @@ def _resolve_model_providers(
     if isinstance(model_providers, list):
         return model_providers
     if isinstance(model_providers, str) and "\n" not in model_providers:
-        candidate = Path(model_providers.strip())
+        candidate = Path(model_providers.strip()).expanduser()
         if candidate.suffix in (".yaml", ".yml"):
             if not candidate.is_file():
                 raise FileNotFoundError(f"Providers config file not found: {candidate}")

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -348,7 +348,7 @@ def _resolve_model_providers(
     if isinstance(model_providers, str) and "\n" not in model_providers:
         candidate = Path(model_providers.strip())
         if candidate.suffix in (".yaml", ".yml"):
-            if not candidate.exists():
+            if not candidate.is_file():
                 raise FileNotFoundError(f"Providers config file not found: {candidate}")
             model_providers = candidate
     config_dict = load_config_file(model_providers)

--- a/src/anonymizer/interface/cli/main.py
+++ b/src/anonymizer/interface/cli/main.py
@@ -140,7 +140,7 @@ def _cli_error_handler(fn):
     def wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except (ValidationError, ValueError, InvalidConfigError, AnonymizerIOError, FileNotFoundError) as exc:
+        except (ValidationError, ValueError, InvalidConfigError, AnonymizerIOError, OSError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
             raise SystemExit(1)
 

--- a/src/anonymizer/interface/cli/main.py
+++ b/src/anonymizer/interface/cli/main.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 logger = logging.getLogger("anonymizer.cli")
 
@@ -61,14 +61,42 @@ class CliOpts:
 
     # -- shared --
     detect: Annotated[Detect, cyclopts.Parameter(name="*")] = field(default_factory=Detect)
-    model_configs: str | None = None
-    model_providers: str | None = None
-    artifact_path: str | None = None
+    model_configs: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help=(
+                "Path to a YAML file (.yaml/.yml) or inline YAML string defining the model pool "
+                "and optional selected_models overrides. Omit to use bundled defaults."
+            )
+        ),
+    ] = None
+    model_providers: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help=(
+                "Path to a YAML file (.yaml/.yml) or inline YAML string defining custom provider "
+                "endpoints. Each entry maps a provider name to its API base URL and optional key."
+            )
+        ),
+    ] = None
+    artifact_path: Annotated[
+        str | None,
+        cyclopts.Parameter(help="Directory for intermediate pipeline artifacts. Defaults to .anonymizer-artifacts."),
+    ] = None
     verbose: bool = False
     debug: bool = False
 
     # -- replace-specific --
-    format_template: str | None = None
+    format_template: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help=(
+                "Output template for the replacement token. "
+                "Redact supports {label}; Annotate requires {text} and {label}; "
+                "Hash requires {digest} and optionally {label}. Not used by substitute."
+            )
+        ),
+    ] = None
     normalize_label: bool = True
     algorithm: Annotated[Literal["sha256", "sha1", "md5"], cyclopts.Parameter(help="Hash algorithm.")] = "sha256"
     digest_length: Annotated[int, cyclopts.Parameter(help="Hash digest length (6-64).")] = 12
@@ -77,13 +105,13 @@ class CliOpts:
     protect: Annotated[str | None, cyclopts.Parameter(help="What to protect (privacy goal).")] = None
     preserve: Annotated[str | None, cyclopts.Parameter(help="What to preserve (utility goal).")] = None
     risk_tolerance: Annotated[RiskToleranceChoice, cyclopts.Parameter(help="Risk tolerance preset.")] = "low"
-    max_repair_iterations: Annotated[int, cyclopts.Parameter(help="Max evaluate-repair iterations.")] = 2
+    max_repair_iterations: Annotated[int, cyclopts.Parameter(help="Max evaluate-repair iterations.")] = 3
 
     # -- shared between substitute (replace) and rewrite --
     instructions: Annotated[str | None, cyclopts.Parameter(help="Extra instructions for the LLM.")] = None
 
-    _REPLACE_ONLY_FLAGS: tuple[str, ...] = ("format_template",)
-    _REWRITE_ONLY_FLAGS: tuple[str, ...] = ("protect", "preserve")
+    _REPLACE_ONLY_FLAGS: ClassVar[tuple[str, ...]] = ("format_template",)
+    _REWRITE_ONLY_FLAGS: ClassVar[tuple[str, ...]] = ("protect", "preserve")
 
     def __post_init__(self) -> None:
         if self.replace and self.rewrite:
@@ -112,7 +140,7 @@ def _cli_error_handler(fn):
     def wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except (ValidationError, ValueError, InvalidConfigError, AnonymizerIOError) as exc:
+        except (ValidationError, ValueError, InvalidConfigError, AnonymizerIOError, FileNotFoundError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -188,7 +216,12 @@ def run(
     *,
     data: Annotated[AnonymizerInput, cyclopts.Parameter(name="*")],
     opts: Annotated[CliOpts, cyclopts.Parameter(name="*")] = CliOpts(),
-    output: str | None = None,
+    output: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help="Output file path (.csv or .parquet). Defaults to source stem + _anonymized or _rewritten."
+        ),
+    ] = None,
 ) -> None:
     """Run the full anonymization pipeline (detection + replacement or rewrite)."""
     if output is None:

--- a/tests/interface/cli/test_cli_model_configs.py
+++ b/tests/interface/cli/test_cli_model_configs.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for --model-configs and --model-providers file-path handling in the CLI.
+
+Covers:
+- File paths (existing and missing) for both flags
+- Inline YAML strings still work (regression)
+- FileNotFoundError is caught by _cli_error_handler (no traceback)
+- Non-YAML-extension strings are treated as inline YAML, not file paths
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from anonymizer.engine.ndd.model_loader import parse_model_configs
+from anonymizer.interface.anonymizer import _resolve_model_providers
+from anonymizer.interface.cli.main import app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def csv_file(tmp_path: Path) -> Path:
+    path = tmp_path / "data.csv"
+    pd.DataFrame({"text": ["Alice works at Acme Corp"]}).to_csv(path, index=False)
+    return path
+
+
+@pytest.fixture
+def model_configs_yaml(tmp_path: Path) -> Path:
+    """Minimal valid model_configs YAML file."""
+    path = tmp_path / "models.yaml"
+    path.write_text(
+        textwrap.dedent("""\
+            model_configs:
+              - alias: my-model
+                model: nvidia/some-model
+                provider: nvidia
+        """)
+    )
+    return path
+
+
+@pytest.fixture
+def providers_yaml(tmp_path: Path) -> Path:
+    """Minimal valid providers YAML file."""
+    path = tmp_path / "providers.yaml"
+    path.write_text(
+        textwrap.dedent("""\
+            providers:
+              - name: nvidia
+                endpoint: https://example.com/v1
+                provider_type: openai
+        """)
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# parse_model_configs: file-path detection
+# ---------------------------------------------------------------------------
+
+
+def test_model_configs_yaml_path_loads_file(model_configs_yaml: Path) -> None:
+    """A string ending in .yaml that exists on disk is loaded as a file."""
+    result = parse_model_configs(str(model_configs_yaml))
+    aliases = {mc.alias for mc in result.model_configs}
+    assert "my-model" in aliases
+
+
+def test_model_configs_yml_extension_loads_file(tmp_path: Path) -> None:
+    """A string ending in .yml (not .yaml) is also treated as a file path."""
+    path = tmp_path / "models.yml"
+    path.write_text(
+        textwrap.dedent("""\
+            model_configs:
+              - alias: yml-model
+                model: nvidia/yml-model
+                provider: nvidia
+        """)
+    )
+    result = parse_model_configs(str(path))
+    aliases = {mc.alias for mc in result.model_configs}
+    assert "yml-model" in aliases
+
+
+def test_model_configs_missing_yaml_file_raises_file_not_found() -> None:
+    """A .yaml path that does not exist raises FileNotFoundError with a clear message."""
+    with pytest.raises(FileNotFoundError, match="Config file not found"):
+        parse_model_configs("does_not_exist/models_super.yaml")
+
+
+def test_model_configs_missing_yaml_message_names_the_file() -> None:
+    """The FileNotFoundError message includes the bad file path so users can self-diagnose."""
+    bad_path = "configs/models_typo.yaml"
+    with pytest.raises(FileNotFoundError, match="models_typo.yaml"):
+        parse_model_configs(bad_path)
+
+
+def test_model_configs_inline_yaml_still_works() -> None:
+    """Multi-line inline YAML (no file extension) still parses correctly — no regression."""
+    inline = textwrap.dedent("""\
+        model_configs:
+          - alias: inline-model
+            model: nvidia/inline
+            provider: nvidia
+    """)
+    result = parse_model_configs(inline)
+    aliases = {mc.alias for mc in result.model_configs}
+    assert "inline-model" in aliases
+
+
+def test_model_configs_non_yaml_extension_string_parsed_as_yaml() -> None:
+    """A string without a .yaml/.yml extension is treated as inline YAML, not a file path."""
+    with pytest.raises(ValueError, match="Expected YAML mapping"):
+        parse_model_configs("not_a_file.json")
+
+
+def test_model_configs_none_uses_defaults() -> None:
+    """None falls back to bundled defaults without error."""
+    result = parse_model_configs(None)
+    assert len(result.model_configs) > 0
+
+
+def test_model_configs_path_object_still_works(model_configs_yaml: Path) -> None:
+    """Passing a Path object (programmatic use) is unchanged — no regression."""
+    result = parse_model_configs(model_configs_yaml)
+    aliases = {mc.alias for mc in result.model_configs}
+    assert "my-model" in aliases
+
+
+# ---------------------------------------------------------------------------
+# _resolve_model_providers: file-path detection
+# ---------------------------------------------------------------------------
+
+
+def test_model_providers_yaml_path_loads_file(providers_yaml: Path) -> None:
+    """A string ending in .yaml that exists on disk is loaded as a file."""
+    result = _resolve_model_providers(str(providers_yaml))
+    assert result is not None
+    names = {p.name for p in result}
+    assert "nvidia" in names
+
+
+def test_model_providers_missing_yaml_file_raises_file_not_found() -> None:
+    """A .yaml path that does not exist raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match="Providers config file not found"):
+        _resolve_model_providers("does_not_exist/providers.yaml")
+
+
+def test_model_providers_missing_yaml_message_names_the_file() -> None:
+    """The FileNotFoundError message includes the bad file path."""
+    bad_path = "configs/providers_typo.yaml"
+    with pytest.raises(FileNotFoundError, match="providers_typo.yaml"):
+        _resolve_model_providers(bad_path)
+
+
+def test_model_providers_none_returns_none() -> None:
+    """None returns None — no providers registered."""
+    assert _resolve_model_providers(None) is None
+
+
+def test_model_providers_list_passthrough() -> None:
+    """A pre-built list of ModelProvider objects is returned as-is."""
+    from data_designer.config.models import ModelProvider
+
+    providers = [ModelProvider(name="my-provider", endpoint="https://example.com/v1")]
+    result = _resolve_model_providers(providers)
+    assert result is providers
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: _cli_error_handler catches FileNotFoundError
+# ---------------------------------------------------------------------------
+
+
+def test_cli_missing_model_configs_exits_cleanly(csv_file: Path, capsys: pytest.CaptureFixture) -> None:
+    """A missing --model-configs file exits with code 1 and prints a useful message — no traceback."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(
+            [
+                "run",
+                "--source",
+                str(csv_file),
+                "--replace",
+                "redact",
+                "--model-configs",
+                "nonexistent/models.yaml",
+            ]
+        )
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "models.yaml" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_missing_model_providers_exits_cleanly(csv_file: Path, capsys: pytest.CaptureFixture) -> None:
+    """A missing --model-providers file exits with code 1 and prints a useful message."""
+    with patch("anonymizer.interface.cli.main.Anonymizer") as mock_cls:
+        mock_cls.side_effect = FileNotFoundError("Providers config file not found: nonexistent/providers.yaml")
+        with pytest.raises(SystemExit) as exc_info:
+            app(
+                [
+                    "run",
+                    "--source",
+                    str(csv_file),
+                    "--replace",
+                    "redact",
+                    "--model-providers",
+                    "nonexistent/providers.yaml",
+                ]
+            )
+    assert exc_info.value.code != 0
+
+
+def test_cli_model_configs_file_path_accepted(csv_file: Path, model_configs_yaml: Path) -> None:
+    """--model-configs accepts a YAML file path; Anonymizer is constructed with the loaded configs."""
+    mock_anonymizer = MagicMock()
+    mock_result = MagicMock()
+    mock_result.dataframe = pd.DataFrame()
+    mock_result.failed_records = []
+    mock_anonymizer.run.return_value = mock_result
+
+    with patch("anonymizer.interface.cli.main.Anonymizer", return_value=mock_anonymizer) as mock_cls:
+        with pytest.raises(SystemExit) as exc_info:
+            app(
+                [
+                    "run",
+                    "--source",
+                    str(csv_file),
+                    "--replace",
+                    "redact",
+                    "--model-configs",
+                    str(model_configs_yaml),
+                ]
+            )
+    assert exc_info.value.code == 0
+    mock_cls.assert_called_once()
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["model_configs"] == str(model_configs_yaml)
+
+
+def test_cli_model_providers_file_path_accepted(csv_file: Path, providers_yaml: Path) -> None:
+    """--model-providers accepts a YAML file path."""
+    mock_anonymizer = MagicMock()
+    mock_result = MagicMock()
+    mock_result.dataframe = pd.DataFrame()
+    mock_result.failed_records = []
+    mock_anonymizer.run.return_value = mock_result
+
+    with patch("anonymizer.interface.cli.main.Anonymizer", return_value=mock_anonymizer) as mock_cls:
+        with pytest.raises(SystemExit) as exc_info:
+            app(
+                [
+                    "run",
+                    "--source",
+                    str(csv_file),
+                    "--replace",
+                    "redact",
+                    "--model-providers",
+                    str(providers_yaml),
+                ]
+            )
+    assert exc_info.value.code == 0
+    mock_cls.assert_called_once()
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["model_providers"] == str(providers_yaml)
+
+
+def test_cli_old_confusing_error_message_is_gone(csv_file: Path, capsys: pytest.CaptureFixture) -> None:
+    """The old 'Expected YAML mapping, got str' message no longer appears for a missing .yaml file."""
+    with pytest.raises(SystemExit):
+        app(
+            [
+                "run",
+                "--source",
+                str(csv_file),
+                "--replace",
+                "redact",
+                "--model-configs",
+                "configs/models_super.yaml",
+            ]
+        )
+    captured = capsys.readouterr()
+    assert "Expected YAML mapping" not in captured.err
+    assert "got str" not in captured.err

--- a/tests/interface/cli/test_cli_model_configs.py
+++ b/tests/interface/cli/test_cli_model_configs.py
@@ -1,16 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for --model-configs and --model-providers file-path handling in the CLI.
-
-Covers:
-- File paths (existing and missing) for both flags
-- Directory paths with .yaml extension are rejected cleanly (is_file check)
-- Inline YAML strings still work (regression)
-- OSError (and subclasses) is caught by _cli_error_handler (no traceback)
-- Non-YAML-extension strings are treated as inline YAML, not file paths
-"""
-
 from __future__ import annotations
 
 import textwrap

--- a/tests/interface/cli/test_cli_model_configs.py
+++ b/tests/interface/cli/test_cli_model_configs.py
@@ -136,6 +136,39 @@ def test_model_providers_directory_path_raises_file_not_found(tmp_path: Path) ->
         _resolve_model_providers(str(yaml_dir))
 
 
+def test_model_configs_tilde_path_expanded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """~/models.yaml expands to the user's home directory (not treated as a literal ~ path)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = tmp_path / "models.yaml"
+    path.write_text(
+        textwrap.dedent("""\
+            model_configs:
+              - alias: tilde-model
+                model: nvidia/tilde
+                provider: nvidia
+        """)
+    )
+    result = parse_model_configs("~/models.yaml")
+    assert "tilde-model" in {mc.alias for mc in result.model_configs}
+
+
+def test_model_providers_tilde_path_expanded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """~/providers.yaml expands to the user's home directory."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = tmp_path / "providers.yaml"
+    path.write_text(
+        textwrap.dedent("""\
+            providers:
+              - name: tilde-provider
+                endpoint: https://example.com/v1
+                provider_type: openai
+        """)
+    )
+    result = _resolve_model_providers("~/providers.yaml")
+    assert result is not None
+    assert "tilde-provider" in {p.name for p in result}
+
+
 def test_model_configs_non_yaml_extension_string_parsed_as_yaml() -> None:
     """A string without a .yaml/.yml extension is treated as inline YAML, not a file path."""
     with pytest.raises(ValueError, match="Expected YAML mapping"):

--- a/tests/interface/cli/test_cli_model_configs.py
+++ b/tests/interface/cli/test_cli_model_configs.py
@@ -23,7 +23,6 @@ from anonymizer.engine.ndd.model_loader import parse_model_configs
 from anonymizer.interface.anonymizer import _resolve_model_providers
 from anonymizer.interface.cli.main import app
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/interface/cli/test_cli_model_configs.py
+++ b/tests/interface/cli/test_cli_model_configs.py
@@ -5,8 +5,9 @@
 
 Covers:
 - File paths (existing and missing) for both flags
+- Directory paths with .yaml extension are rejected cleanly (is_file check)
 - Inline YAML strings still work (regression)
-- FileNotFoundError is caught by _cli_error_handler (no traceback)
+- OSError (and subclasses) is caught by _cli_error_handler (no traceback)
 - Non-YAML-extension strings are treated as inline YAML, not file paths
 """
 
@@ -119,6 +120,22 @@ def test_model_configs_inline_yaml_still_works() -> None:
     assert "inline-model" in aliases
 
 
+def test_model_configs_directory_path_raises_file_not_found(tmp_path: Path) -> None:
+    """A directory named *.yaml is rejected with FileNotFoundError, not a cryptic open() error."""
+    yaml_dir = tmp_path / "models.yaml"
+    yaml_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="Config file not found"):
+        parse_model_configs(str(yaml_dir))
+
+
+def test_model_providers_directory_path_raises_file_not_found(tmp_path: Path) -> None:
+    """A directory named *.yaml for providers is rejected with FileNotFoundError."""
+    yaml_dir = tmp_path / "providers.yaml"
+    yaml_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="Providers config file not found"):
+        _resolve_model_providers(str(yaml_dir))
+
+
 def test_model_configs_non_yaml_extension_string_parsed_as_yaml() -> None:
     """A string without a .yaml/.yml extension is treated as inline YAML, not a file path."""
     with pytest.raises(ValueError, match="Expected YAML mapping"):
@@ -206,7 +223,7 @@ def test_cli_missing_model_configs_exits_cleanly(csv_file: Path, capsys: pytest.
 def test_cli_missing_model_providers_exits_cleanly(csv_file: Path, capsys: pytest.CaptureFixture) -> None:
     """A missing --model-providers file exits with code 1 and prints a useful message."""
     with patch("anonymizer.interface.cli.main.Anonymizer") as mock_cls:
-        mock_cls.side_effect = FileNotFoundError("Providers config file not found: nonexistent/providers.yaml")
+        mock_cls.side_effect = OSError("Providers config file not found: nonexistent/providers.yaml")
         with pytest.raises(SystemExit) as exc_info:
             app(
                 [
@@ -220,6 +237,27 @@ def test_cli_missing_model_providers_exits_cleanly(csv_file: Path, capsys: pytes
                 ]
             )
     assert exc_info.value.code != 0
+
+
+def test_cli_oserror_exits_cleanly(csv_file: Path, capsys: pytest.CaptureFixture) -> None:
+    """Any OSError (e.g. PermissionError) is caught cleanly — no traceback."""
+    with patch("anonymizer.interface.cli.main.Anonymizer") as mock_cls:
+        mock_cls.side_effect = PermissionError("Permission denied: /secure/models.yaml")
+        with pytest.raises(SystemExit) as exc_info:
+            app(
+                [
+                    "run",
+                    "--source",
+                    str(csv_file),
+                    "--replace",
+                    "redact",
+                    "--model-configs",
+                    "/secure/models.yaml",
+                ]
+            )
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.err
 
 
 def test_cli_model_configs_file_path_accepted(csv_file: Path, model_configs_yaml: Path) -> None:


### PR DESCRIPTION
## Summary

- `--model-configs` and `--model-providers` now accept `.yaml`/`.yml` file paths from the CLI — previously any string was parsed as inline YAML, causing the cryptic `Expected YAML mapping, got str` error when a filename was passed
- Missing files now raise a clear `Error: Config file not found: <path>` instead of a traceback
- `FileNotFoundError` added to `_cli_error_handler` so it prints cleanly like other user errors
- `_REPLACE_ONLY_FLAGS` / `_REWRITE_ONLY_FLAGS` converted to `ClassVar` — they were leaking into `--help` as `--replace-only-flags` / `--rewrite-only-flags`
- `--max-repair-iterations` default corrected from `2` to `3` to match the SDK's `Rewrite` model
- Added help text to previously undocumented flags: `--model-configs`, `--model-providers`, `--artifact-path`, `--format-template`, `--output`

## Type of Change
- [x] Bug fix
- [x] New feature

## Testing
- [x] `make test` passes locally
- [x] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

18 new tests in `tests/interface/cli/test_cli_model_configs.py` covering file-path loading, missing-file errors, inline YAML regression, and clean CLI exit behaviour.

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->