### PR TITLE
fix(replace): drop workflow-internal columns and use COL_* constants

### DIFF
--- a/src/anonymizer/engine/constants.py
+++ b/src/anonymizer/engine/constants.py
@@ -46,6 +46,13 @@ COL_ENTITIES_BY_VALUE = "_entities_by_value"
 COL_REPLACED_TEXT = "__nemo_anonymizer_text_output__"
 COL_REPLACEMENT_MAP = "_replacement_map"
 
+# LlmReplaceWorkflow internal prompt-construction columns. Created by
+# `LlmReplaceWorkflow.generate_map_only` for the replacement-generator prompt
+# template, dropped before returning. Not part of the output surface.
+COL_ENTITY_EXAMPLES = "_entity_examples"
+COL_ENTITIES_FOR_REPLACE = "_entities_for_replace"
+COL_ENTITIES_FOR_REPLACE_JSON = "_entities_for_replace_json"
+
 # Latent detection (optional second workflow)
 COL_LATENT_ENTITIES = "_latent_entities"
 

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -222,7 +222,7 @@ Entities to replace:
 - "{{ entity.value }}" ({{ entity.labels_str }})
 {%- endfor %}
 
-Examples: {{ _entity_examples }}
+Examples: {{ <<ENTITY_EXAMPLES_COLUMN>> }}
 
 Rules:
 1. Related entities must stay consistent:
@@ -262,6 +262,7 @@ Before generating replacements, verify:
         {
             "<<INSTRUCTION_BLOCK>>": instruction_block,
             "<<ENTITIES_COLUMN>>": entities_column,
+            "<<ENTITY_EXAMPLES_COLUMN>>": COL_ENTITY_EXAMPLES,
         },
     )
 

--- a/src/anonymizer/engine/replace/llm_replace_workflow.py
+++ b/src/anonymizer/engine/replace/llm_replace_workflow.py
@@ -12,7 +12,14 @@ from data_designer.config.column_configs import LLMStructuredColumnConfig
 from data_designer.config.models import ModelConfig
 
 from anonymizer.config.models import ReplaceModelSelection
-from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, ENTITY_LABEL_EXAMPLES
+from anonymizer.engine.constants import (
+    COL_ENTITIES_BY_VALUE,
+    COL_ENTITIES_FOR_REPLACE,
+    COL_ENTITIES_FOR_REPLACE_JSON,
+    COL_ENTITY_EXAMPLES,
+    COL_REPLACEMENT_MAP,
+    ENTITY_LABEL_EXAMPLES,
+)
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias
 from anonymizer.engine.prompt_utils import substitute_placeholders
@@ -20,6 +27,12 @@ from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
 from anonymizer.engine.schemas import EntitiesByValueSchema, EntityReplacementMapSchema
 
 logger = logging.getLogger("anonymizer.replace.llm_workflow")
+
+# Workflow-internal scratch columns used only to build the replacement-generator
+# prompt. Created in `generate_map_only` and dropped before returning — nothing
+# downstream consumes them, and they carry pyarrow-backed pandas extension
+# dtypes that would break trace_dataframe.to_parquet round-trip.
+_INTERNAL_COLUMNS = (COL_ENTITY_EXAMPLES, COL_ENTITIES_FOR_REPLACE, COL_ENTITIES_FOR_REPLACE_JSON)
 
 
 @dataclass(frozen=True)
@@ -50,17 +63,18 @@ class LlmReplaceWorkflow:
 
         # Parse the per-row entity payload once, then reuse it for prompt inputs.
         parsed_entities = working_df[entities_column].apply(EntitiesByValueSchema.from_raw)
-        working_df["_entity_examples"] = parsed_entities.apply(_create_entity_examples)
-        working_df["_entities_for_replace"] = parsed_entities.apply(_enrich_entities_for_template)
-        working_df["_entities_for_replace_json"] = working_df["_entities_for_replace"].apply(json.dumps)
+        working_df[COL_ENTITY_EXAMPLES] = parsed_entities.apply(_create_entity_examples)
+        working_df[COL_ENTITIES_FOR_REPLACE] = parsed_entities.apply(_enrich_entities_for_template)
+        working_df[COL_ENTITIES_FOR_REPLACE_JSON] = working_df[COL_ENTITIES_FOR_REPLACE].apply(json.dumps)
 
         # Partition: rows with an empty entity list bypass replacement-map generation.
-        entity_rows, passthrough_rows = split_rows(working_df, column="_entities_for_replace", predicate=bool)
+        entity_rows, passthrough_rows = split_rows(working_df, column=COL_ENTITIES_FOR_REPLACE, predicate=bool)
         passthrough_rows[COL_REPLACEMENT_MAP] = [{"replacements": []} for _ in range(len(passthrough_rows))]
 
         if entity_rows.empty:
+            passthrough_only = merge_and_reorder(passthrough_rows, attrs=dataframe.attrs)
             return LlmReplaceResult(
-                dataframe=merge_and_reorder(passthrough_rows, attrs=dataframe.attrs),
+                dataframe=passthrough_only.drop(columns=list(_INTERNAL_COLUMNS), errors="ignore"),
                 failed_records=[],
             )
 
