### PR TITLE
docs: replace placeholder patient_data.csv with real sample dataset

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,9 +65,9 @@ By default, Anonymizer uses NVIDIA-hosted models for detection and LLM-based ano
     from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Substitute
 
     input_data = AnonymizerInput(
-        source="patient_data.csv",
-        text_column="notes",
-        data_summary="Records containing detailed notes on patient encounters",
+        source="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv",
+        text_column="biography",
+        data_summary="Biographical profiles of individuals",
     )
     anonymizer = Anonymizer()
     config = AnonymizerConfig(replace=Substitute())
@@ -93,19 +93,19 @@ By default, Anonymizer uses NVIDIA-hosted models for detection and LLM-based ano
     ```bash
     # Preview a few rows first
     anonymizer preview \
-      --source patient_data.csv \
-      --text-column notes \
-      --data-summary "Records containing detailed notes on patient encounters" \
+      --source "https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv" \
+      --text-column biography \
+      --data-summary "Biographical profiles of individuals" \
       --replace substitute \
       --num-records 5
 
     # Then run the full dataset
     anonymizer run \
-      --source patient_data.csv \
-      --text-column notes \
-      --data-summary "Records containing detailed notes on patient encounters" \
+      --source "https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/main/docs/data/NVIDIA_synthetic_biographies.csv" \
+      --text-column biography \
+      --data-summary "Biographical profiles of individuals" \
       --replace substitute \
-      --output patient_data_anonymized.csv
+      --output biographies_anonymized.csv
     ```
 
 !!! note "`data_summary` improves detection"


### PR DESCRIPTION
## Summary
- Quickstart example on the homepage referenced `patient_data.csv` which doesn't exist in the repo, leaving users with no way to run the code
- Replaced with the synthetic biographies CSV already used in tutorial notebook 01, loaded via public GitHub URL
- Updated both Python and CLI examples; updated output filename to match

## Test plan
- [ ] Verify the URL resolves to the CSV and has the expected `biography` column
- [ ] Confirm the rendered docs look correct at the quickstart section

🤖 Generated with [Claude Code](https://claude.com/claude-code)