### PR TITLE
chore: fix data designer version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 license = "Apache-2.0"
 
 dependencies = [
-    "data-designer>=0.5.7",
+    "data-designer==0.5.7",
     "pydantic>=2.9,<3",
     "cyclopts>=3",
     "pygments>=2.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2448,7 +2448,7 @@ notebooks = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "cyclopts", specifier = ">=3" },
-    { name = "data-designer", specifier = ">=0.5.7" },
+    { name = "data-designer", specifier = "==0.5.7" },
     { name = "pydantic", specifier = ">=2.9,<3" },
     { name = "pygments", specifier = ">=2.20.0" },
 ]


### PR DESCRIPTION
## Summary
Small PR to fix `data-designer==0.5.7` instead of `>=` so we do not suffer from untested consequences of upcoming async defaults in data designer (overwhelming our default model set and leading to failures). Before we upgrade, we need to perform the task of default model selection to spread the load across models, not just pin all rewrite steps to `gpt-oss-120b` which overloads the model on build. 