@@ -75,7 +89,7 @@ class LlmReplaceWorkflow:
                 LLMStructuredColumnConfig(
                     name=COL_REPLACEMENT_MAP,
                     prompt=_get_replacement_mapping_prompt(
-                        entities_column="_entities_for_replace",
+                        entities_column=COL_ENTITIES_FOR_REPLACE,
                         instructions=instructions,
                     ),
                     model_alias=replace_alias,
@@ -99,7 +113,10 @@ class LlmReplaceWorkflow:
         combined = merge_and_reorder(
             output_df, passthrough_rows, attrs={**run_result.dataframe.attrs, **dataframe.attrs}
         )
-        return LlmReplaceResult(dataframe=combined, failed_records=run_result.failed_records)
+        return LlmReplaceResult(
+            dataframe=combined.drop(columns=list(_INTERNAL_COLUMNS), errors="ignore"),
+            failed_records=run_result.failed_records,
+        )
 
 
 def _enrich_entities_for_template(parsed: EntitiesByValueSchema) -> list[dict[str, str | list[str]]]:

--- a/tests/engine/test_llm_replace_workflow.py
+++ b/tests/engine/test_llm_replace_workflow.py
@@ -11,7 +11,7 @@ from data_designer.config.models import ModelConfig
 from anonymizer.config.models import ReplaceModelSelection
 from anonymizer.engine.constants import COL_ENTITIES_BY_VALUE, COL_REPLACEMENT_MAP, COL_TEXT
 from anonymizer.engine.ndd.adapter import WorkflowRunResult
-from anonymizer.engine.replace.llm_replace_workflow import LlmReplaceWorkflow
+from anonymizer.engine.replace.llm_replace_workflow import _INTERNAL_COLUMNS, LlmReplaceWorkflow
 
 
 def test_generate_map_only_preserves_input_attrs(
@@ -168,3 +168,74 @@ def test_generate_map_only_preserves_original_anonymizer_row_order_with_mixed_ro
         {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]},
         {"replacements": []},
     ]
+
+
+def test_generate_map_only_strips_internal_prompt_columns(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    """Workflow-internal prompt-construction columns must be stripped from the
+    result. They carry pyarrow-backed pandas extension dtypes that would break
+    a downstream `trace_dataframe.to_parquet` round-trip, and nothing
+    downstream of this workflow consumes them.
+    """
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Alice works at Acme"],
+                COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
+                "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
+                "_anonymizer_row_order": [0],
+                COL_REPLACEMENT_MAP: [
+                    {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]}
+                ],
+            }
+        ),
+        failed_records=[],
+    )
+    workflow = LlmReplaceWorkflow(adapter=adapter)
+
+    input_df = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice works at Acme"],
+            COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
+            "tagged_text": ["<<PII:first_name>>Alice<</PII:first_name>> works at Acme"],
+        }
+    )
+
+    result = workflow.generate_map_only(
+        input_df,
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+
+    for col in _INTERNAL_COLUMNS:
+        assert col not in result.dataframe.columns, f"workflow-internal column {col!r} leaked into result"
+
+
+def test_generate_map_only_strips_internal_prompt_columns_when_no_entities(
+    stub_model_configs: list[ModelConfig],
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    """Same guarantee as above for the early-return path (no entities → no NDD call)."""
+    adapter = Mock()
+    workflow = LlmReplaceWorkflow(adapter=adapter)
+
+    input_df = pd.DataFrame(
+        {
+            COL_TEXT: ["No entities here"],
+            COL_ENTITIES_BY_VALUE: [{"entities_by_value": []}],
+            "tagged_text": ["No entities here"],
+        }
+    )
+
+    result = workflow.generate_map_only(
+        input_df,
+        model_configs=stub_model_configs,
+        selected_models=stub_replace_model_selection,
+    )
+
+    adapter.run_workflow.assert_not_called()
+    for col in _INTERNAL_COLUMNS:
+        assert col not in result.dataframe.columns, f"workflow-internal column {col!r} leaked into result"

--- a/tests/engine/test_llm_replace_workflow.py
+++ b/tests/engine/test_llm_replace_workflow.py
@@ -190,6 +190,9 @@ def test_generate_map_only_strips_internal_prompt_columns(
                 COL_REPLACEMENT_MAP: [
                     {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maya"}]}
                 ],
+                # NDD passes input columns through to its output; simulate that so the
+                # drop in the entity-rows return path actually has work to do.
+                **{col: [""] for col in _INTERNAL_COLUMNS},
             }
         ),
         failed_records=[],


### PR DESCRIPTION
## Summary

Both issues (#148 and #152) touch the same three lines in `engine/replace/llm_replace_workflow.py:53-55`. Addresses both in one mechanical fix.

**#148 — string-literal column names violate the `STYLEGUIDE.md` rule that all column names live in `engine/constants.py`:**
- Add `COL_ENTITY_EXAMPLES`, `COL_ENTITIES_FOR_REPLACE`, `COL_ENTITIES_FOR_REPLACE_JSON` to `engine/constants.py`.
- Use them in all 5 places these columns appear in `llm_replace_workflow.py`.

**#152 — `result.trace_dataframe.to_parquet` fails to round-trip:**
- These three columns are prompt-construction scratch: consumed only by the replacement-generator Jinja template, never read downstream. They carry pyarrow-backed pandas extension dtypes that pandas can't reconstruct on `read_parquet`, which poisoned the entire trace file's readability.
- Drop them from the result before returning, in both `generate_map_only` return paths (entity rows present and entity rows absent).
- Tracked via a module-level `_INTERNAL_COLUMNS` tuple so the drop and the regression tests stay in sync.

## Test plan

- [x] Two regression tests in `test_llm_replace_workflow.py` cover both return paths
- [x] Mutation tested — removing the `.drop()` calls makes both regression tests fail; restoring them makes them pass
- [x] Manually verified parquet round-trip on a captured trace dataframe: stripping the 3 columns lets `pd.read_parquet` succeed; downstream trace columns (`_validated_entities`, `_sensitivity_disposition`, etc.) remain accessible as Python dicts
- [x] `make format-check` passes locally
- [ ] CI passes

Closes #148.
Closes #152.