### PR TITLE
fix(telemetry): flush events when called from a running event loop

### DIFF
--- a/src/anonymizer/telemetry.py
+++ b/src/anonymizer/telemetry.py
@@ -22,6 +22,7 @@ Related environment variables (read at runtime, not import time):
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import platform
 from dataclasses import dataclass
@@ -34,6 +35,8 @@ from pydantic import BaseModel, Field
 if TYPE_CHECKING:
     import httpx
     from data_designer.config.models import ModelProvider
+
+logger = logging.getLogger("anonymizer")
 
 CLIENT_ID = "184482118588404"
 NEMO_TELEMETRY_VERSION = "nemo-telemetry/1.0"
@@ -334,9 +337,38 @@ class TelemetryHandler:
         if not (self._events or self._dlq):
             return
         try:
-            asyncio.run(self._flush_events())
+            self._run_sync(self._flush_events())
         except Exception:
-            pass  # best-effort
+            # Telemetry is best-effort; never raise into the caller's pipeline.
+            # Logged at DEBUG so it's surfaceable via `logging.getLogger("anonymizer")`
+            # without spamming default-level output.
+            logger.debug("Telemetry flush failed", exc_info=True)
+
+    @staticmethod
+    def _run_sync(coro: Any) -> Any:
+        """Run an awaitable synchronously from any caller context.
+
+        Mirrors DataDesigner's ``TelemetryHandler._run_sync`` (see
+        ``data_designer/engine/models/telemetry.py``). Plain ``asyncio.run`` raises
+        ``RuntimeError`` when called from a thread that already has a running event
+        loop — e.g. a Jupyter kernel, an async test runner, or any caller invoking
+        ``Anonymizer.run()`` from within ``asyncio.run(...)``. In that case the
+        previous implementation swallowed the error and silently dropped every
+        queued event. We instead off-load to a worker thread, which gets its own
+        fresh loop, so flush works identically in sync and async contexts.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, coro)
+                return future.result()
+        return asyncio.run(coro)
 
     def __enter__(self) -> TelemetryHandler:
         return self

--- a/src/anonymizer/telemetry.py
+++ b/src/anonymizer/telemetry.py
@@ -362,7 +362,7 @@ class TelemetryHandler:
         except RuntimeError:
             loop = None
 
-        if loop and loop.is_running():
+        if loop:
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -434,3 +434,75 @@ class TestContextManager:
         with TelemetryHandler(source_client_version="1.0") as handler:
             pass
         assert handler._events == []
+
+
+# =============================================================================
+# TelemetryHandler — flush in async contexts (notebook regression)
+# =============================================================================
+
+
+class TestFlushFromRunningLoop:
+    """Regression: when flush() is called from a thread that already has a running
+    event loop (Jupyter kernels, async test runners, FastAPI handlers, callers using
+    ``asyncio.run(Anonymizer.run(...))``), the previous ``asyncio.run`` call raised
+    ``RuntimeError`` and the queue was silently dropped. ``_run_sync`` must off-load
+    flush to a worker thread so events still go out.
+    """
+
+    def test_run_sync_uses_thread_when_loop_is_running(self) -> None:
+        sent: list[int] = []
+
+        async def fake_flush(self) -> None:  # noqa: ARG001 - bound-method signature
+            sent.append(1)
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0")
+            # Patch _flush_events so we don't actually hit the network; we just
+            # want to prove _run_sync drove the coroutine to completion from
+            # inside a running loop.
+            with patch.object(TelemetryHandler, "_flush_events", new=fake_flush):
+                handler._events.append(QueuedEvent(event=_minimal_event(), timestamp=datetime.now(timezone.utc)))
+                handler.flush()
+
+        asyncio.run(driver())
+        assert sent == [1], "flush() should drive _flush_events to completion even with a running loop"
+
+    def test_context_manager_flushes_from_running_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end shape Anonymizer uses: enqueue in a `with` block; the
+        ``__exit__`` calls ``flush()``. From inside an async caller this used
+        to drop everything silently.
+        """
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        sent: list[int] = []
+
+        async def fake_send(self, client, events):  # noqa: ARG001 - mirror real signature
+            sent.append(len(events))
+
+        async def driver() -> None:
+            with patch.object(TelemetryHandler, "_send_events_with_client", new=fake_send):
+                with TelemetryHandler(source_client_version="1.0") as handler:
+                    handler.enqueue(_minimal_event())
+            assert handler._events == []
+
+        asyncio.run(driver())
+        assert sent == [1], "flush() must actually post the queued event from inside a running loop"
+
+    def test_run_sync_propagates_exception_to_flush(self) -> None:
+        """``_run_sync`` is the boundary that must surface failures to ``flush()``
+        so they can be logged at DEBUG. If the worker-thread loop swallowed
+        exceptions, the new logger.debug call would be unreachable.
+        """
+
+        async def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        async def driver() -> RuntimeError | None:
+            try:
+                TelemetryHandler._run_sync(boom())
+            except RuntimeError as e:
+                return e
+            return None
+
+        captured = asyncio.run(driver())
+        assert isinstance(captured, RuntimeError)
+        assert str(captured) == "kaboom"


