### PR TITLE
feat: re-export ModelProvider from anonymizer public API

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -31,60 +31,58 @@ Each pipeline stage has a **role** mapped to one of these aliases. See the full 
 
 ## Custom providers
 
-To use models from a different provider (OpenAI, OpenRouter, etc.), configure one or more providers when constructing the `Anonymizer`. Each provider maps a `name` to an API endpoint; the name is later referenced from your model configs.
+Use `model_providers` to define named API endpoints for hosted models such as OpenAI or OpenRouter.
 
-Providers can be defined either in a YAML file or programmatically in Python — both forms accept the same fields and are equivalent.
-
-Set your provider API keys as environment variables first:
+Set your API keys first:
 
 ```bash
 export OPENAI_API_KEY="your-openai-api-key"
 export OPENROUTER_API_KEY="your-openrouter-api-key"
 ```
 
-### YAML file
+=== "YAML"
 
-Define the providers in a YAML file and pass the path. API keys are read from the environment by the underlying client, so they don't need to appear in the file.
+    Define providers in a YAML file and pass the path to `Anonymizer`.
 
-```yaml
-# my_providers.yaml
-providers:
-  - name: openai
-    endpoint: https://api.openai.com/v1
-  - name: openrouter
-    endpoint: https://openrouter.ai/api/v1
-```
+    ```yaml
+    providers:
+      - name: openai
+        endpoint: https://api.openai.com/v1
+      - name: openrouter
+        endpoint: https://openrouter.ai/api/v1
+    ```
 
-```python
-from anonymizer import Anonymizer
+    ```python
+    from anonymizer import Anonymizer
 
-anonymizer = Anonymizer(model_providers="my_providers.yaml")
-```
+    anonymizer = Anonymizer(model_providers="my_providers.yaml")
+    ```
 
-### Programmatic
+=== "Python"
 
-Build a list of `ModelProvider` instances in code. Useful when you want your setup to be self-contained, or need to pull secrets from a vault rather than the environment.
+    Construct `ModelProvider` objects directly in code.
 
-```python
-import os
+    ```python
+    import os
+    from anonymizer import Anonymizer, ModelProvider
 
-from anonymizer import Anonymizer, ModelProvider
+    providers = [
+        ModelProvider(
+            name="openai",
+            endpoint="https://api.openai.com/v1",
+            api_key=os.environ["OPENAI_API_KEY"],
+        ),
+        ModelProvider(
+            name="openrouter",
+            endpoint="https://openrouter.ai/api/v1",
+            api_key=os.environ["OPENROUTER_API_KEY"],
+        ),
+    ]
 
-providers = [
-    ModelProvider(
-        name="openai",
-        endpoint="https://api.openai.com/v1",
-        api_key=os.environ["OPENAI_API_KEY"],
-    ),
-    ModelProvider(
-        name="openrouter",
-        endpoint="https://openrouter.ai/api/v1",
-        api_key=os.environ["OPENROUTER_API_KEY"],
-    ),
-]
+    anonymizer = Anonymizer(model_providers=providers)
+    ```
 
-anonymizer = Anonymizer(model_providers=providers)
-```
+After defining providers, reference them from your model configs as described below.
 
 ---
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -31,28 +31,59 @@ Each pipeline stage has a **role** mapped to one of these aliases. See the full 
 
 ## Custom providers
 
-To use models from a different provider (OpenAI, OpenRouter, etc.), define a providers YAML:
+To use models from a different provider (OpenAI, OpenRouter, etc.), configure one or more providers when constructing the `Anonymizer`. Each provider maps a `name` to an API endpoint; the name is later referenced from your model configs.
 
-```yaml
-# my_providers.yaml
-providers:
-  - name: openai
-    base_url: https://api.openai.com/v1
-    api_key_env_var: OPENAI_API_KEY
-  - name: openrouter
-    base_url: https://openrouter.ai/api/v1
-    api_key_env_var: OPENROUTER_API_KEY
-```
+Providers can be defined either in a YAML file or programmatically in Python — both forms accept the same fields and are equivalent.
 
-Make sure the environment variables are set:
+Set your provider API keys as environment variables first:
 
 ```bash
 export OPENAI_API_KEY="your-openai-api-key"
 export OPENROUTER_API_KEY="your-openrouter-api-key"
 ```
 
+### YAML file
+
+Define the providers in a YAML file and pass the path. API keys are read from the environment by the underlying client, so they don't need to appear in the file.
+
+```yaml
+# my_providers.yaml
+providers:
+  - name: openai
+    endpoint: https://api.openai.com/v1
+  - name: openrouter
+    endpoint: https://openrouter.ai/api/v1
+```
+
 ```python
+from anonymizer import Anonymizer
+
 anonymizer = Anonymizer(model_providers="my_providers.yaml")
+```
+
+### Programmatic
+
+Build a list of `ModelProvider` instances in code. Useful when you want your setup to be self-contained, or need to pull secrets from a vault rather than the environment.
+
+```python
+import os
+
+from anonymizer import Anonymizer, ModelProvider
+
+providers = [
+    ModelProvider(
+        name="openai",
+        endpoint="https://api.openai.com/v1",
+        api_key=os.environ["OPENAI_API_KEY"],
+    ),
+    ModelProvider(
+        name="openrouter",
+        endpoint="https://openrouter.ai/api/v1",
+        api_key=os.environ["OPENROUTER_API_KEY"],
+    ),
+]
+
+anonymizer = Anonymizer(model_providers=providers)
 ```
 
 ---
