### PR TITLE
refactor(display): consume structured rewrite columns in native shape

### DIFF
--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -402,7 +402,7 @@ def _render_scores_section(row: pd.Series) -> str:
 
     judge_raw = row.get(COL_JUDGE_EVALUATION)
     judge_scores = _extract_judge_scores(judge_raw)
-    if judge_raw is not None and not pd.isna(judge_raw) and not judge_scores:
+    if isinstance(judge_raw, dict) and not judge_scores:
         logger.warning(
             "Judge evaluation present but produced no scores (unexpected shape: %s)", type(judge_raw).__name__
         )

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -9,8 +9,6 @@ import logging
 import re
 from dataclasses import dataclass
 
-logger = logging.getLogger(__name__)
-
 import pandas as pd
 
 from anonymizer.engine.constants import (
@@ -21,6 +19,8 @@ from anonymizer.engine.constants import (
     COL_SENSITIVITY_DISPOSITION,
 )
 from anonymizer.engine.schemas import EntitiesSchema, EntitySchema
+
+logger = logging.getLogger(__name__)
 
 ENTITY_COLORS: list[str] = [
     "#dbeafe",  # blue
@@ -402,7 +402,7 @@ def _render_scores_section(row: pd.Series) -> str:
 
     judge_raw = row.get(COL_JUDGE_EVALUATION)
     judge_scores = _extract_judge_scores(judge_raw)
-    if judge_raw is not None and not judge_scores:
+    if judge_raw is not None and not pd.isna(judge_raw) and not judge_scores:
         logger.warning(
             "Judge evaluation present but produced no scores (unexpected shape: %s)", type(judge_raw).__name__
         )

--- a/src/anonymizer/interface/display.py
+++ b/src/anonymizer/interface/display.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 import html
 import json
+import logging
 import re
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 import pandas as pd
 
@@ -381,13 +384,13 @@ def _render_scores_section(row: pd.Series) -> str:
     needs_review = row.get("needs_human_review")
 
     if utility is not None:
-        parts.append(f"<span style='margin-right:16px'><strong>Utility:</strong> {float(utility):.2f}</span>")
+        parts.append(f"<span style='margin-right:16px'><strong>Utility:</strong> {utility:.2f}</span>")
     if leakage is not None:
-        parts.append(f"<span style='margin-right:16px'><strong>Leakage:</strong> {float(leakage):.2f}</span>")
+        parts.append(f"<span style='margin-right:16px'><strong>Leakage:</strong> {leakage:.2f}</span>")
     if weighted_leakage_rate is not None:
         parts.append(
             "<span style='margin-right:16px'><strong>Weighted Leakage Rate:</strong> "
-            f"{float(weighted_leakage_rate):.2f}</span>"
+            f"{weighted_leakage_rate:.2f}</span>"
         )
     if needs_review is not None:
         badge_color = "#ef4444" if needs_review else "#22c55e"
@@ -399,6 +402,10 @@ def _render_scores_section(row: pd.Series) -> str:
 
     judge_raw = row.get(COL_JUDGE_EVALUATION)
     judge_scores = _extract_judge_scores(judge_raw)
+    if judge_raw is not None and not judge_scores:
+        logger.warning(
+            "Judge evaluation present but produced no scores (unexpected shape: %s)", type(judge_raw).__name__
+        )
     if judge_scores:
         score_strs = [f"{name}: {score}/10" for name, score in judge_scores]
         parts.append(f"<span><strong>Judge:</strong> {html.escape(', '.join(score_strs))}</span>")
@@ -411,18 +418,9 @@ def _render_scores_section(row: pd.Series) -> str:
 def _extract_judge_scores(raw: object) -> list[tuple[str, int]]:
     """Extract (name, score) pairs from the judge evaluation column.
 
-    LLMJudgeColumnConfig output is keyed by rubric name, each value carrying
-    ``{"score": <enum_value>, "reasoning": "..."}``.
+    LLMJudgeColumnConfig output is a plain dict keyed by rubric name, each
+    value carrying ``{"score": <int>, "reasoning": "..."}``.
     """
-    if raw is None:
-        return []
-    if hasattr(raw, "model_dump"):
-        raw = raw.model_dump()
-    if isinstance(raw, str):
-        try:
-            raw = json.loads(raw)
-        except (json.JSONDecodeError, ValueError):
-            return []
     if not isinstance(raw, dict):
         return []
     result: list[tuple[str, int]] = []
@@ -473,21 +471,17 @@ def _render_disposition_table(row: pd.Series) -> str:
 
 
 def _normalize_disposition(raw: object) -> list[dict[str, str]]:
-    """Extract disposition entries from the raw column value."""
-    if raw is None:
+    """Extract disposition entries from the raw column value.
+
+    LLMStructuredColumnConfig output lands as a plain dict keyed by
+    ``sensitivity_disposition``, each entry being an EntityDispositionSchema dict.
+    """
+    if not isinstance(raw, dict):
         return []
-    if hasattr(raw, "model_dump"):
-        raw = raw.model_dump()
-    if isinstance(raw, str):
-        try:
-            raw = json.loads(raw)
-        except (json.JSONDecodeError, ValueError):
-            return []
-    if isinstance(raw, dict):
-        entries = raw.get("sensitivity_disposition", [])
-        if isinstance(entries, list):
-            return [e if isinstance(e, dict) else getattr(e, "model_dump", dict)() for e in entries]
-    return []
+    entries = raw.get("sensitivity_disposition", [])
+    if not isinstance(entries, list):
+        return []
+    return [e for e in entries if isinstance(e, dict)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -7,8 +7,15 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from anonymizer.engine.constants import COL_DETECTED_ENTITIES, COL_FINAL_ENTITIES, COL_REPLACEMENT_MAP
+from anonymizer.engine.constants import (
+    COL_DETECTED_ENTITIES,
+    COL_FINAL_ENTITIES,
+    COL_REPLACEMENT_MAP,
+    COL_SENSITIVITY_DISPOSITION,
+)
+from anonymizer.engine.rewrite.final_judge import NATURALNESS_RUBRIC, PRIVACY_RUBRIC, QUALITY_RUBRIC
 from anonymizer.engine.schemas import EntitiesSchema, EntitySchema
+from anonymizer.engine.schemas.rewrite import EntityDispositionSchema, SensitivityDispositionSchema
 from anonymizer.interface.display import (
     _build_replaced_entities,
     _normalize_replacement_map,
@@ -486,6 +493,12 @@ def test_render_record_html_rewrite_mode_shows_rewrite_layout() -> None:
 
 
 def test_render_record_html_rewrite_mode_with_judge_scores() -> None:
+    # Derive keys from the actual rubric configs so test↔runtime drift is impossible.
+    judge_eval = {
+        PRIVACY_RUBRIC.name: {"score": 8, "reasoning": "good privacy"},
+        QUALITY_RUBRIC.name: {"score": 9, "reasoning": "high quality"},
+        NATURALNESS_RUBRIC.name: {"score": 7, "reasoning": "mostly natural"},
+    }
     row = pd.Series(
         {
             "text": "Alice works at Acme",
@@ -494,20 +507,34 @@ def test_render_record_html_rewrite_mode_with_judge_scores() -> None:
             "utility_score": 0.9,
             "leakage_mass": 0.1,
             "needs_human_review": False,
-            "_judge_evaluation": {
-                "privacy": {"score": 8, "reasoning": "good privacy"},
-                "quality": {"score": 9, "reasoning": "high quality"},
-                "naturalness": {"score": 7, "reasoning": "mostly natural"},
-            },
+            "_judge_evaluation": judge_eval,
         }
     )
     result = render_record_html(row, record_index=0)
-    assert "privacy: 8/10" in result
-    assert "quality: 9/10" in result
-    assert "naturalness: 7/10" in result
+    assert f"{PRIVACY_RUBRIC.name}: 8/10" in result
+    assert f"{QUALITY_RUBRIC.name}: 9/10" in result
+    assert f"{NATURALNESS_RUBRIC.name}: 7/10" in result
 
 
 def test_render_record_html_rewrite_mode_with_disposition() -> None:
+    # Construct the fixture via model_dump() so it matches the exact dict shape
+    # that LLMStructuredColumnConfig writes to the dataframe at runtime.
+    disposition = SensitivityDispositionSchema(
+        sensitivity_disposition=[
+            EntityDispositionSchema(
+                id=1,
+                source="tagged",
+                category="direct_identifier",
+                sensitivity="high",
+                entity_label="first_name",
+                entity_value="Alice",
+                needs_protection=True,
+                protection_reason="Direct identifier that uniquely identifies the subject.",
+                protection_method_suggestion="replace",
+                combined_risk_level="high",
+            ),
+        ]
+    ).model_dump()
     row = pd.Series(
         {
             "text": "Alice works at Acme",
@@ -516,16 +543,7 @@ def test_render_record_html_rewrite_mode_with_disposition() -> None:
             "utility_score": 0.85,
             "leakage_mass": 0.3,
             "needs_human_review": False,
-            "_sensitivity_disposition": {
-                "sensitivity_disposition": [
-                    {
-                        "entity_value": "Alice",
-                        "entity_label": "first_name",
-                        "sensitivity": "high",
-                        "protection_method_suggestion": "replace",
-                    },
-                ]
-            },
+            COL_SENSITIVITY_DISPOSITION: disposition,
         }
     )
     result = render_record_html(row, record_index=0)

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -514,6 +516,49 @@ def test_render_record_html_rewrite_mode_with_judge_scores() -> None:
     assert f"{PRIVACY_RUBRIC.name}: 8/10" in result
     assert f"{QUALITY_RUBRIC.name}: 9/10" in result
     assert f"{NATURALNESS_RUBRIC.name}: 7/10" in result
+
+
+def test_render_record_html_rewrite_mode_nan_judge_column_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the judge column exists but a row's value is NaN (typical pandas
+    missing-value sentinel for object columns), the renderer must not emit
+    the 'unexpected shape' warning - that's a normal not-yet-judged row."""
+    row = pd.Series(
+        {
+            "text": "Alice works at Acme",
+            "text_rewritten": "Beth works at Globex",
+            COL_DETECTED_ENTITIES: {"entities": []},
+            "utility_score": 0.9,
+            "leakage_mass": 0.1,
+            "needs_human_review": False,
+            "_judge_evaluation": np.nan,
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="anonymizer.interface.display"):
+        render_record_html(row, record_index=0)
+    assert not any("Judge evaluation present but produced no scores" in rec.message for rec in caplog.records)
+
+
+def test_render_record_html_rewrite_mode_malformed_judge_dict_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A judge column whose value is a dict that yields no extractable scores
+    is a real upstream-shape regression and SHOULD emit the warning."""
+    row = pd.Series(
+        {
+            "text": "Alice works at Acme",
+            "text_rewritten": "Beth works at Globex",
+            COL_DETECTED_ENTITIES: {"entities": []},
+            "utility_score": 0.9,
+            "leakage_mass": 0.1,
+            "needs_human_review": False,
+            "_judge_evaluation": {"unexpected_key": "no score field here"},
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="anonymizer.interface.display"):
+        render_record_html(row, record_index=0)
+    assert any("Judge evaluation present but produced no scores" in rec.message for rec in caplog.records)
 
 
 def test_render_record_html_rewrite_mode_with_disposition() -> None:

--- a/tests/interface/test_display.py
+++ b/tests/interface/test_display.py
@@ -12,6 +12,7 @@ import pytest
 from anonymizer.engine.constants import (
     COL_DETECTED_ENTITIES,
     COL_FINAL_ENTITIES,
+    COL_JUDGE_EVALUATION,
     COL_REPLACEMENT_MAP,
     COL_SENSITIVITY_DISPOSITION,
 )
@@ -509,7 +510,7 @@ def test_render_record_html_rewrite_mode_with_judge_scores() -> None:
             "utility_score": 0.9,
             "leakage_mass": 0.1,
             "needs_human_review": False,
-            "_judge_evaluation": judge_eval,
+            COL_JUDGE_EVALUATION: judge_eval,
         }
     )
     result = render_record_html(row, record_index=0)
@@ -532,7 +533,7 @@ def test_render_record_html_rewrite_mode_nan_judge_column_does_not_warn(
             "utility_score": 0.9,
             "leakage_mass": 0.1,
             "needs_human_review": False,
-            "_judge_evaluation": np.nan,
+            COL_JUDGE_EVALUATION: np.nan,
         }
     )
     with caplog.at_level(logging.WARNING, logger="anonymizer.interface.display"):
@@ -553,7 +554,7 @@ def test_render_record_html_rewrite_mode_malformed_judge_dict_warns(
             "utility_score": 0.9,
             "leakage_mass": 0.1,
             "needs_human_review": False,
-            "_judge_evaluation": {"unexpected_key": "no score field here"},
+            COL_JUDGE_EVALUATION: {"unexpected_key": "no score field here"},
         }
     )
     with caplog.at_level(logging.WARNING, logger="anonymizer.interface.display"):


### PR DESCRIPTION
## Summary
# Maintain native shape for structured rewrite columns

## Motivation

The rewrite pipeline (`LLMJudgeColumnConfig`, `LLMStructuredColumnConfig`) already writes plain Python dicts into the dataframe via pydantic `model_dump()`. The display layer was defensively re-normalizing these columns from three possible shapes — `None`, pydantic model, or JSON string — which masked upstream bugs and duplicated work.

This PR removes the defensive coercion and trusts the native dict shape throughout the display path.

## Changes

### `src/anonymizer/interface/display.py`

- Removed speculative type-coercion from `_extract_judge_scores`: no more `None` short-circuit, `model_dump()` fallback, or `json.loads` attempt. The function now expects a plain `dict` and returns `[]` otherwise.
- Removed the same coercion ladder from `_normalize_disposition`; it now expects a plain dict with `"sensitivity_disposition"` as a list, filtering entries via `isinstance(e, dict)` instead of calling `getattr(e, "model_dump", dict)()`.
- Dropped redundant `float(...)` wrappers around `utility`, `leakage`, and `weighted_leakage_rate` in `_render_scores_section` — values are already numeric at this stage.
- Added a module-level logger and a warning when `COL_JUDGE_EVALUATION` is present but yields no scores, so unexpected shapes surface instead of silently rendering nothing.
- Updated docstrings on `_extract_judge_scores` and `_normalize_disposition` to document the expected native dict shape.

### `tests/interface/test_display.py`

- Judge-scores test now derives rubric keys from the real `PRIVACY_RUBRIC`, `QUALITY_RUBRIC`, and `NATURALNESS_RUBRIC` configs (imported from `final_judge`) instead of hardcoded strings, preventing test-vs-runtime drift if a rubric is renamed.
- Disposition test fixture is now built via `SensitivityDispositionSchema(...).model_dump()` with a full `EntityDispositionSchema`, matching the exact dict that `LLMStructuredColumnConfig` writes at runtime. Replaces the hand-rolled partial dict.
- Disposition test uses the `COL_SENSITIVITY_DISPOSITION` constant instead of a hardcoded `"_sensitivity_disposition"` key.
- Added imports for `COL_SENSITIVITY_DISPOSITION`, the three rubric configs, and the two rewrite schemas.

## Net effect

- `display.py`: −24 / +18 lines (simpler, one observability signal added).
- `test_display.py`: +35 / −21 lines (fixtures pinned to real schemas/constants).

## Test plan

- [ ] `pytest tests/interface/test_display.py` passes locally.
- [ ] Existing e2e rewrite flow renders judge scores and disposition table correctly.
- [ ] Warning log fires when an unexpected judge-evaluation shape reaches the renderer.

## Testing
- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
Closes #70 