### PR DESCRIPTION
## Summary

`TelemetryHandler.flush()` was silently dropping every event when called from a thread with a running asyncio loop — i.e. every Jupyter notebook run, every async test, and any caller invoking `Anonymizer.run()` from within `asyncio.run(...)`. CLI runs (no pre-existing loop) were unaffected, which is why this surfaced as *"my notebook events don't reach the dashboard, but my colleague's CLI events do."*

**Root cause.** `flush()` called `asyncio.run(self._flush_events())` directly. `asyncio.run` raises `RuntimeError: asyncio.run() cannot be called from a running event loop` when invoked on a thread with an active loop. The surrounding `except Exception: pass` swallowed it and the coroutine was garbage-collected with a `RuntimeWarning: coroutine '_flush_events' was never awaited`, so the queued batch never left the process.

**Fix.** Adopt the same `_run_sync` pattern DataDesigner already uses ([`data_designer/engine/models/telemetry.py:283-296`](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/packages/data-designer-engine/src/data_designer/engine/models/telemetry.py#L283-L296)): detect a running loop, and if one is active off-load the coroutine to a one-shot `ThreadPoolExecutor` (which gets its own fresh loop); otherwise plain `asyncio.run`. Our handler was deliberately stripped down from DD's (no background timer task — Anonymizer runs are fire-and-flush, see `TelemetryHandler` docstring + `AGENTS.md`), but in flattening we kept the bare `asyncio.run` and dropped the `_run_sync` indirection that protected DD from this exact case. Re-adopting it keeps the idiom consistent across NeMo.

Also upgrades the swallowed-error arm in `flush()` from `pass` to `logger.debug("Telemetry flush failed", exc_info=True)`, so future debugging of telemetry issues is a `logging.getLogger("anonymizer").setLevel(DEBUG)` away instead of patching `telemetry.py` with `raise`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally (80/80 in the telemetry suites; full suite green)
- [x] `make check` passes locally (format + lint)
- [x] Added/updated tests for changes

New regression coverage in `tests/test_telemetry.py::TestFlushFromRunningLoop`:
- `flush()` from inside `asyncio.run(...)` drives `_flush_events` to completion
- the full `with TelemetryHandler(...) as h:` shape (what `_emit_telemetry_event` uses at the call site) actually POSTs from inside a running loop
- `_run_sync` re-raises so the new `logger.debug` arm in `flush()` is reachable

**Manual verification.** Repro'd the bug on `main` by running a notebook cell that constructed a `TelemetryHandler` and enqueued one event — got `RuntimeWarning: coroutine 'TelemetryHandler._flush_events' was never awaited`. Pulled this branch, re-ran the same cell, no warning, event POSTed successfully (verified by pointing `NEMO_TELEMETRY_ENDPOINT` at `https://httpbin.org/post` and observing the request body). Also ran `Anonymizer().preview()` end-to-end from a notebook — clean exit, no warning, no `Telemetry flush failed` debug log.

## Documentation
- [x] No docs changes needed (internal handler implementation, behavior unchanged for healthy CLI path)

## Related Issues
<!-- N/A — surfaced internally; reporter was running notebooks against the dashboard. -->