### PR TITLE
docs: add AGENTS.md, STYLEGUIDE.md, agent-assisted contribution (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ CLAUDE.local.md
 .claude/settings.local.json
 ai/tmp/
 
+# Claude worktrees
+.claude/worktrees/
+
 # Anonymizer execution artifacts
 .anonymizer-artifacts/
 docs/notebook_source/data/synth_bios_sample10_anonymized.csv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ If you are an agent helping a user **anonymize data**, use the [product document
 
 **NeMo Anonymizer** detects and protects PII through context-aware entity replacement and LLM-powered rewriting. Users supply a text dataset and a strategy; Anonymizer detects entities and transforms the text.
 
+## Agent compatibility
+
+`AGENTS.md` is the canonical instruction file for coding agents working in this repository. Keep it tool-neutral:
+
+- Use plain Markdown and repository-relative links.
+- Do not rely on vendor-specific include syntax, slash commands, MCP names, or IDE-only behavior.
+- Put tool-specific adapter instructions in thin wrapper files such as `CLAUDE.md`.
+
 ## Module Map
 
 `nemo-anonymizer` is a single package with three primary subpackages plus top-level public utilities:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md
+
+This file is for agents **developing** NeMo Anonymizer — the codebase you are working in.
+If you are an agent helping a user **anonymize data**, use the [product documentation](https://nvidia-nemo.github.io/Anonymizer/) instead.
+
+**NeMo Anonymizer** detects and protects PII through context-aware entity replacement and LLM-powered rewriting. Users supply a text dataset and a strategy; Anonymizer detects entities and transforms the text.
+
+## Module Map
+
+`nemo-anonymizer` is a single package with three modules:
+
+- **`anonymizer.config`** — user-facing configuration: `AnonymizerConfig`, `AnonymizerInput`, replace strategies (`Substitute`, `Redact`, `Annotate`, `Hash`), and rewrite config (`Rewrite`, `EvaluationCriteria`, `RiskTolerance`). New user-facing knobs go here.
+- **`anonymizer.engine`** — internal pipeline implementation: detection, replacement, and rewrite sub-workflows, the NDD adapter, prompt utilities, and all `COL_*` column constants. Never imported directly by users.
+- **`anonymizer.interface`** — user-facing entry points: the `Anonymizer` class, CLI, `AnonymizerResult`, `PreviewResult`, and canonical error types. Thin layer that wires config → engine and exposes results.
+
+NeMo Anonymizer wraps [DataDesigner](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. `NddAdapter` is the only place this dependency crosses — engine sub-workflows declare NDD column configs and hand them to the adapter, which manages DataDesigner internally.
+
+## Core Concepts
+
+- **Entity** — a detected span of text with a label (e.g. `"Alice"` → `first_name`) and character offsets
+- **Latent entity** — an entity detected in rewrite mode that is sensitive but not directly named; used to guide rewriting without explicit replacement
+- **Replacement map** — a per-record dict mapping entity text → substitute value, built by `LlmReplaceWorkflow` and injected into rewrite prompts
+- **Leakage mass** — a weighted score measuring how much sensitive information survives in a rewritten record; drives the repair loop
+- **Utility score** — a 0–1 score measuring how much semantic content the rewritten record preserves
+- **RiskTolerance** — a preset (`minimal` / `low` / `moderate` / `high`) that bundles the leakage threshold, repair behaviour, and human-review flags into a single user-facing knob
+- **Repair loop** — the evaluate → repair → re-evaluate cycle in `RewriteWorkflow`; runs up to `max_repair_iterations` times on failing rows
+- **FailedRecord** — a record that was dropped by an NDD workflow; surfaced explicitly rather than silently lost
+
+## Pipelines
+
+### Replace mode — `AnonymizerConfig(replace=...)`
+
+```
+input_df
+  → EntityDetectionWorkflow.run()              # engine/detection/detection_workflow.py
+        GLiNER detection
+        → parse + tag
+        → LLM augmentation  (add entities GLiNER missed)
+        → LLM validation    (keep / drop candidates)
+        → merge + finalize  → COL_DETECTED_ENTITIES, COL_FINAL_ENTITIES
+  → ReplacementWorkflow.run()                  # engine/replace/replace_runner.py
+        Redact / Annotate / Hash  → applied locally, no LLM
+        Substitute                → LlmReplaceWorkflow → NddAdapter
+  → output: {text_col}_replaced, {text_col}_with_spans, final_entities
+```
+
+### Rewrite mode — `AnonymizerConfig(rewrite=...)`
+
+```
+input_df
+  → EntityDetectionWorkflow.run()              # same as above, plus latent entity tagging
+  → RewriteWorkflow.run()                      # engine/rewrite/rewrite_workflow.py
+        LlmReplaceWorkflow.generate_map_only() # build replacement map for prompt
+        → single NDD adapter call (pipeline_columns):
+              DomainClassificationWorkflow    → _domain, _domain_supplement
+              SensitivityDispositionWorkflow  → _sensitivity_disposition
+              QAGenerationWorkflow            → _quality_qa, _privacy_qa
+              RewriteGenerationWorkflow       → _rewritten_text
+        → evaluate-repair loop (up to max_repair_iterations):
+              EvaluateWorkflow                → leakage_mass, utility_score, _needs_repair
+              RepairWorkflow                  → _rewritten_text (failing rows only)
+        → FinalJudgeWorkflow (non-critical)   → _judge_evaluation, needs_human_review
+  → output: {text_col}_rewritten, utility_score, leakage_mass, needs_human_review, …
+```
+
+Records with no detected entities skip all LLM sub-workflows and pass through with default metrics (utility=1.0, leakage=0.0).
+
+## Config Pattern
+
+`AnonymizerConfig.rewrite` is the user-facing `Rewrite` model. The engine never receives `Rewrite` directly — it receives `EvaluationCriteria` via the `Rewrite.evaluation` property.
+
+`Rewrite` and `EvaluationCriteria` both hold `max_repair_iterations`. They must stay in sync:
+
+- `Rewrite.max_repair_iterations` is the user-facing field (default 3)
+- `Rewrite.evaluation` constructs `EvaluationCriteria(risk_tolerance=..., max_repair_iterations=self.max_repair_iterations)`
+- **Never construct `EvaluationCriteria` with hardcoded values** — always go through `Rewrite.evaluation`
+
+Leakage thresholds and repair parameters are derived from `RiskTolerance` via `_RiskToleranceBundle` in `config/rewrite.py`. Don't hardcode them elsewhere.
+
+## NDD Adapter
+
+`NddAdapter.run_workflow()` (`engine/ndd/adapter.py`) wraps a DataFrame slice + NDD column configs into a DataDesigner run and returns `WorkflowRunResult(dataframe, failed_records)`. Records missing from the output surface as `FailedRecord` objects rather than silently disappearing. Never access DataDesigner directly from engine workflows — always go through `NddAdapter`.
+
+## Prompt Conventions
+
+All column references in NDD prompt templates go through `_jinja()` (`engine/constants.py`) — never format column names directly into strings. Dynamic prompt values use `substitute_placeholders()` (`engine/prompt_utils.py`) with `<<PLACEHOLDER>>` markers; see its docstring for the substitution contract. Prompts are inline triple-quoted strings in the workflow file that uses them; there is no separate registry.
+
+## Structural Invariants
+
+- `from __future__ import annotations` in every Python file
+- Absolute imports only (enforced by ruff `TID`)
+- Type annotations on all functions, methods, and class attributes
+- SPDX license header on every file
+- All column names defined in `engine/constants.py` — never use string literals for column names
+- `COL_TEXT` is the internal name for the input text column; renamed to the user's original column name in final output
+
+## What NOT To Do
+
+- **Don't bypass `Rewrite.evaluation`** — don't construct `EvaluationCriteria` with hardcoded thresholds
+- **Don't call DataDesigner directly** — always go through `NddAdapter.run_workflow()`
+- **Don't use string literals for column names** — use `COL_*` constants from `engine/constants.py`
+- **Don't add a domain to only one supplement map** — see `engine/rewrite/domain_classification.py` for the sync invariant
+- **Don't hardcode `gliner_threshold`** — it belongs in `Detect` config (default 0.3)
+
+## Development
+
+```bash
+make test          # run all tests
+make bootstrap     # install dev dependencies
+make format        # ruff format + sort imports
+make format-check  # read-only lint check (used in CI)
+make typecheck     # ty type check (advisory)
+make docs-serve    # local MkDocs server at http://127.0.0.1:8000
+```
+
+For contributor workflow and branch naming see [CONTRIBUTING.md](CONTRIBUTING.md).
+For code style and naming conventions see [STYLEGUIDE.md](STYLEGUIDE.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,14 @@ If you are an agent helping a user **anonymize data**, use the [product document
 
 ## Module Map
 
-`nemo-anonymizer` is a single package with three modules:
+`nemo-anonymizer` is a single package with three primary subpackages plus top-level public utilities:
 
 - **`anonymizer.config`** — user-facing configuration: `AnonymizerConfig`, `AnonymizerInput`, replace strategies (`Substitute`, `Redact`, `Annotate`, `Hash`), and rewrite config (`Rewrite`, `EvaluationCriteria`, `RiskTolerance`). New user-facing knobs go here.
 - **`anonymizer.engine`** — internal pipeline implementation: detection, replacement, and rewrite sub-workflows, the NDD adapter, prompt utilities, and all `COL_*` column constants. Never imported directly by users.
 - **`anonymizer.interface`** — user-facing entry points: the `Anonymizer` class, CLI, `AnonymizerResult`, `PreviewResult`, and canonical error types. Thin layer that wires config → engine and exposes results.
+- **`anonymizer.logging`** — public logging configuration (`LoggingConfig`, `configure_logging`) used by the API, CLI, and examples.
 
-NeMo Anonymizer wraps [DataDesigner](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. `NddAdapter` is the only place this dependency crosses — engine sub-workflows declare NDD column configs and hand them to the adapter, which manages DataDesigner internally.
+NeMo Anonymizer wraps [DataDesigner](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. `NddAdapter.run_workflow()` is the engine boundary for *executing* DataDesigner workflows — engine sub-workflows may declare DataDesigner column configs (e.g. `LLMStructuredColumnConfig`), but they do not call `DataDesigner.create()` or `preview()` directly.
 
 ## Core Concepts
 
@@ -70,37 +71,26 @@ Records with no detected entities skip all LLM sub-workflows and pass through wi
 
 ## Config Pattern
 
-`AnonymizerConfig.rewrite` is the user-facing `Rewrite` model. The engine never receives `Rewrite` directly — it receives `EvaluationCriteria` via the `Rewrite.evaluation` property.
-
-`Rewrite` and `EvaluationCriteria` both hold `max_repair_iterations`. They must stay in sync:
-
-- `Rewrite.max_repair_iterations` is the user-facing field (default 3)
-- `Rewrite.evaluation` constructs `EvaluationCriteria(risk_tolerance=..., max_repair_iterations=self.max_repair_iterations)`
-- **Never construct `EvaluationCriteria` with hardcoded values** — always go through `Rewrite.evaluation`
-
-Leakage thresholds and repair parameters are derived from `RiskTolerance` via `_RiskToleranceBundle` in `config/rewrite.py`. Don't hardcode them elsewhere.
+`AnonymizerConfig.rewrite` is the user-facing `Rewrite` model. The engine never receives `Rewrite` directly — it receives `EvaluationCriteria` via the `Rewrite.evaluation` property. See that property's docstring for the sync contract (how `risk_tolerance` and `max_repair_iterations` flow into the engine, why production code should not duplicate the mapping).
 
 ## NDD Adapter
 
-`NddAdapter.run_workflow()` (`engine/ndd/adapter.py`) wraps a DataFrame slice + NDD column configs into a DataDesigner run and returns `WorkflowRunResult(dataframe, failed_records)`. Records missing from the output surface as `FailedRecord` objects rather than silently disappearing. Never access DataDesigner directly from engine workflows — always go through `NddAdapter`.
+`NddAdapter.run_workflow()` (`engine/ndd/adapter.py`) is the engine boundary for *executing* DataDesigner workflows. See its docstring for the contract (input/output shapes, `FailedRecord` semantics).
 
 ## Prompt Conventions
 
-All column references in NDD prompt templates go through `_jinja()` (`engine/constants.py`) — never format column names directly into strings. Dynamic prompt values use `substitute_placeholders()` (`engine/prompt_utils.py`) with `<<PLACEHOLDER>>` markers; see its docstring for the substitution contract. Prompts are inline triple-quoted strings in the workflow file that uses them; there is no separate registry.
+NDD prompts are inline triple-quoted strings in the workflow file that uses them; there is no separate registry. For DataFrame column references inside templates, use `_jinja()`; for dynamic prompt values, use `substitute_placeholders()`. See each function's docstring for details.
 
 ## Structural Invariants
 
-- `from __future__ import annotations` in every Python file
-- Absolute imports only (enforced by ruff `TID`)
-- Type annotations on all functions, methods, and class attributes
-- SPDX license header on every file
-- All column names defined in `engine/constants.py` — never use string literals for column names
-- `COL_TEXT` is the internal name for the input text column; renamed to the user's original column name in final output
+Code conventions enforced in review (future-annotations import, absolute imports, type annotations, SPDX headers, column-name constants) live in [STYLEGUIDE.md](STYLEGUIDE.md).
+
+One pipeline-specific fact worth knowing: `COL_TEXT` is the internal name for the input text column; it's renamed to the user's original column name in final output.
 
 ## What NOT To Do
 
-- **Don't bypass `Rewrite.evaluation`** — don't construct `EvaluationCriteria` with hardcoded thresholds
-- **Don't call DataDesigner directly** — always go through `NddAdapter.run_workflow()`
+- **Don't duplicate the `Rewrite` → `EvaluationCriteria` mapping** when production code starts from a `Rewrite`; route it through `Rewrite.evaluation`.
+- **Don't execute DataDesigner workflows directly** — call `DataDesigner.create()` / `.preview()` only via `NddAdapter.run_workflow()`. Declaring column configs (`LLMStructuredColumnConfig`, etc.) is fine.
 - **Don't use string literals for column names** — use `COL_*` constants from `engine/constants.py`
 - **Don't add a domain to only one supplement map** — see `engine/rewrite/domain_classification.py` for the sync invariant
 - **Don't hardcode `gliner_threshold`** — it belongs in `Detect` config (default 0.3)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # AGENTS.md
 
 This file is for agents **developing** NeMo Anonymizer — the codebase you are working in.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# In ./CLAUDE.md
+
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# In ./CLAUDE.md
+# Claude Code instructions
+
+Canonical agent instructions live in [AGENTS.md](AGENTS.md).
 
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # In ./CLAUDE.md
 
 @AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,14 +210,14 @@ The `main` branch has the following protections:
 
 ### Agent-Assisted Development
 
-If you use Claude Code, Cursor, Codex, or another coding agent, follow the standard [Pull Request Process](#pull-request-process) plus these additions:
+When automating edits with coding agents (IDE assistants, CLI tools, or hosted models), follow the standard [Pull Request Process](#pull-request-process) plus these additions:
 
 1. **For non-trivial changes, draft a plan first.** Non-trivial includes: changes spanning more than one of the `config` / `engine` / `interface` subsystems, introducing a new public API, or modifying an invariant called out in [AGENTS.md](AGENTS.md) or [STYLEGUIDE.md](STYLEGUIDE.md).
    - Write a markdown file detailing the approach, trade-offs considered, affected subsystems, and delivery strategy — enough for reviewers to evaluate the design before implementation begins. (Have the agent draft it; review and refine before submitting.)
    - Save it at `plans/<issue-number>/<short-name>.md` and submit it as its own PR for review.
    - Once the plan is approved, implement it in a follow-up PR.
 
-2. **Implement following [AGENTS.md](AGENTS.md) and [STYLEGUIDE.md](STYLEGUIDE.md).** Both capture pipeline structure, naming conventions, and invariants ruff and ty cannot enforce. The agent should read these before non-trivial changes.
+2. **Implement following [AGENTS.md](AGENTS.md) and [STYLEGUIDE.md](STYLEGUIDE.md).** Both capture pipeline structure, naming conventions, and invariants ruff and ty cannot enforce. Implementers — human or agentic — should read these before non-trivial changes.
 
 ## Issues and Discussions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,17 @@ The `main` branch has the following protections:
 - All `src` and `tests` files: `@NVIDIA-NeMo/anonymizer-reviewers`
 - All remaining files (`pyproject.toml`, `uv.lock`, `SECURITY.md`, `LICENSE`, `.github/`, etc.): `@NVIDIA-NeMo/anonymizer-maintainers`
 
+### Agent-Assisted Development
+
+If you use Claude Code, Cursor, Codex, or another coding agent, follow the standard [Pull Request Process](#pull-request-process) plus these additions:
+
+1. **For non-trivial changes, draft a plan first.** Non-trivial includes: changes spanning more than one of the `config` / `engine` / `interface` subsystems, introducing a new public API, or modifying an invariant called out in [AGENTS.md](AGENTS.md) or [STYLEGUIDE.md](STYLEGUIDE.md).
+   - Write a markdown file detailing the approach, trade-offs considered, affected subsystems, and delivery strategy — enough for reviewers to evaluate the design before implementation begins. (Have the agent draft it; review and refine before submitting.)
+   - Save it at `plans/<issue-number>/<short-name>.md` and submit it as its own PR for review.
+   - Once the plan is approved, implement it in a follow-up PR.
+
+2. **Implement following [AGENTS.md](AGENTS.md) and [STYLEGUIDE.md](STYLEGUIDE.md).** Both capture pipeline structure, naming conventions, and invariants ruff and ty cannot enforce. The agent should read these before non-trivial changes.
+
 ## Issues and Discussions
 
 ### Issue Templates

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Style Guide
 
 Conventions for NeMo Anonymizer that ruff and ty cannot enforce. Read before adding a new module, workflow, or config class.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -5,7 +5,7 @@
 
 Conventions for NeMo Anonymizer that ruff and ty cannot enforce. Read before adding a new module, workflow, or config class.
 
-NeMo Anonymizer wraps [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. References to NDD below mean that library.
+NeMo Anonymizer wraps [DataDesigner](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. References to NDD below mean that library.
 
 For architecture and pipeline identity, see [AGENTS.md](AGENTS.md).
 For contribution workflow and branch naming, see [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -118,7 +118,7 @@ Prompts live as inline triple-quoted strings in the workflow file that uses them
 
 Type annotations are required on all functions, methods, and class attributes including tests.
 
-Use `TYPE_CHECKING` blocks for imports only needed for type hints — prevents circular imports and avoids loading heavy libraries at import time:
+Use `TYPE_CHECKING` blocks for imports needed *only* in type annotations. This prevents circular imports and avoids loading heavy libraries at import time:
 
 ```python
 from typing import TYPE_CHECKING
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
     import pandas as pd
 ```
 
-`pandas` is import-time expensive — only import it at the top level where it is actually needed at runtime.
+If a module uses `pandas` at runtime — calls `pd.DataFrame`, indexes a DataFrame in a function body, etc. — import it at the top level. A `TYPE_CHECKING` import raises `NameError` if you reference it at runtime. `pandas` is import-time expensive, so keep top-level imports of it limited to modules that genuinely need it.
 
 ---
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -3,7 +3,7 @@
 
 # Style Guide
 
-Conventions for NeMo Anonymizer that ruff and ty cannot enforce. Read before adding a new module, workflow, or config class.
+Code and documentation conventions for NeMo Anonymizer that ruff and ty cannot enforce. Architecture boundaries and agent workflow rules live in [AGENTS.md](AGENTS.md). Read before adding a new module, workflow, or config class.
 
 NeMo Anonymizer wraps [DataDesigner](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. References to NDD below mean that library.
 
@@ -19,7 +19,7 @@ For contribution workflow and branch naming, see [CONTRIBUTING.md](CONTRIBUTING.
 | Need | Use |
 |------|-----|
 | User-facing config, validation, JSON schema | `BaseModel` |
-| Internal result type, frozen value object | `@dataclass(frozen=True)` |
+| Private/internal frozen value object (e.g. `WorkflowRunResult`, `_RiskToleranceBundle`) | `@dataclass(frozen=True)` |
 
 ```python
 # Config — Pydantic
@@ -55,7 +55,7 @@ except Exception as exc:
     raise AnonymizerWorkflowError("Workflow failed")
 ```
 
-Don't use defensive `try/except` on trusted internal calls that shouldn't fail — only catch at module boundaries. The final judge step is the intentional exception: it's explicitly non-critical and catches broadly, logging with `exc_info=True` and substituting safe defaults.
+Don't use defensive `try/except` on trusted internal calls that shouldn't fail — only catch at module boundaries. `RewriteWorkflow._run_final_judge` is the intentional exception: it's explicitly non-critical and catches broadly, logging with `exc_info=True` and substituting safe defaults.
 
 **Error messages** must identify the actual bad value. Use `!r` to make interpolated values unambiguous:
 
@@ -67,7 +67,7 @@ raise ValueError(f"Unsupported strategy: {strategy!r}")
 raise ValueError("Invalid strategy")
 ```
 
-**No `assert` for validation** — `assert` statements are stripped when Python runs with `-O`. Use `if/raise` instead:
+**No `assert` for validation in production/library code** — `assert` statements are stripped when Python runs with `-O`. Use `if/raise` instead. Pytest assertions in tests are fine.
 
 ```python
 # Good
@@ -98,7 +98,7 @@ Internal (intermediate) columns are prefixed with `_`. User-facing output column
 
 ## Prompt Construction
 
-**`_jinja(col, key=None)`** from `engine/constants.py` — use for NDD prompt template column references. Never format column names directly into prompt strings; `_jinja` keeps column references grep-able.
+**`_jinja(col, key=None)`** from `engine/constants.py` — use for **shared DataFrame column references** in NDD prompt templates. Never format shared column names directly into prompt strings; `_jinja` keeps them grep-able. Local Jinja loop variables (e.g. `entity.value` inside `{% for entity in ... %}`) are scoped to the prompt and don't need `_jinja`.
 
 ```python
 # Good
@@ -164,7 +164,7 @@ def process_file(filename: str) -> None:
 
 ## Code Organization
 
-- Public functions and methods before private (`_`-prefixed) ones within a module or class
+- When adding new symbols, prefer public functions and methods before private (`_`-prefixed) ones within a module or class
 - Define helpers at module or class level — avoid nested functions. Nested functions hide logic, make testing harder, and complicate stack traces. The only acceptable use is a closure that genuinely needs to capture local state.
 
 ---
@@ -197,6 +197,12 @@ for record in records:
 ## Future Annotations
 
 Every Python file must include `from __future__ import annotations` after the license header. This defers annotation evaluation, enables forward references, and keeps behavior consistent across the codebase.
+
+---
+
+## License Headers
+
+Every Python and Markdown file requires an SPDX header at the top (enforced by `tools/codestyle/copyright_fixer.py --check`, run via `make copyright-check`). Files listed in `.copyrightignore` are exempt.
 
 ---
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,171 @@
+# Style Guide
+
+Conventions for NeMo Anonymizer that ruff and ty cannot enforce. Read before adding a new module, workflow, or config class.
+
+NeMo Anonymizer wraps [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner) (NDD) for LLM column generation. References to NDD below mean that library.
+
+For architecture and pipeline identity, see [AGENTS.md](AGENTS.md).
+For contribution workflow and branch naming, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## Pydantic vs Dataclasses
+
+**Pydantic** for config, validation, and serialization. **Dataclasses** for simple typed containers in the engine.
+
+| Need | Use |
+|------|-----|
+| User-facing config, validation, JSON schema | `BaseModel` |
+| Internal result type, frozen value object | `@dataclass(frozen=True)` |
+
+```python
+# Config — Pydantic
+class Detect(BaseModel):
+    gliner_threshold: float = Field(default=0.3, ge=0.0, le=1.0)
+
+# Internal result — dataclass
+@dataclass(frozen=True)
+class WorkflowRunResult:
+    dataframe: pd.DataFrame
+    failed_records: list[FailedRecord]
+```
+
+Use `Field()` only when you need constraints (`ge`, `le`), descriptions, or `default_factory`. Use bare defaults for simple flags and strings.
+
+---
+
+## Error Handling
+
+Wrap exceptions from NDD and other third-party calls at module boundaries into canonical types from `interface/errors.py`. Callers should never see raw NDD exceptions.
+
+Preserve the traceback:
+
+```python
+# Good
+try:
+    run_results = self._data_designer.create(...)
+except Exception as exc:
+    raise AnonymizerWorkflowError(f"Workflow failed: {exc}") from exc
+
+# Bad — swallows the traceback
+except Exception as exc:
+    raise AnonymizerWorkflowError("Workflow failed")
+```
+
+Don't use defensive `try/except` on trusted internal calls that shouldn't fail — only catch at module boundaries. The final judge step is the intentional exception: it's explicitly non-critical and catches broadly, logging with `exc_info=True` and substituting safe defaults.
+
+**Error messages** must identify the actual bad value. Use `!r` to make interpolated values unambiguous:
+
+```python
+# Good
+raise ValueError(f"Unsupported strategy: {strategy!r}")
+
+# Bad
+raise ValueError("Invalid strategy")
+```
+
+**No `assert` for validation** — `assert` statements are stripped when Python runs with `-O`. Use `if/raise` instead:
+
+```python
+# Good
+if not isinstance(config, AnonymizerConfig):
+    raise TypeError(f"Expected AnonymizerConfig, got {type(config)!r}")
+
+# Bad
+assert isinstance(config, AnonymizerConfig)
+```
+
+---
+
+## Column Names
+
+All column names are constants in `engine/constants.py`. Never use string literals for column names.
+
+```python
+# Good
+df[COL_DETECTED_ENTITIES]
+
+# Bad
+df["_detected_entities"]
+```
+
+Internal (intermediate) columns are prefixed with `_`. User-facing output columns use clean names (`final_entities`, `utility_score`). The input text column is always `COL_TEXT` internally and renamed to the user's original column name in `Anonymizer._rename_output_columns()`.
+
+---
+
+## Prompt Construction
+
+**`_jinja(col, key=None)`** from `engine/constants.py` — use for NDD prompt template column references. Never format column names directly into prompt strings; `_jinja` keeps column references grep-able.
+
+```python
+# Good
+f"The text is: {_jinja(COL_TEXT)}"
+
+# Bad
+f"The text is: {{{{ {COL_TEXT} }}}}"
+```
+
+**`substitute_placeholders(template, replacements)`** from `engine/prompt_utils.py` — use for dynamic prompt values. The `<<PLACEHOLDER>>` format avoids collisions with Jinja2 syntax. Never use f-strings or `.format()` for prompt templates with dynamic values; single-pass substitution prevents a replacement value from being interpreted as a placeholder.
+
+Prompts live as inline triple-quoted strings in the workflow file that uses them. There is no separate prompt registry.
+
+---
+
+## Type Annotations
+
+Type annotations are required on all functions, methods, and class attributes including tests.
+
+Use `TYPE_CHECKING` blocks for imports only needed for type hints — prevents circular imports and avoids loading heavy libraries at import time:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+```
+
+`pandas` is import-time expensive — only import it at the top level where it is actually needed at runtime.
+
+---
+
+## Code Organization
+
+- Public functions and methods before private (`_`-prefixed) ones within a module or class
+- Define helpers at module or class level — avoid nested functions. Nested functions hide logic, make testing harder, and complicate stack traces. The only acceptable use is a closure that genuinely needs to capture local state.
+
+---
+
+## Naming
+
+- Functions and variables: `snake_case`
+- Classes: `PascalCase`
+- Constants: `UPPER_SNAKE_CASE`
+- Function names start with a verb: `run_workflow`, `build_entity_id`, not `entity_id` or `workflow`
+
+---
+
+## Comments
+
+Only add a comment when the WHY is non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug. Don't narrate what the code already says:
+
+```python
+# Good — explains a non-obvious invariant
+# uuid5 is deterministic so input/output IDs match for missing-record tracking.
+
+# Bad — narrates what the code does
+# Loop through the records and append to list
+for record in records:
+    results.append(record)
+```
+
+---
+
+## Future Annotations
+
+Every Python file must include `from __future__ import annotations` after the license header. This defers annotation evaluation, enables forward references, and keeps behavior consistent across the codebase.
+
+---
+
+## Docstrings
+
+Google style (`Args:`, `Returns:`, `Raises:`). Public API classes and methods get docstrings; private helpers (`_`-prefixed) only when the logic is non-obvious. Don't restate the signature — explain why or what, not what the type annotation already says.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -131,6 +131,37 @@ If a module uses `pandas` at runtime — calls `pd.DataFrame`, indexes a DataFra
 
 ---
 
+## Import Style
+
+- **ALWAYS** use absolute imports, never relative imports (enforced by `TID`)
+- Place imports at module level, not inside functions (exception: unavoidable for performance reasons)
+- Import sorting is handled by `ruff`'s `isort` — imports should be grouped and sorted:
+  1. Standard library imports
+  2. Third-party imports
+  3. First-party imports (`anonymizer`)
+- Use standard import conventions (enforced by `ICN`)
+
+```python
+# Good
+from anonymizer.config.anonymizer_config import AnonymizerConfig
+
+# Bad - relative import (will cause linter errors)
+from .anonymizer_config import AnonymizerConfig
+
+# Good - imports at module level
+from pathlib import Path
+
+def process_file(filename: str) -> None:
+    path = Path(filename)
+
+# Bad - import inside function
+def process_file(filename: str) -> None:
+    from pathlib import Path
+    path = Path(filename)
+```
+
+---
+
 ## Code Organization
 
 - Public functions and methods before private (`_`-prefixed) ones within a module or class
@@ -172,3 +203,28 @@ Every Python file must include `from __future__ import annotations` after the li
 ## Docstrings
 
 Google style (`Args:`, `Returns:`, `Raises:`). Public API classes and methods get docstrings; private helpers (`_`-prefixed) only when the logic is non-obvious. Don't restate the signature — explain why or what, not what the type annotation already says.
+
+---
+
+## Design Principles
+
+**DRY**
+
+- Extract shared logic into pure helper functions rather than duplicating across similar call sites
+- Rule of thumb: tolerate duplication until the third occurrence, then extract
+
+**KISS**
+
+- Prefer flat, obvious code over clever abstractions — two similar lines is better than a premature helper
+- When in doubt between DRY and KISS, favor readability over deduplication
+
+**YAGNI**
+
+- Don't add parameters, config, or abstraction layers for hypothetical future use cases
+- Don't generalize until the third caller appears
+
+**SOLID**
+
+- Wrap third-party exceptions at module boundaries — callers depend on canonical error types, not leaked internals
+- Use `Protocol` for contracts between layers
+- One function, one job — separate logic from I/O

--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -147,7 +147,20 @@ class Rewrite(BaseModel):
 
     @property
     def evaluation(self) -> EvaluationCriteria:
-        """Internal: construct EvaluationCriteria for the engine."""
+        """Construct `EvaluationCriteria` from this `Rewrite` config for the engine.
+
+        `Rewrite` and `EvaluationCriteria` both carry `max_repair_iterations`.
+        This property keeps them in sync: it passes through `self.risk_tolerance`
+        and `self.max_repair_iterations`. Leakage thresholds and repair
+        parameters are derived from `risk_tolerance` via `_RiskToleranceBundle`
+        (see `rewrite.py`).
+
+        Production code that starts from a user-facing `Rewrite` should pass
+        `rewrite.evaluation` into the engine — never duplicate the mapping
+        manually. Tests and engine-internal callers may construct
+        `EvaluationCriteria` directly when they aren't routing through a
+        user-facing `Rewrite`.
+        """
         return EvaluationCriteria(
             risk_tolerance=self.risk_tolerance,
             max_repair_iterations=self.max_repair_iterations,

--- a/src/anonymizer/config/rewrite.py
+++ b/src/anonymizer/config/rewrite.py
@@ -105,12 +105,12 @@ class PrivacyGoal(BaseModel):
 class EvaluationCriteria(BaseModel):
     """Criteria for privacy leakage evaluation and repair.
 
-    ``risk_tolerance`` controls the leakage threshold that triggers repair,
+    `risk_tolerance` controls the leakage threshold that triggers repair,
     whether individual high-sensitivity leaks trigger repair, and the
-    thresholds for flagging records for human review. See ``RiskTolerance``
+    thresholds for flagging records for human review. See `RiskTolerance`
     for preset descriptions.
 
-    ``max_repair_iterations`` caps how many repair rounds are attempted
+    `max_repair_iterations` caps how many repair rounds are attempted
     (each round = one LLM call per failing row). Set to 0 to disable repair
     while still producing evaluation metrics.
     """

--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -186,9 +186,14 @@ DEFAULT_ENTITY_LABELS: list[str] = list(ENTITY_LABEL_EXAMPLES.keys())
 
 
 def _jinja(col: str, *, key: str | None = None) -> str:
-    """Wrap a column name in Jinja2 template syntax for use in NDD prompts.
+    """Wrap a DataFrame column name in Jinja2 template syntax for NDD prompts.
 
-    When *key* is given the expression becomes ``{{ col['key'] }}``,
+    Use this for any DataFrame column reference inside an NDD prompt
+    template — it keeps column references grep-able. Local Jinja loop
+    variables (e.g. `entity.value` inside `{% for entity in ... %}`) are
+    scoped to the prompt and should *not* go through this helper.
+
+    When `key` is given the expression becomes `{{ col['key'] }}`,
     providing a single grep-able call site for nested schema access.
     """
     expr = col if key is None else f"{col}['{key}']"

--- a/src/anonymizer/engine/ndd/adapter.py
+++ b/src/anonymizer/engine/ndd/adapter.py
@@ -61,7 +61,27 @@ class NddAdapter:
         workflow_name: str,
         preview_num_records: int | None = None,
     ) -> WorkflowRunResult:
-        """Run one workflow and return output with missing-record tracking."""
+        """Run one workflow and return output with missing-record tracking.
+
+        Wraps a DataFrame slice plus NDD column configs into a DataDesigner
+        run and returns `WorkflowRunResult(dataframe, failed_records)`.
+        Records missing from the output surface as `FailedRecord` objects
+        rather than silently disappearing.
+
+        This is the engine boundary for *executing* DataDesigner workflows.
+        Engine sub-workflows declare column configs and call this method;
+        they do not call `DataDesigner.create()` or `.preview()` directly.
+
+        Args:
+            df: Input DataFrame.
+            model_configs: NDD model aliases available to the workflow.
+            columns: NDD column configs to add to the workflow.
+            workflow_name: Identifier used in logs and on `FailedRecord` entries.
+            preview_num_records: If set, run in preview mode against this many rows.
+
+        Returns:
+            `WorkflowRunResult` with the output DataFrame and any `FailedRecord` entries.
+        """
         workflow_input_df = self._attach_record_ids(df=df)
         logger.debug("NDD workflow '%s' starting with %d records", workflow_name, len(workflow_input_df))
         col_names = [c.name for c in columns]

--- a/src/anonymizer/engine/prompt_utils.py
+++ b/src/anonymizer/engine/prompt_utils.py
@@ -20,16 +20,17 @@ def substitute_placeholders(
     *,
     strict: bool = True,
 ) -> str:
-    """Single-pass placeholder substitution.
+    """Single-pass placeholder substitution for dynamic prompt values.
 
-    All ``<<PLACEHOLDER>>`` markers are replaced simultaneously so that
-    user-controlled values inserted for one placeholder cannot collide
-    with markers intended for a later placeholder.
+    Used for dynamic prompt values that aren't DataFrame column
+    references. All `<<PLACEHOLDER>>` markers are replaced simultaneously
+    so that user-controlled values inserted for one placeholder cannot
+    collide with markers intended for a later placeholder.
 
-    When *strict* is True (default):
+    When `strict` is True (default):
 
-    - Raises ``ValueError`` if any key does not match the ``<<...>>`` format.
-    - Raises ``ValueError`` if any ``<<...>>`` placeholders remain after substitution.
+    - Raises `ValueError` if any key does not match the `<<...>>` format.
+    - Raises `ValueError` if any `<<...>>` placeholders remain after substitution.
     - Logs a warning if the dict contains keys not present in the template.
     """
     if not replacements:


### PR DESCRIPTION
  ## Summary

  - Add `AGENTS.md` — architecture overview, pipeline diagrams, and structural invariants for agents working in
  the codebase.
  - Add `STYLEGUIDE.md` — code conventions ruff and ty cannot enforce (Pydantic vs dataclass, error handling,
  column-name constants, prompt construction).
  - Add `CLAUDE.md` — 3-line redirect to `AGENTS.md` so Claude Code picks it up.
  - Add an "Agent-Assisted Development" subsection to `CONTRIBUTING.md` establishing the
  `plans/<issue-number>/<short-name>.md` convention for non-trivial changes.
  - Ignore `.claude/worktrees/` (Claude Code session worktrees).

  Filed #148 as a follow-up for three pre-existing column-name string-literal violations in
  `llm_replace_workflow.py:53-55` that the new STYLEGUIDE rule covers.

  Closes #114.

  ## Test plan

  - [ ] CI passes (format-check, `mkdocs build --strict`)
  - [ ] Reviewer can navigate the AGENTS.md ↔ STYLEGUIDE.md ↔ CONTRIBUTING.md cross-links
  - [ ] `git check-ignore .claude/worktrees/foo` returns the path (worktrees properly ignored)