@@ -96,7 +127,7 @@ model_configs:
 ```python
 anonymizer = Anonymizer(
     model_configs="my_models.yaml",
-    model_providers="my_providers.yaml",
+    model_providers="providers",  # or my_providers.yaml
 )
 ```
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -36,8 +36,10 @@ Use `model_providers` to define named API endpoints for hosted models such as Op
 Set your API keys first:
 
 ```bash
+export NVIDIA_API_KEY="your-nvidia-api-key"  # Used by the nvidia provider (build.nvidia.com)
 export OPENAI_API_KEY="your-openai-api-key"
 export OPENROUTER_API_KEY="your-openrouter-api-key"
+
 ```
 
 === "YAML"
@@ -46,6 +48,8 @@ export OPENROUTER_API_KEY="your-openrouter-api-key"
 
     ```yaml
     providers:
+      - name: nvidia
+        endpoint: https://integrate.api.nvidia.com/v1
       - name: openai
         endpoint: https://api.openai.com/v1
       - name: openrouter
@@ -88,7 +92,7 @@ After defining providers, reference them from your model configs as described be
 
 ## Custom models
 
-Override specific roles by passing a unified YAML path to `Anonymizer(model_configs=...)`. The `provider` field references a provider by name -- use `nvidia` for build.nvidia.com, or a custom provider defined above.
+Override specific roles by passing a unified YAML path to `Anonymizer(model_configs=...)`. The `provider` field references a provider by name from the custom providers defined above.
 
 ```yaml
 # my_models.yaml

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -127,7 +127,7 @@ model_configs:
 ```python
 anonymizer = Anonymizer(
     model_configs="my_models.yaml",
-    model_providers="providers",  # or my_providers.yaml
+    model_providers=providers,  # or "my_providers.yaml"
 )
 ```
 

--- a/src/anonymizer/__init__.py
+++ b/src/anonymizer/__init__.py
@@ -7,6 +7,9 @@ from importlib.metadata import version
 
 __version__ = version("nemo-anonymizer")
 
+# Re-exports from Data Designer so users don't import it directly.
+from data_designer.config.models import ModelProvider as ModelProvider
+
 from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Detect, Rewrite, RiskTolerance
 from anonymizer.config.replace_strategies import Annotate, Hash, Redact, Substitute
 from anonymizer.engine.constants import DEFAULT_ENTITY_LABELS as _DEFAULT_ENTITY_LABELS
@@ -36,6 +39,7 @@ __all__ = [
     "InvalidConfigError",
     "InvalidInputError",
     "LoggingConfig",
+    "ModelProvider",
     "Redact",
     "Rewrite",
     "RiskTolerance",

--- a/src/anonymizer/__init__.py
+++ b/src/anonymizer/__init__.py
@@ -7,7 +7,6 @@ from importlib.metadata import version
 
 __version__ = version("nemo-anonymizer")
 
-# Re-exports from Data Designer so users don't import it directly.
 from data_designer.config.models import ModelProvider as ModelProvider
 
 from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Detect, Rewrite, RiskTolerance

--- a/tests/interface/cli/test_cli_model_configs.py
+++ b/tests/interface/cli/test_cli_model_configs.py
@@ -211,7 +211,7 @@ def test_model_providers_none_returns_none() -> None:
 
 def test_model_providers_list_passthrough() -> None:
     """A pre-built list of ModelProvider objects is returned as-is."""
-    from data_designer.config.models import ModelProvider
+    from anonymizer import ModelProvider
 
     providers = [ModelProvider(name="my-provider", endpoint="https://example.com/v1")]
     result = _resolve_model_providers(providers)


### PR DESCRIPTION
## Summary
- Re-export `ModelProvider` from the top-level `anonymizer` package so users no longer need to import `data_designer` internals when configuring providers programmatically.
- Users can now keep all public-API imports on a single line:
  ```python
  from anonymizer import (
      Anonymizer,
      AnonymizerConfig,
      AnonymizerInput,
      ModelProvider,
      Redact,
      Substitute,
      configure_logging,
  )
  ```
- Also fixes a pre-existing docs bug where the YAML provider example used fields that don't exist on the `ModelProvider` pydantic model.
## Changes
- **`src/anonymizer/__init__.py`**
  - Added `from data_designer.config.models import ModelProvider as ModelProvider` (explicit `as` alias so strict type checkers treat it as an intentional public re-export).
  - Added `"ModelProvider"` to `__all__`.
- **`docs/concepts/models.md`**
  - Rewrote the *Custom providers* section with two subsections — *YAML file* and *Programmatic* — sharing a single env-var setup block.
  - Fixed the YAML example: replaced invalid `base_url` / `api_key_env_var` with the real fields `name` / `endpoint`, matching the `ModelProvider` schema and the tested code path (`_resolve_model_providers`).
  - Added a programmatic example using `from anonymizer import Anonymizer, ModelProvider`.
  - Updated the *Custom models* example so the `model_providers` kwarg comment references the `providers` variable from the section above.
- **`tests/interface/cli/test_cli_model_configs.py`**
  - Updated `test_model_providers_list_passthrough` to import `ModelProvider` from `anonymizer` instead of `data_designer.config.models`, covering the new public re-export.


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->
