### PR TITLE
fix: add visibility to silent failures in NDD adapter

### DIFF
--- a/src/anonymizer/engine/ndd/adapter.py
+++ b/src/anonymizer/engine/ndd/adapter.py
@@ -153,8 +153,7 @@ class NddAdapter:
             logger.warning(
                 "Missing-record detection skipped: input DataFrame lacks the record-tracking "
                 "column, so the adapter cannot verify whether any of %d input record(s) were "
-                "dropped. This indicates an internal invariant violation - `_attach_record_ids` "
-                "was not called on this DataFrame before detection.",
+                "dropped.",
                 len(input_df),
             )
             logger.debug(

--- a/src/anonymizer/engine/ndd/adapter.py
+++ b/src/anonymizer/engine/ndd/adapter.py
@@ -64,6 +64,7 @@ class NddAdapter:
         logger.debug("NDD workflow '%s' starting with %d records", workflow_name, len(workflow_input_df))
         col_names = [c.name for c in columns]
         logger.debug("NDD workflow '%s': %d columns %s", workflow_name, len(col_names), col_names)
+        model_aliases = [m.alias for m in model_configs]
 
         with tempfile.TemporaryDirectory(prefix=f"anonymizer_{workflow_name}_") as tmp_dir:
             seed_path = str(Path(tmp_dir) / "seed.parquet")
@@ -75,18 +76,50 @@ class NddAdapter:
                 config_builder.add_column(column)
 
             if preview_num_records is None:
-                run_results = self._data_designer.create(
-                    config_builder,
-                    num_records=len(workflow_input_df),
-                    dataset_name=workflow_name,
-                )
-                output_df = run_results.load_dataset()
+                try:
+                    run_results = self._data_designer.create(
+                        config_builder,
+                        num_records=len(workflow_input_df),
+                        dataset_name=workflow_name,
+                    )
+                    output_df = run_results.load_dataset()
+                except Exception as exc:
+                    logger.warning(
+                        "Workflow execution failed for %d input record(s) on model(s) %s: %s: %s. "
+                        "Check endpoint reachability, credentials, and quota.",
+                        len(workflow_input_df),
+                        model_aliases,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    logger.debug(
+                        "Workflow '%s' execution failure context: columns=%s",
+                        workflow_name,
+                        col_names,
+                    )
+                    raise
             else:
                 effective_preview = min(preview_num_records, len(workflow_input_df))
-                preview_results = self._data_designer.preview(
-                    config_builder,
-                    num_records=effective_preview,
-                )
+                try:
+                    preview_results = self._data_designer.preview(
+                        config_builder,
+                        num_records=effective_preview,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Workflow preview failed for %d input record(s) on model(s) %s: %s: %s. "
+                        "Check endpoint reachability, credentials, and quota.",
+                        effective_preview,
+                        model_aliases,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    logger.debug(
+                        "Workflow '%s' preview failure context: columns=%s",
+                        workflow_name,
+                        col_names,
+                    )
+                    raise
                 if preview_results.dataset is None:
                     output_df = workflow_input_df.iloc[0:0].copy()
                 else:
@@ -129,8 +162,42 @@ class NddAdapter:
         output_df: pd.DataFrame,
     ) -> list[FailedRecord]:
         if RECORD_ID_COLUMN not in input_df.columns:
+            logger.warning(
+                "Missing-record detection skipped: input DataFrame lacks the record-tracking "
+                "column, so the adapter cannot verify whether any of %d input record(s) were "
+                "dropped. This indicates an internal invariant violation - `_attach_record_ids` "
+                "was not called on this DataFrame before detection.",
+                len(input_df),
+            )
+            logger.debug(
+                "Workflow '%s' detection skipped: input missing '%s'; input_columns=%s",
+                workflow_name,
+                RECORD_ID_COLUMN,
+                list(input_df.columns),
+            )
             return []
         if RECORD_ID_COLUMN not in output_df.columns:
+            input_cols = set(input_df.columns)
+            output_cols = set(output_df.columns)
+            other_dropped = sorted((input_cols - output_cols) - {RECORD_ID_COLUMN})
+            added = sorted(output_cols - input_cols)
+            logger.warning(
+                "Missing-record detection disabled: workflow output does not contain "
+                "the record-tracking column, so all %d input record(s) are being marked as "
+                "failed. This typically means seed-column pass-through is disabled or a "
+                "user-supplied column config overwrote it. Other input columns that were "
+                "also dropped: %s. Columns added by the workflow: %s.",
+                len(input_df),
+                other_dropped,
+                added,
+            )
+            logger.debug(
+                "Workflow '%s' detection disabled: output missing '%s'; input_columns=%s output_columns=%s",
+                workflow_name,
+                RECORD_ID_COLUMN,
+                list(input_df.columns),
+                list(output_df.columns),
+            )
             return [
                 FailedRecord(
                     record_id=record_id,

--- a/src/anonymizer/engine/ndd/adapter.py
+++ b/src/anonymizer/engine/ndd/adapter.py
@@ -82,7 +82,6 @@ class NddAdapter:
                         num_records=len(workflow_input_df),
                         dataset_name=workflow_name,
                     )
-                    output_df = run_results.load_dataset()
                 except Exception as exc:
                     logger.warning(
                         "Workflow execution failed for %d input record(s) on model(s) %s: %s: %s. "
@@ -94,6 +93,24 @@ class NddAdapter:
                     )
                     logger.debug(
                         "Workflow '%s' execution failure context: columns=%s",
+                        workflow_name,
+                        col_names,
+                    )
+                    raise
+                try:
+                    output_df = run_results.load_dataset()
+                except Exception as exc:
+                    logger.warning(
+                        "Workflow execution completed but loading the generated dataset failed for "
+                        "%d input record(s) on model(s) %s: %s: %s. "
+                        "Check local storage and dataset integrity.",
+                        len(workflow_input_df),
+                        model_aliases,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    logger.debug(
+                        "Workflow '%s' dataset load failure context: columns=%s",
                         workflow_name,
                         col_names,
                     )

--- a/src/anonymizer/engine/ndd/adapter.py
+++ b/src/anonymizer/engine/ndd/adapter.py
@@ -17,6 +17,8 @@ from data_designer.config.models import ModelConfig
 from data_designer.config.seed import SamplingStrategy
 from data_designer.config.seed_source import LocalFileSeedSource
 
+from anonymizer.interface.errors import AnonymizerWorkflowError
+
 if TYPE_CHECKING:
     import pandas as pd
     from data_designer.interface.data_designer import DataDesigner
@@ -75,72 +77,41 @@ class NddAdapter:
             for column in columns:
                 config_builder.add_column(column)
 
-            if preview_num_records is None:
-                try:
+            record_count = (
+                min(preview_num_records, len(workflow_input_df))
+                if preview_num_records is not None
+                else len(workflow_input_df)
+            )
+            try:
+                if preview_num_records is None:
                     run_results = self._data_designer.create(
                         config_builder,
                         num_records=len(workflow_input_df),
                         dataset_name=workflow_name,
                     )
-                except Exception as exc:
-                    logger.warning(
-                        "Workflow execution failed for %d input record(s) on model(s) %s: %s: %s. "
-                        "Check endpoint reachability, credentials, and quota.",
-                        len(workflow_input_df),
-                        model_aliases,
-                        type(exc).__name__,
-                        exc,
-                    )
-                    logger.debug(
-                        "Workflow '%s' execution failure context: columns=%s",
-                        workflow_name,
-                        col_names,
-                    )
-                    raise
-                try:
                     output_df = run_results.load_dataset()
-                except Exception as exc:
-                    logger.warning(
-                        "Workflow execution completed but loading the generated dataset failed for "
-                        "%d input record(s) on model(s) %s: %s: %s. "
-                        "Check local storage and dataset integrity.",
-                        len(workflow_input_df),
-                        model_aliases,
-                        type(exc).__name__,
-                        exc,
-                    )
-                    logger.debug(
-                        "Workflow '%s' dataset load failure context: columns=%s",
-                        workflow_name,
-                        col_names,
-                    )
-                    raise
-            else:
-                effective_preview = min(preview_num_records, len(workflow_input_df))
-                try:
+                else:
                     preview_results = self._data_designer.preview(
                         config_builder,
-                        num_records=effective_preview,
+                        num_records=record_count,
                     )
-                except Exception as exc:
-                    logger.warning(
-                        "Workflow preview failed for %d input record(s) on model(s) %s: %s: %s. "
-                        "Check endpoint reachability, credentials, and quota.",
-                        effective_preview,
-                        model_aliases,
-                        type(exc).__name__,
-                        exc,
-                    )
-                    logger.debug(
-                        "Workflow '%s' preview failure context: columns=%s",
-                        workflow_name,
-                        col_names,
-                    )
-                    raise
-                if preview_results.dataset is None:
-                    output_df = workflow_input_df.iloc[0:0].copy()
-                else:
-                    output_df = preview_results.dataset
+                    if preview_results.dataset is None:
+                        output_df = workflow_input_df.iloc[0:0].copy()
+                    else:
+                        output_df = preview_results.dataset
+            except Exception as exc:
+                logger.warning(
+                    "Workflow failed for %d input record(s) on model(s) %s: %s",
+                    record_count,
+                    model_aliases,
+                    exc,
+                )
+                logger.debug(
+                    "Workflow '%s' failure context: columns=%s",
+                    workflow_name,
+                    col_names,
+                )
+                raise AnonymizerWorkflowError(f"Workflow failed: {exc}") from exc
 
         logger.debug("NDD workflow '%s' returned %d records", workflow_name, len(output_df))
         failed_records = self._detect_missing_records(

--- a/src/anonymizer/interface/errors.py
+++ b/src/anonymizer/interface/errors.py
@@ -18,3 +18,12 @@ class InvalidConfigError(AnonymizerError):
 
 class AnonymizerIOError(AnonymizerError):
     """Raised when file IO operations fail."""
+
+
+class AnonymizerWorkflowError(AnonymizerError):
+    """Raised when an underlying workflow step (preview, execution, or dataset load) fails.
+
+    The original backend exception is preserved as ``__cause__`` via ``raise ... from exc``
+    so callers can inspect the exact failure without the anonymizer layer leaking backend
+    exception types into its own public error hierarchy.
+    """

--- a/tests/engine/test_ndd_adapter.py
+++ b/tests/engine/test_ndd_adapter.py
@@ -180,6 +180,59 @@ def test_create_exception_warns_with_count_model_and_type_and_debug_carries_work
     _assert_no_backend_reference(debug_msg)
 
 
+def test_load_dataset_exception_warns_with_distinct_local_failure_hint(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
+
+    class LoadExplosion(Exception):
+        pass
+
+    mock_dd = Mock(spec=DataDesigner)
+    mock_create_results = Mock()
+    mock_create_results.load_dataset.side_effect = LoadExplosion("corrupt parquet")
+    mock_dd.create.return_value = mock_create_results
+
+    adapter = NddAdapter(data_designer=mock_dd)
+    input_df = pd.DataFrame({"text": ["row-1", "row-2"]})
+
+    with pytest.raises(LoadExplosion):
+        adapter.run_workflow(
+            input_df,
+            model_configs=[_make_model_config()],
+            columns=_make_columns(),
+            workflow_name="replace-workflow",
+            preview_num_records=None,
+        )
+
+    warning_records = _unique_records(
+        caplog,
+        level=logging.WARNING,
+        message_contains="loading the generated dataset failed",
+    )
+    assert len(warning_records) == 1
+    warning_msg = warning_records[0].getMessage()
+    assert "2" in warning_msg
+    assert "test-model-alias" in warning_msg
+    assert "LoadExplosion" in warning_msg
+    assert "Check local storage and dataset integrity" in warning_msg
+    assert "endpoint reachability" not in warning_msg
+    assert "replace-workflow" not in warning_msg
+    _assert_no_backend_reference(warning_msg)
+
+    execution_failed_records = _unique_records(
+        caplog, level=logging.WARNING, message_contains="Workflow execution failed"
+    )
+    assert execution_failed_records == []
+
+    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="dataset load failure context")
+    assert len(debug_records) == 1
+    debug_msg = debug_records[0].getMessage()
+    assert "replace-workflow" in debug_msg
+    assert "output" in debug_msg
+    _assert_no_backend_reference(debug_msg)
+
+
 def test_detect_missing_records_short_circuit_warns_when_input_missing_id(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/engine/test_ndd_adapter.py
+++ b/tests/engine/test_ndd_adapter.py
@@ -259,7 +259,7 @@ def test_detect_missing_records_short_circuit_warns_when_input_missing_id(
     warning_msg = warning_records[0].getMessage()
     assert "3" in warning_msg
     assert "detection skipped" in warning_msg
-    assert "invariant violation" in warning_msg
+    assert "cannot verify" in warning_msg
     _assert_no_backend_reference(warning_msg)
 
     debug_records = _unique_records(caplog, level=logging.DEBUG)

--- a/tests/engine/test_ndd_adapter.py
+++ b/tests/engine/test_ndd_adapter.py
@@ -14,8 +14,9 @@ from data_designer.config.models import ModelConfig
 from data_designer.interface.data_designer import DataDesigner
 
 from anonymizer.engine.ndd.adapter import RECORD_ID_COLUMN, NddAdapter
+from anonymizer.interface.errors import AnonymizerWorkflowError
 
-_FORBIDDEN_BACKEND_STRINGS = ("Data Designer", "data_designer", "DD")
+_FORBIDDEN_BACKEND_STRINGS = ("Data Designer", "DataDesigner", "data_designer", "DD")
 
 
 def _assert_no_backend_reference(message: str) -> None:
@@ -100,21 +101,21 @@ def test_detect_missing_records_for_preview_subset_has_no_false_failures() -> No
     assert len(failed_records) == 0
 
 
-def test_preview_exception_warns_with_count_model_and_type_and_debug_carries_workflow(
+def test_preview_exception_wraps_in_workflow_error_and_logs(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
 
-    class PreviewExplosion(Exception):
+    class DataDesignerRuntimeError(Exception):
         pass
 
     mock_dd = Mock(spec=DataDesigner)
-    mock_dd.preview.side_effect = PreviewExplosion("endpoint unreachable")
+    mock_dd.preview.side_effect = DataDesignerRuntimeError("endpoint unreachable")
 
     adapter = NddAdapter(data_designer=mock_dd)
     input_df = pd.DataFrame({"text": ["row-1", "row-2", "row-3"]})
 
-    with pytest.raises(PreviewExplosion):
+    with pytest.raises(AnonymizerWorkflowError) as exc_info:
         adapter.run_workflow(
             input_df,
             model_configs=[_make_model_config()],
@@ -123,16 +124,20 @@ def test_preview_exception_warns_with_count_model_and_type_and_debug_carries_wor
             preview_num_records=3,
         )
 
-    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="preview failed")
+    assert isinstance(exc_info.value.__cause__, DataDesignerRuntimeError)
+    assert "endpoint unreachable" in str(exc_info.value)
+
+    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="Workflow failed")
     assert len(warning_records) == 1
     warning_msg = warning_records[0].getMessage()
     assert "3" in warning_msg
     assert "test-model-alias" in warning_msg
-    assert "PreviewExplosion" in warning_msg
+    assert "endpoint unreachable" in warning_msg
+    assert "Check endpoint reachability" not in warning_msg
     assert "detect-workflow" not in warning_msg
     _assert_no_backend_reference(warning_msg)
 
-    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="preview failure context")
+    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="failure context")
     assert len(debug_records) == 1
     debug_msg = debug_records[0].getMessage()
     assert "detect-workflow" in debug_msg
@@ -140,21 +145,21 @@ def test_preview_exception_warns_with_count_model_and_type_and_debug_carries_wor
     _assert_no_backend_reference(debug_msg)
 
 
-def test_create_exception_warns_with_count_model_and_type_and_debug_carries_workflow(
+def test_create_exception_wraps_in_workflow_error_and_logs(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
 
-    class CreateExplosion(Exception):
+    class DataDesignerRuntimeError(Exception):
         pass
 
     mock_dd = Mock(spec=DataDesigner)
-    mock_dd.create.side_effect = CreateExplosion("quota exceeded")
+    mock_dd.create.side_effect = DataDesignerRuntimeError("quota exceeded")
 
     adapter = NddAdapter(data_designer=mock_dd)
     input_df = pd.DataFrame({"text": ["row-1", "row-2"]})
 
-    with pytest.raises(CreateExplosion):
+    with pytest.raises(AnonymizerWorkflowError) as exc_info:
         adapter.run_workflow(
             input_df,
             model_configs=[_make_model_config()],
@@ -163,16 +168,20 @@ def test_create_exception_warns_with_count_model_and_type_and_debug_carries_work
             preview_num_records=None,
         )
 
-    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="execution failed")
+    assert isinstance(exc_info.value.__cause__, DataDesignerRuntimeError)
+    assert "quota exceeded" in str(exc_info.value)
+
+    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="Workflow failed")
     assert len(warning_records) == 1
     warning_msg = warning_records[0].getMessage()
     assert "2" in warning_msg
     assert "test-model-alias" in warning_msg
-    assert "CreateExplosion" in warning_msg
+    assert "quota exceeded" in warning_msg
+    assert "Check endpoint reachability" not in warning_msg
     assert "replace-workflow" not in warning_msg
     _assert_no_backend_reference(warning_msg)
 
-    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="execution failure context")
+    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="failure context")
     assert len(debug_records) == 1
     debug_msg = debug_records[0].getMessage()
     assert "replace-workflow" in debug_msg
@@ -180,23 +189,23 @@ def test_create_exception_warns_with_count_model_and_type_and_debug_carries_work
     _assert_no_backend_reference(debug_msg)
 
 
-def test_load_dataset_exception_warns_with_distinct_local_failure_hint(
+def test_load_dataset_exception_wraps_in_workflow_error_and_logs(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
 
-    class LoadExplosion(Exception):
+    class DataDesignerRuntimeError(Exception):
         pass
 
     mock_dd = Mock(spec=DataDesigner)
     mock_create_results = Mock()
-    mock_create_results.load_dataset.side_effect = LoadExplosion("corrupt parquet")
+    mock_create_results.load_dataset.side_effect = DataDesignerRuntimeError("corrupt parquet")
     mock_dd.create.return_value = mock_create_results
 
     adapter = NddAdapter(data_designer=mock_dd)
     input_df = pd.DataFrame({"text": ["row-1", "row-2"]})
 
-    with pytest.raises(LoadExplosion):
+    with pytest.raises(AnonymizerWorkflowError) as exc_info:
         adapter.run_workflow(
             input_df,
             model_configs=[_make_model_config()],
@@ -205,27 +214,21 @@ def test_load_dataset_exception_warns_with_distinct_local_failure_hint(
             preview_num_records=None,
         )
 
-    warning_records = _unique_records(
-        caplog,
-        level=logging.WARNING,
-        message_contains="loading the generated dataset failed",
-    )
+    assert isinstance(exc_info.value.__cause__, DataDesignerRuntimeError)
+    assert "corrupt parquet" in str(exc_info.value)
+
+    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="Workflow failed")
     assert len(warning_records) == 1
     warning_msg = warning_records[0].getMessage()
     assert "2" in warning_msg
     assert "test-model-alias" in warning_msg
-    assert "LoadExplosion" in warning_msg
-    assert "Check local storage and dataset integrity" in warning_msg
-    assert "endpoint reachability" not in warning_msg
+    assert "corrupt parquet" in warning_msg
+    assert "Check local storage" not in warning_msg
+    assert "Check endpoint reachability" not in warning_msg
     assert "replace-workflow" not in warning_msg
     _assert_no_backend_reference(warning_msg)
 
-    execution_failed_records = _unique_records(
-        caplog, level=logging.WARNING, message_contains="Workflow execution failed"
-    )
-    assert execution_failed_records == []
-
-    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="dataset load failure context")
+    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="failure context")
     assert len(debug_records) == 1
     debug_msg = debug_records[0].getMessage()
     assert "replace-workflow" in debug_msg

--- a/tests/engine/test_ndd_adapter.py
+++ b/tests/engine/test_ndd_adapter.py
@@ -3,12 +3,60 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import Mock
 
 import pandas as pd
+import pytest
+from data_designer.config.column_configs import LLMTextColumnConfig
+from data_designer.config.column_types import ColumnConfigT
+from data_designer.config.models import ModelConfig
 from data_designer.interface.data_designer import DataDesigner
 
 from anonymizer.engine.ndd.adapter import RECORD_ID_COLUMN, NddAdapter
+
+_FORBIDDEN_BACKEND_STRINGS = ("Data Designer", "data_designer", "DD")
+
+
+def _assert_no_backend_reference(message: str) -> None:
+    for forbidden in _FORBIDDEN_BACKEND_STRINGS:
+        assert forbidden not in message, f"log message leaks backend reference {forbidden!r}: {message}"
+
+
+def _unique_records(
+    caplog: pytest.LogCaptureFixture,
+    *,
+    level: int,
+    message_contains: str | None = None,
+) -> list[logging.LogRecord]:
+    """Return unique records at *level* from the ``anonymizer.ndd`` logger.
+
+    The autouse ``_caplog_for_anonymizer`` fixture causes each record to be
+    observed twice (once via the anonymizer logger, once via propagation to root),
+    so we dedupe by object identity.
+    """
+    seen: dict[int, logging.LogRecord] = {}
+    for record in caplog.records:
+        if record.name != "anonymizer.ndd" or record.levelno != level:
+            continue
+        if message_contains is not None and message_contains not in record.getMessage():
+            continue
+        seen[id(record)] = record
+    return list(seen.values())
+
+
+def _make_model_config(alias: str = "test-model-alias") -> ModelConfig:
+    return ModelConfig(alias=alias, model="dummy-model-id")
+
+
+def _make_columns() -> list[ColumnConfigT]:
+    return [
+        LLMTextColumnConfig(
+            name="output",
+            prompt="Echo: {{ text }}",
+            model_alias="test-model-alias",
+        ),
+    ]
 
 
 def test_attach_record_ids_adds_deterministic_ids() -> None:
@@ -50,3 +98,173 @@ def test_detect_missing_records_for_preview_subset_has_no_false_failures() -> No
     )
 
     assert len(failed_records) == 0
+
+
+def test_preview_exception_warns_with_count_model_and_type_and_debug_carries_workflow(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
+
+    class PreviewExplosion(Exception):
+        pass
+
+    mock_dd = Mock(spec=DataDesigner)
+    mock_dd.preview.side_effect = PreviewExplosion("endpoint unreachable")
+
+    adapter = NddAdapter(data_designer=mock_dd)
+    input_df = pd.DataFrame({"text": ["row-1", "row-2", "row-3"]})
+
+    with pytest.raises(PreviewExplosion):
+        adapter.run_workflow(
+            input_df,
+            model_configs=[_make_model_config()],
+            columns=_make_columns(),
+            workflow_name="detect-workflow",
+            preview_num_records=3,
+        )
+
+    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="preview failed")
+    assert len(warning_records) == 1
+    warning_msg = warning_records[0].getMessage()
+    assert "3" in warning_msg
+    assert "test-model-alias" in warning_msg
+    assert "PreviewExplosion" in warning_msg
+    assert "detect-workflow" not in warning_msg
+    _assert_no_backend_reference(warning_msg)
+
+    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="preview failure context")
+    assert len(debug_records) == 1
+    debug_msg = debug_records[0].getMessage()
+    assert "detect-workflow" in debug_msg
+    assert "output" in debug_msg
+    _assert_no_backend_reference(debug_msg)
+
+
+def test_create_exception_warns_with_count_model_and_type_and_debug_carries_workflow(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
+
+    class CreateExplosion(Exception):
+        pass
+
+    mock_dd = Mock(spec=DataDesigner)
+    mock_dd.create.side_effect = CreateExplosion("quota exceeded")
+
+    adapter = NddAdapter(data_designer=mock_dd)
+    input_df = pd.DataFrame({"text": ["row-1", "row-2"]})
+
+    with pytest.raises(CreateExplosion):
+        adapter.run_workflow(
+            input_df,
+            model_configs=[_make_model_config()],
+            columns=_make_columns(),
+            workflow_name="replace-workflow",
+            preview_num_records=None,
+        )
+
+    warning_records = _unique_records(caplog, level=logging.WARNING, message_contains="execution failed")
+    assert len(warning_records) == 1
+    warning_msg = warning_records[0].getMessage()
+    assert "2" in warning_msg
+    assert "test-model-alias" in warning_msg
+    assert "CreateExplosion" in warning_msg
+    assert "replace-workflow" not in warning_msg
+    _assert_no_backend_reference(warning_msg)
+
+    debug_records = _unique_records(caplog, level=logging.DEBUG, message_contains="execution failure context")
+    assert len(debug_records) == 1
+    debug_msg = debug_records[0].getMessage()
+    assert "replace-workflow" in debug_msg
+    assert "output" in debug_msg
+    _assert_no_backend_reference(debug_msg)
+
+
+def test_detect_missing_records_short_circuit_warns_when_input_missing_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    adapter = NddAdapter(data_designer=Mock(spec=DataDesigner))
+    caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
+    caplog.clear()
+
+    input_df = pd.DataFrame({"text": ["a", "b", "c"], "label": [1, 2, 3]})
+    output_df = pd.DataFrame({"text": ["a", "b", "c"]})
+
+    result = adapter._detect_missing_records(
+        workflow_name="detect-workflow",
+        input_df=input_df,
+        output_df=output_df,
+    )
+
+    assert result == []
+
+    warning_records = _unique_records(caplog, level=logging.WARNING)
+    assert len(warning_records) == 1
+    warning_msg = warning_records[0].getMessage()
+    assert "3" in warning_msg
+    assert "detection skipped" in warning_msg
+    assert "invariant violation" in warning_msg
+    _assert_no_backend_reference(warning_msg)
+
+    debug_records = _unique_records(caplog, level=logging.DEBUG)
+    assert len(debug_records) == 1
+    debug_msg = debug_records[0].getMessage()
+    assert "detect-workflow" in debug_msg
+    assert RECORD_ID_COLUMN in debug_msg
+    assert "text" in debug_msg
+    assert "label" in debug_msg
+    _assert_no_backend_reference(debug_msg)
+
+
+def test_detect_missing_records_short_circuit_warns_when_output_missing_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    adapter = NddAdapter(data_designer=Mock(spec=DataDesigner))
+    caplog.set_level(logging.DEBUG, logger="anonymizer.ndd")
+    caplog.clear()
+
+    input_df = pd.DataFrame(
+        {
+            RECORD_ID_COLUMN: ["id-1", "id-2", "id-3"],
+            "text": ["a", "b", "c"],
+            "label": [1, 2, 3],
+        }
+    )
+    output_df = pd.DataFrame(
+        {
+            "text": ["a", "b", "c"],
+            "rewrite": ["A", "B", "C"],
+        }
+    )
+
+    result = adapter._detect_missing_records(
+        workflow_name="rewrite-workflow",
+        input_df=input_df,
+        output_df=output_df,
+    )
+
+    assert len(result) == 3
+    for record in result:
+        assert record.step == "rewrite-workflow"
+        assert RECORD_ID_COLUMN in record.reason
+    assert {r.record_id for r in result} == {"id-1", "id-2", "id-3"}
+
+    warning_records = _unique_records(caplog, level=logging.WARNING)
+    assert len(warning_records) == 1
+    warning_msg = warning_records[0].getMessage()
+    assert "3" in warning_msg
+    assert "detection disabled" in warning_msg
+    assert "'label'" in warning_msg
+    assert "'rewrite'" in warning_msg
+    assert RECORD_ID_COLUMN not in warning_msg
+    _assert_no_backend_reference(warning_msg)
+
+    debug_records = _unique_records(caplog, level=logging.DEBUG)
+    assert len(debug_records) == 1
+    debug_msg = debug_records[0].getMessage()
+    assert "rewrite-workflow" in debug_msg
+    assert RECORD_ID_COLUMN in debug_msg
+    assert "'text'" in debug_msg
+    assert "'label'" in debug_msg
+    assert "'rewrite'" in debug_msg
+    _assert_no_backend_reference(debug_msg)


### PR DESCRIPTION
## Summary

Surface previously silent failure modes in `NddAdapter` via structured logs, and introduce a typed error wrapper so callers don't depend on backend exception types.

### Changes
- **`src/anonymizer/engine/ndd/adapter.py`**
  - Wrap `create()` / `load_dataset()` / `preview()` in a `try/except` that logs a `WARNING` (row count, model aliases, exception) + `DEBUG` (workflow name, columns) and re-raises as `AnonymizerWorkflowError` with `__cause__` preserved.
  - Add `WARNING` + `DEBUG` logs for the two silent short-circuits in `_detect_missing_records` (input missing tracking column, output missing tracking column, with a column-diff breadcrumb).
- **`src/anonymizer/interface/errors.py`**
  - New `AnonymizerWorkflowError` for wrapping workflow-step failures.
- **`tests/engine/test_ndd_adapter.py`**
  - Five new tests covering the three exception-wrap paths and the two detection short-circuit warnings, plus an assertion that log messages don't leak backend product names.

## Type of Change
- [x] Bug fix

## Testing
- [x] `make test` passes locally
- [x] `make check` passes locally

## Related Issues
Plan for this issue created in draft PR #128 => some parts partially changed
Closes #110