### PR TITLE
fix(docs): publish release docs from release workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Deploy docs with mike
         if: github.event_name == 'push'
-        run: uv run --group docs mike deploy --push --update-aliases dev latest
+        run: uv run --group docs mike deploy --push --update-aliases dev
 
   deploy-release:
     if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,3 +132,38 @@ jobs:
             --generate-notes \
             --title "v${VERSION}" \
             $PRERELEASE_FLAG
+
+  deploy-release-docs:
+    name: Deploy release docs
+    needs: [publish-wheel, create-gh-release]
+    if: ${{ inputs.create-gh-release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout at release ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release-ref }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python-env
+        with:
+          ref: ${{ inputs.release-ref }}
+          fetch-depth: "0"
+
+      - name: Install docs dependencies
+        run: uv sync --group dev --group docs
+
+      - name: Configure git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build docs
+        run: make docs-build
+
+      - name: Deploy release docs with mike
+        env:
+          VERSION: ${{ needs.publish-wheel.outputs.version }}
+        run: uv run --group docs mike deploy --push --update-aliases "$VERSION" latest


### PR DESCRIPTION
## Summary
- Keep `latest` pointed at the newest released docs instead of `dev`
- Deploy release docs from the release workflow so Actions-created releases publish versioned docs reliably

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Testing
- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [x] If docs changed: `make docs-build` passes locally