### PR TITLE
feat: add benchmark CI scaffold

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -4,6 +4,13 @@
 name: Benchmark CI
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/benchmark-ci.yml"
+      - "scripts/benchmark_ci.py"
+      - "tests/test_benchmark_ci.py"
   workflow_dispatch:
     inputs:
       ref:
@@ -58,8 +65,17 @@ env:
 jobs:
   benchmark:
     name: Benchmark
+    if: github.event_name == 'workflow_dispatch' || (github.head_ref == 'andreatgretel/feat/benchmark-ci' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, anonymizer-evals]
     timeout-minutes: 60
+    env:
+      BENCHMARK_REF: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+      BENCHMARK_NUM_RECORDS: ${{ inputs.num_records || '1' }}
+      BENCHMARK_EXPERIMENTS: ${{ inputs.experiments || 'redact' }}
+      BENCHMARK_SYNC_ASYNC_RECORDS: ${{ inputs.sync_async_records || '20' }}
+      BENCHMARK_SYNC_ASYNC_ITERATIONS: ${{ inputs.sync_async_iterations || '1' }}
+      BENCHMARK_RUN_SYNC_ASYNC: ${{ inputs.run_sync_async || 'false' }}
+      BENCHMARK_DD_TRACE: ${{ inputs.dd_trace || 'none' }}
 
     steps:
       - name: Checkout benchmark harness
@@ -70,7 +86,7 @@ jobs:
       - name: Checkout benchmark target
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ env.BENCHMARK_REF }}
           path: .benchmark-sut
           fetch-depth: "0"
 
@@ -99,23 +115,23 @@ jobs:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           SYNC_ASYNC_ARGS=()
-          if [ "${{ inputs.run_sync_async }}" = "true" ]; then
+          if [ "$BENCHMARK_RUN_SYNC_ASYNC" = "true" ]; then
             SYNC_ASYNC_ARGS+=(--run-sync-async)
           fi
 
-          TRACE_ARGS=(--dd-trace "${{ inputs.dd_trace }}")
-          if [ "${{ inputs.dd_trace }}" != "none" ]; then
+          TRACE_ARGS=(--dd-trace "$BENCHMARK_DD_TRACE")
+          if [ "$BENCHMARK_DD_TRACE" != "none" ]; then
             TRACE_ARGS+=(--trace-dir benchmark-results/traces)
           fi
 
           .venv/bin/python scripts/benchmark_ci.py \
             --require-api-key \
-            --sut-ref "${{ inputs.ref }}" \
+            --sut-ref "$BENCHMARK_REF" \
             --sut-commit "${{ steps.target.outputs.commit }}" \
-            --num-records "${{ inputs.num_records }}" \
-            --experiments "${{ inputs.experiments }}" \
-            --sync-async-records "${{ inputs.sync_async_records }}" \
-            --sync-async-iterations "${{ inputs.sync_async_iterations }}" \
+            --num-records "$BENCHMARK_NUM_RECORDS" \
+            --experiments "$BENCHMARK_EXPERIMENTS" \
+            --sync-async-records "$BENCHMARK_SYNC_ASYNC_RECORDS" \
+            --sync-async-iterations "$BENCHMARK_SYNC_ASYNC_ITERATIONS" \
             --out benchmark-results/results.json \
             --summary-out benchmark-results/summary.md \
             "${TRACE_ARGS[@]}" \

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Benchmark CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit SHA, branch, or tag to benchmark"
+        required: true
+        default: "main"
+      num_records:
+        description: "Rows for the rewrite preview experiment"
+        required: true
+        default: "1"
+      experiments:
+        description: "Experiments to run"
+        required: true
+        type: choice
+        options:
+          - "all"
+          - "rewrite"
+          - "redact"
+        default: "all"
+      sync_async_records:
+        description: "Rows for the mock sync/async benchmark"
+        required: true
+        default: "20"
+      sync_async_iterations:
+        description: "Iterations for the mock sync/async benchmark"
+        required: true
+        default: "1"
+      run_sync_async:
+        description: "Run the optional mock sync/async benchmark"
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
+      dd_trace:
+        description: "Capture DataDesigner LLM traces"
+        required: true
+        type: choice
+        options:
+          - "none"
+          - "last_message"
+          - "all_messages"
+        default: "none"
+
+permissions:
+  contents: read
+
+env:
+  NEMO_TELEMETRY_ENABLED: "false"
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: [self-hosted, anonymizer-evals]
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout benchmark harness
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
+      - name: Checkout benchmark target
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: .benchmark-sut
+          fetch-depth: "0"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install benchmark target
+        run: |
+          uv venv .venv
+          uv pip install --python .venv/bin/python ./.benchmark-sut
+
+      - name: Resolve benchmark target commit
+        id: target
+        working-directory: .benchmark-sut
+        run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Run benchmark scaffold
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+        run: |
+          SYNC_ASYNC_ARGS=()
+          if [ "${{ inputs.run_sync_async }}" = "true" ]; then
+            SYNC_ASYNC_ARGS+=(--run-sync-async)
+          fi
+
+          TRACE_ARGS=(--dd-trace "${{ inputs.dd_trace }}")
+          if [ "${{ inputs.dd_trace }}" != "none" ]; then
+            TRACE_ARGS+=(--trace-dir benchmark-results/traces)
+          fi
+
+          .venv/bin/python scripts/benchmark_ci.py \
+            --require-api-key \
+            --sut-ref "${{ inputs.ref }}" \
+            --sut-commit "${{ steps.target.outputs.commit }}" \
+            --num-records "${{ inputs.num_records }}" \
+            --experiments "${{ inputs.experiments }}" \
+            --sync-async-records "${{ inputs.sync_async_records }}" \
+            --sync-async-iterations "${{ inputs.sync_async_iterations }}" \
+            --out benchmark-results/results.json \
+            --summary-out benchmark-results/summary.md \
+            "${TRACE_ARGS[@]}" \
+            "${SYNC_ASYNC_ARGS[@]}"
+
+      - name: Add summary
+        if: always()
+        run: |
+          if [ -f benchmark-results/summary.md ]; then
+            cat benchmark-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-results/

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - ".github/workflows/benchmark-ci.yml"
+      - "benchmarks/**"
       - "scripts/benchmark_ci.py"
       - "tests/test_benchmark_ci.py"
   workflow_dispatch:
@@ -17,8 +18,12 @@ on:
         description: "Commit SHA, branch, or tag to benchmark"
         required: true
         default: "main"
+      config:
+        description: "Benchmark config path"
+        required: true
+        default: "benchmarks/configs/smoke.json"
       num_records:
-        description: "Rows for the rewrite preview experiment"
+        description: "Rows for each configured preview experiment"
         required: true
         default: "1"
       experiments:
@@ -70,6 +75,7 @@ jobs:
     timeout-minutes: 60
     env:
       BENCHMARK_REF: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+      BENCHMARK_CONFIG: ${{ inputs.config || 'benchmarks/configs/smoke.json' }}
       BENCHMARK_NUM_RECORDS: ${{ inputs.num_records || '1' }}
       BENCHMARK_EXPERIMENTS: ${{ inputs.experiments || 'redact' }}
       BENCHMARK_SYNC_ASYNC_RECORDS: ${{ inputs.sync_async_records || '20' }}
@@ -126,6 +132,7 @@ jobs:
 
           .venv/bin/python scripts/benchmark_ci.py \
             --require-api-key \
+            --config "$BENCHMARK_CONFIG" \
             --sut-ref "$BENCHMARK_REF" \
             --sut-commit "${{ steps.target.outputs.commit }}" \
             --num-records "$BENCHMARK_NUM_RECORDS" \

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -4,14 +4,6 @@
 name: Benchmark CI
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/benchmark-ci.yml"
-      - "benchmarks/**"
-      - "scripts/benchmark_ci.py"
-      - "tests/test_benchmark_ci.py"
   workflow_dispatch:
     inputs:
       ref:
@@ -70,18 +62,17 @@ env:
 jobs:
   benchmark:
     name: Benchmark
-    if: github.event_name == 'workflow_dispatch' || (github.head_ref == 'andreatgretel/feat/benchmark-ci' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, anonymizer-evals]
     timeout-minutes: 60
     env:
-      BENCHMARK_REF: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
-      BENCHMARK_CONFIG: ${{ inputs.config || 'benchmarks/configs/smoke.json' }}
-      BENCHMARK_NUM_RECORDS: ${{ inputs.num_records || '1' }}
-      BENCHMARK_EXPERIMENTS: ${{ inputs.experiments || 'redact' }}
-      BENCHMARK_SYNC_ASYNC_RECORDS: ${{ inputs.sync_async_records || '20' }}
-      BENCHMARK_SYNC_ASYNC_ITERATIONS: ${{ inputs.sync_async_iterations || '1' }}
-      BENCHMARK_RUN_SYNC_ASYNC: ${{ inputs.run_sync_async || 'false' }}
-      BENCHMARK_DD_TRACE: ${{ inputs.dd_trace || 'none' }}
+      BENCHMARK_REF: ${{ inputs.ref }}
+      BENCHMARK_CONFIG: ${{ inputs.config }}
+      BENCHMARK_NUM_RECORDS: ${{ inputs.num_records }}
+      BENCHMARK_EXPERIMENTS: ${{ inputs.experiments }}
+      BENCHMARK_SYNC_ASYNC_RECORDS: ${{ inputs.sync_async_records }}
+      BENCHMARK_SYNC_ASYNC_ITERATIONS: ${{ inputs.sync_async_iterations }}
+      BENCHMARK_RUN_SYNC_ASYNC: ${{ inputs.run_sync_async }}
+      BENCHMARK_DD_TRACE: ${{ inputs.dd_trace }}
 
     steps:
       - name: Checkout benchmark harness

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ ai/tmp/
 
 # Anonymizer execution artifacts
 .anonymizer-artifacts/
+benchmark-results/
 docs/notebook_source/data/synth_bios_sample10_anonymized.csv
 
 # TLS certs and keys (if any)

--- a/benchmarks/HANDOFF.md
+++ b/benchmarks/HANDOFF.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Benchmark CI handoff
 
 This PR adds the first benchmark CI scaffold for Anonymizer. It is intentionally small: the goal is to prove the Brev self-hosted runner, real provider calls, artifact output, and a config-driven benchmark shape that other people can extend.

--- a/benchmarks/HANDOFF.md
+++ b/benchmarks/HANDOFF.md
@@ -1,0 +1,114 @@
+# Benchmark CI handoff
+
+This PR adds the first benchmark CI scaffold for Anonymizer. It is intentionally small: the goal is to prove the Brev self-hosted runner, real provider calls, artifact output, and a config-driven benchmark shape that other people can extend.
+
+## What exists now
+
+The new workflow is `.github/workflows/benchmark-ci.yml`. It is manual-only through `workflow_dispatch` and runs on the self-hosted runner labels:
+
+```yaml
+runs-on: [self-hosted, anonymizer-evals]
+```
+
+The workflow checks out two copies of the repo:
+
+- the benchmark harness at the workflow commit
+- the target ref under `.benchmark-sut`
+
+It installs the target package into `.venv`, runs `scripts/benchmark_ci.py`, adds a GitHub step summary, and uploads `benchmark-results/` as an artifact.
+
+The benchmark runner now reads JSON configs. The first one is `benchmarks/configs/smoke.json`. It defines one public-safe dataset, `synthetic_bios`, backed by `docs/data/NVIDIA_synthetic_biographies.csv`, and two preview experiments:
+
+- `rewrite_preview`
+- `redact_preview`
+
+Datasets can be local paths or URLs. Every dataset can include a `sha256`; URL datasets must include one. The runner verifies the hash before running and records dataset metadata in `results.json`.
+
+## What the current output tells us
+
+The CI artifact contains:
+
+- `results.json`
+- `summary.md`
+
+The summary includes the target ref, target commit, Anonymizer version, harness commit, config name, config hash, dataset metadata, experiment metrics, and per-model latency.
+
+The last config-driven self-hosted smoke run passed on `redact_preview`:
+
+- duration: about 50s for 1 row
+- failed records: 0
+- model calls: 5
+- GLiNER: about 0.3s mean latency
+- `gpt-oss-120b`: about 16s mean latency, about 25s max
+- endpoint: `https://integrate.api.nvidia.com/v1`
+
+So the smoke benchmark is useful as a real-provider health check and bottleneck detector, but it is not yet a quality benchmark.
+
+## Things we learned
+
+The runner label `anonymizer-evals` is working.
+
+The CI secret `NVIDIA_API_KEY` is available to the benchmark workflow.
+
+Manual dispatch could not be tested from the PR branch because GitHub only exposes new `workflow_dispatch` workflows after the workflow exists on the default branch. We temporarily added a branch-guarded `pull_request` trigger, tested the workflow, then removed that trigger before publishing the PR.
+
+`SyncClientUnavailableError: Sync methods are not available on an async-mode HttpModelClient.` is expected DataDesigner bridge behavior in this path. DD raises it when a sync facade call reaches an async-mode client, catches it in the async custom-column bridge, and falls through to `agenerate()`. The benchmark latency probe now ignores that internal sentinel so it does not look like a model failure.
+
+## How to add another benchmark
+
+Add a dataset and experiment to a config file:
+
+```json
+{
+  "datasets": {
+    "my_dataset": {
+      "path": "docs/data/example.csv",
+      "sha256": "<sha256>",
+      "text_column": "text",
+      "data_summary": "Short dataset description"
+    }
+  },
+  "experiments": [
+    {
+      "name": "redact_my_dataset",
+      "pipeline": "redact",
+      "dataset": "my_dataset",
+      "num_records": 10
+    }
+  ]
+}
+```
+
+For remote data, use `url` instead of `path`. The runner downloads it into `.benchmark-data-cache` and verifies `sha256` before use.
+
+Supported pipeline values today:
+
+- `redact`
+- `rewrite`
+
+The workflow input `experiments` can run `all`, `redact`, or `rewrite`. The `num_records` workflow input overrides each configured experiment's `num_records`, which is useful for quick smoke runs.
+
+## What is not built yet
+
+This PR does not add baselines or regression gates. It only emits current-run metrics.
+
+The next useful pieces are:
+
+1. Add `baseline_ref` and run the same config against target and baseline.
+2. Render a delta report from two `results.json` files.
+3. Add a nightly schedule once baseline comparison exists.
+4. Add annotated fixtures and detection metrics: recall, precision, F1, span accuracy, label accuracy.
+5. Add more datasets through the config path, preferably pinned public-safe data first.
+6. Decide where long-lived benchmark artifacts should live: GitHub artifacts are fine for smoke runs, but S3 or another bucket is better for history.
+7. Eventually split this into a fuller `evals/` harness if RAT-Bench, private datasets, or heavier dependencies become part of the benchmark suite.
+
+## Recommended next commit
+
+Add baseline comparison. Keep it simple:
+
+- add `--baseline-results` or `--baseline-ref`
+- compare aggregate experiment metrics and model latency rows
+- emit `delta.md`
+- upload both raw results and delta
+
+That turns the scaffold from "did the benchmark run" into "what changed." It is the point where nightly runs become genuinely useful.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,6 +2,8 @@
 
 `scripts/benchmark_ci.py` reads benchmark experiments from JSON config files. The smoke config is intentionally small and runs one public-safe dataset through the preview pipelines.
 
+See `benchmarks/HANDOFF.md` for the current implementation status and recommended next steps.
+
 Add a benchmark by adding a dataset and experiment to a config:
 
 ```json

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,28 @@
+# Benchmark configs
+
+`scripts/benchmark_ci.py` reads benchmark experiments from JSON config files. The smoke config is intentionally small and runs one public-safe dataset through the preview pipelines.
+
+Add a benchmark by adding a dataset and experiment to a config:
+
+```json
+{
+  "datasets": {
+    "my_dataset": {
+      "path": "docs/data/example.csv",
+      "sha256": "<sha256>",
+      "text_column": "text",
+      "data_summary": "Short dataset description"
+    }
+  },
+  "experiments": [
+    {
+      "name": "redact_my_dataset",
+      "pipeline": "redact",
+      "dataset": "my_dataset",
+      "num_records": 10
+    }
+  ]
+}
+```
+
+Datasets can use either `path` or `url`. URL datasets must include `sha256`; the runner downloads them into `.benchmark-data-cache` and verifies the hash before running.

--- a/benchmarks/configs/smoke.json
+++ b/benchmarks/configs/smoke.json
@@ -1,0 +1,26 @@
+{
+  "name": "smoke",
+  "description": "Small real-provider benchmark smoke test.",
+  "datasets": {
+    "synthetic_bios": {
+      "path": "docs/data/NVIDIA_synthetic_biographies.csv",
+      "sha256": "407efcb6fdc840562b75875862a4b1231b1e44c832f9ed2913f2243314b002ee",
+      "text_column": "biography",
+      "data_summary": "Biographical profiles"
+    }
+  },
+  "experiments": [
+    {
+      "name": "rewrite_preview",
+      "pipeline": "rewrite",
+      "dataset": "synthetic_bios",
+      "num_records": 1
+    },
+    {
+      "name": "redact_preview",
+      "pipeline": "redact",
+      "dataset": "synthetic_bios",
+      "num_records": 1
+    }
+  ]
+}

--- a/scripts/benchmark_ci.py
+++ b/scripts/benchmark_ci.py
@@ -417,41 +417,51 @@ def model_latency_probe(recorder: ModelLatencyRecorder) -> Iterator[None]:
         start = time.perf_counter()
         response = None
         error = None
+        ignore_record = False
         try:
             response = original_completion(self, *args, **kwargs)
             return response
         except Exception as exc:
+            if type(exc).__name__ == "SyncClientUnavailableError":
+                ignore_record = True
+                raise
             error = f"{type(exc).__name__}: {exc}"
             raise
         finally:
-            recorder.record(
-                self,
-                modality="chat",
-                latency_seconds=time.perf_counter() - start,
-                success=response is not None,
-                usage=getattr(response, "usage", None),
-                error=error,
-            )
+            if not ignore_record:
+                recorder.record(
+                    self,
+                    modality="chat",
+                    latency_seconds=time.perf_counter() - start,
+                    success=response is not None,
+                    usage=getattr(response, "usage", None),
+                    error=error,
+                )
 
     async def acompletion_with_latency(self: Any, *args: Any, **kwargs: Any) -> Any:
         start = time.perf_counter()
         response = None
         error = None
+        ignore_record = False
         try:
             response = await original_acompletion(self, *args, **kwargs)
             return response
         except Exception as exc:
+            if type(exc).__name__ == "SyncClientUnavailableError":
+                ignore_record = True
+                raise
             error = f"{type(exc).__name__}: {exc}"
             raise
         finally:
-            recorder.record(
-                self,
-                modality="chat",
-                latency_seconds=time.perf_counter() - start,
-                success=response is not None,
-                usage=getattr(response, "usage", None),
-                error=error,
-            )
+            if not ignore_record:
+                recorder.record(
+                    self,
+                    modality="chat",
+                    latency_seconds=time.perf_counter() - start,
+                    success=response is not None,
+                    usage=getattr(response, "usage", None),
+                    error=error,
+                )
 
     ModelFacade.completion = completion_with_latency
     ModelFacade.acompletion = acompletion_with_latency

--- a/scripts/benchmark_ci.py
+++ b/scripts/benchmark_ci.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Redact, Rewrite, __version__, configure_logging
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = REPO_ROOT / "docs" / "data" / "NVIDIA_synthetic_biographies.csv"
+SYNC_MEAN_RE = re.compile(r"^\s*sync\s+mean:\s+(?P<seconds>[0-9.]+)s", re.MULTILINE)
+ASYNC_MEAN_RE = re.compile(r"^\s*async\s+mean:\s+(?P<seconds>[0-9.]+)s", re.MULTILINE)
+SPEEDUP_RE = re.compile(r"^\s*speedup:\s+(?P<speedup>[0-9.]+)x", re.MULTILINE)
+
+
+MetricValue = bool | int | float | str | None
+
+
+@dataclass
+class ExperimentResult:
+    name: str
+    status: str
+    duration_seconds: float
+    metrics: dict[str, MetricValue] = field(default_factory=dict)
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelCallRecord:
+    experiment: str | None
+    alias: str
+    model: str
+    provider: str
+    endpoint: str
+    modality: str
+    latency_seconds: float
+    success: bool
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    error: str | None = None
+
+
+class ModelLatencyRecorder:
+    def __init__(self) -> None:
+        self._records: list[ModelCallRecord] = []
+        self._lock = threading.Lock()
+        self._active_experiment: str | None = None
+
+    @contextmanager
+    def experiment(self, name: str) -> Iterator[None]:
+        previous = self._active_experiment
+        self._active_experiment = name
+        try:
+            yield
+        finally:
+            self._active_experiment = previous
+
+    def record(
+        self,
+        model: Any,
+        *,
+        modality: str,
+        latency_seconds: float,
+        success: bool,
+        usage: Any | None = None,
+        error: str | None = None,
+    ) -> None:
+        with self._lock:
+            self._records.append(
+                ModelCallRecord(
+                    experiment=self._active_experiment,
+                    alias=str(getattr(model, "model_alias", "unknown")),
+                    model=str(getattr(model, "model_name", "unknown")),
+                    provider=str(getattr(model, "model_provider_name", "unknown")),
+                    endpoint=str(getattr(getattr(model, "model_provider", None), "endpoint", "unknown")),
+                    modality=modality,
+                    latency_seconds=latency_seconds,
+                    success=success,
+                    input_tokens=getattr(usage, "input_tokens", None),
+                    output_tokens=getattr(usage, "output_tokens", None),
+                    total_tokens=getattr(usage, "total_tokens", None),
+                    error=error,
+                )
+            )
+
+    def records(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [asdict(record) for record in self._records]
+
+    def experiment_metrics(self, experiment: str) -> dict[str, MetricValue]:
+        records = [record for record in self._records if record.experiment == experiment]
+        if not records:
+            return {"model_calls": 0}
+
+        successful = [record for record in records if record.success]
+        if not successful:
+            return {
+                "model_calls": len(records),
+                "model_failures": len(records),
+            }
+
+        durations = [record.latency_seconds for record in successful]
+        slowest = max(successful, key=lambda record: record.latency_seconds)
+        return {
+            "model_calls": len(records),
+            "model_failures": sum(not record.success for record in records),
+            "model_latency_mean_seconds": sum(durations) / len(durations),
+            "model_latency_p50_seconds": percentile(durations, 50),
+            "model_latency_p95_seconds": percentile(durations, 95),
+            "model_latency_max_seconds": slowest.latency_seconds,
+            "slowest_model_alias": slowest.alias,
+            "model_input_tokens": sum_optional(record.input_tokens for record in successful),
+            "model_output_tokens": sum_optional(record.output_tokens for record in successful),
+        }
+
+    def aggregate(self) -> list[dict[str, Any]]:
+        groups: dict[tuple[str | None, str, str, str, str, str], list[ModelCallRecord]] = {}
+        with self._lock:
+            records = list(self._records)
+
+        for record in records:
+            key = (record.experiment, record.alias, record.model, record.provider, record.endpoint, record.modality)
+            groups.setdefault(key, []).append(record)
+
+        summary = []
+        for (experiment, alias, model, provider, endpoint, modality), group in sorted(
+            groups.items(), key=lambda item: tuple(str(part) for part in item[0])
+        ):
+            successful = [record for record in group if record.success]
+            durations = [record.latency_seconds for record in successful]
+            summary.append(
+                {
+                    "experiment": experiment,
+                    "alias": alias,
+                    "model": model,
+                    "provider": provider,
+                    "endpoint": endpoint,
+                    "modality": modality,
+                    "calls": len(group),
+                    "failures": sum(not record.success for record in group),
+                    "mean_seconds": sum(durations) / len(durations) if durations else 0.0,
+                    "p50_seconds": percentile(durations, 50),
+                    "p95_seconds": percentile(durations, 95),
+                    "max_seconds": max(durations) if durations else 0.0,
+                    "input_tokens": sum_optional(record.input_tokens for record in successful),
+                    "output_tokens": sum_optional(record.output_tokens for record in successful),
+                    "total_tokens": sum_optional(record.total_tokens for record in successful),
+                }
+            )
+        return summary
+
+
+def parse_sync_async_output(output: str) -> dict[str, float]:
+    sync_match = SYNC_MEAN_RE.search(output)
+    async_match = ASYNC_MEAN_RE.search(output)
+    speedup_match = SPEEDUP_RE.search(output)
+    if not sync_match or not async_match or not speedup_match:
+        raise ValueError("Could not parse sync/async benchmark output.")
+    return {
+        "sync_mean_seconds": float(sync_match.group("seconds")),
+        "async_mean_seconds": float(async_match.group("seconds")),
+        "speedup": float(speedup_match.group("speedup")),
+    }
+
+
+def build_markdown_summary(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Anonymizer benchmark CI",
+        "",
+        f"- SUT ref: `{payload['meta']['sut_ref']}`",
+        f"- SUT commit: `{payload['meta']['sut_commit']}`",
+        f"- SUT version: `{payload['meta']['sut_version']}`",
+        f"- Harness commit: `{payload['meta']['harness_commit']}`",
+        f"- DD trace: `{payload['meta']['dd_trace']}`",
+        "",
+        "| Experiment | Status | Duration | Key metrics |",
+        "| --- | --- | ---: | --- |",
+    ]
+    for experiment in payload["experiments"]:
+        metric_text = ", ".join(
+            f"{key}={format_metric(value)}" for key, value in experiment["metrics"].items() if value is not None
+        )
+        if experiment.get("reason"):
+            metric_text = experiment["reason"] if not metric_text else f"{metric_text}, reason={experiment['reason']}"
+        lines.append(
+            f"| `{experiment['name']}` | {experiment['status']} | "
+            f"{experiment['duration_seconds']:.2f}s | {metric_text or 'n/a'} |"
+        )
+    lines.append("")
+    if payload.get("model_latency", {}).get("summary"):
+        lines.extend(
+            [
+                "## Model latency",
+                "",
+                "| Experiment | Alias | Model | Provider | Endpoint | Calls | Failures | Mean | P50 | P95 | Max | Tokens |",
+                "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for row in payload["model_latency"]["summary"]:
+            lines.append(
+                f"| `{row['experiment']}` | `{row['alias']}` | `{row['model']}` | `{row['provider']}` | "
+                f"`{row['endpoint']}` | "
+                f"{row['calls']} | {row['failures']} | {row['mean_seconds']:.2f}s | "
+                f"{row['p50_seconds']:.2f}s | "
+                f"{row['p95_seconds']:.2f}s | {row['max_seconds']:.2f}s | {row['total_tokens'] or 'n/a'} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def format_metric(value: MetricValue) -> str:
+    if isinstance(value, float):
+        return f"{value:.4g}"
+    return str(value)
+
+
+def run_rewrite_preview(num_records: int, require_api_key: bool, trace_dir: Path | None) -> ExperimentResult:
+    if not os.getenv("NVIDIA_API_KEY"):
+        reason = "NVIDIA_API_KEY is not set"
+        if require_api_key:
+            raise RuntimeError(reason)
+        return ExperimentResult(name="rewrite_preview", status="skipped", duration_seconds=0.0, reason=reason)
+
+    configure_logging()
+    input_data = AnonymizerInput(
+        source=str(DATA_PATH),
+        text_column="biography",
+        data_summary="Biographical profiles",
+    )
+    config = AnonymizerConfig(rewrite=Rewrite(max_repair_iterations=1))
+
+    start = time.perf_counter()
+    result = Anonymizer().preview(config=config, data=input_data, num_records=num_records)
+    duration = time.perf_counter() - start
+
+    frame = result.dataframe
+    metrics = {
+        "rows": len(frame),
+        "failed_records": len(result.failed_records),
+        "utility_score_mean": mean_column(frame, "utility_score"),
+        "leakage_mass_mean": mean_column(frame, "leakage_mass"),
+        "weighted_leakage_rate_mean": mean_column(frame, "weighted_leakage_rate"),
+        "any_high_leaked": sum_bool_column(frame, "any_high_leaked"),
+        "needs_human_review": sum_bool_column(frame, "needs_human_review"),
+    }
+    metrics.update(trace_metrics(result.trace_dataframe, experiment_name="rewrite_preview", trace_dir=trace_dir))
+    return ExperimentResult(name="rewrite_preview", status="completed", duration_seconds=duration, metrics=metrics)
+
+
+def run_redact_preview(num_records: int, require_api_key: bool, trace_dir: Path | None) -> ExperimentResult:
+    if not os.getenv("NVIDIA_API_KEY"):
+        reason = "NVIDIA_API_KEY is not set"
+        if require_api_key:
+            raise RuntimeError(reason)
+        return ExperimentResult(name="redact_preview", status="skipped", duration_seconds=0.0, reason=reason)
+
+    configure_logging()
+    input_data = AnonymizerInput(
+        source=str(DATA_PATH),
+        text_column="biography",
+        data_summary="Biographical profiles",
+    )
+    config = AnonymizerConfig(replace=Redact())
+
+    start = time.perf_counter()
+    result = Anonymizer().preview(config=config, data=input_data, num_records=num_records)
+    duration = time.perf_counter() - start
+
+    frame = result.dataframe
+    output_column = f"{result.resolved_text_column}_replaced"
+    changed_rows = None
+    if output_column in frame.columns and result.resolved_text_column in frame.columns:
+        changed_rows = int((frame[output_column] != frame[result.resolved_text_column]).sum())
+
+    metrics = {
+        "rows": len(frame),
+        "failed_records": len(result.failed_records),
+        "changed_rows": changed_rows,
+    }
+    metrics.update(trace_metrics(result.trace_dataframe, experiment_name="redact_preview", trace_dir=trace_dir))
+    return ExperimentResult(name="redact_preview", status="completed", duration_seconds=duration, metrics=metrics)
+
+
+def run_sync_async_benchmark(num_records: int, iterations: int, timeout_seconds: int) -> ExperimentResult:
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "benchmark_sync_vs_async.py"),
+        "--num-records",
+        str(num_records),
+        "--iterations",
+        str(iterations),
+    ]
+    start = time.perf_counter()
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"sync/async benchmark timed out after {timeout_seconds}s") from exc
+    duration = time.perf_counter() - start
+    if completed.returncode != 0:
+        tail = completed.stderr[-1000:] or completed.stdout[-1000:]
+        raise RuntimeError(f"sync/async benchmark failed:\n{tail}")
+
+    metrics = parse_sync_async_output(completed.stdout)
+    metrics["records"] = float(num_records)
+    metrics["iterations"] = float(iterations)
+    return ExperimentResult(
+        name="mock_sync_async",
+        status="completed",
+        duration_seconds=duration,
+        metrics=metrics,
+    )
+
+
+def mean_column(frame: Any, column: str) -> float | None:
+    if column not in frame.columns:
+        return None
+    return float(frame[column].mean())
+
+
+def sum_bool_column(frame: Any, column: str) -> int | None:
+    if column not in frame.columns:
+        return None
+    return int(frame[column].fillna(False).astype(bool).sum())
+
+
+def percentile(values: list[float], percentile_value: int) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * percentile_value / 100)
+    return ordered[index]
+
+
+def sum_optional(values: Iterator[int | None]) -> int | None:
+    total = 0
+    found = False
+    for value in values:
+        if value is None:
+            continue
+        total += value
+        found = True
+    return total if found else None
+
+
+def trace_metrics(frame: Any, *, experiment_name: str, trace_dir: Path | None) -> dict[str, MetricValue]:
+    trace_columns = [column for column in frame.columns if str(column).endswith("__trace")]
+    metrics: dict[str, MetricValue] = {"trace_columns": len(trace_columns)}
+    if trace_dir is None:
+        return metrics
+
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    path = trace_dir / f"{experiment_name}.json"
+    frame.to_json(path, orient="records", indent=2, default_handler=str)
+    metrics["trace_dataframe_path"] = str(path)
+    return metrics
+
+
+def git_output(args: list[str]) -> str:
+    completed = subprocess.run(["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=True)
+    return completed.stdout.strip()
+
+
+@contextmanager
+def data_designer_trace(trace_mode: str) -> Iterator[None]:
+    if trace_mode == "none":
+        yield
+        return
+
+    from data_designer.config.utils.trace_type import TraceType
+
+    from anonymizer.engine.ndd.adapter import NddAdapter
+
+    trace_type = TraceType(trace_mode)
+    original = NddAdapter.run_workflow
+
+    def run_workflow_with_trace(self: Any, df: Any, **kwargs: Any) -> Any:
+        kwargs["columns"] = [copy_with_trace(column, trace_type) for column in kwargs["columns"]]
+        return original(self, df, **kwargs)
+
+    NddAdapter.run_workflow = run_workflow_with_trace
+    try:
+        yield
+    finally:
+        NddAdapter.run_workflow = original
+
+
+def copy_with_trace(column: Any, trace_type: Any) -> Any:
+    if hasattr(column, "with_trace") and hasattr(column, "model_copy"):
+        return column.model_copy(update={"with_trace": trace_type})
+    return column
+
+
+@contextmanager
+def model_latency_probe(recorder: ModelLatencyRecorder) -> Iterator[None]:
+    from data_designer.engine.models.facade import ModelFacade
+
+    original_completion = ModelFacade.completion
+    original_acompletion = ModelFacade.acompletion
+
+    def completion_with_latency(self: Any, *args: Any, **kwargs: Any) -> Any:
+        start = time.perf_counter()
+        response = None
+        error = None
+        try:
+            response = original_completion(self, *args, **kwargs)
+            return response
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            recorder.record(
+                self,
+                modality="chat",
+                latency_seconds=time.perf_counter() - start,
+                success=response is not None,
+                usage=getattr(response, "usage", None),
+                error=error,
+            )
+
+    async def acompletion_with_latency(self: Any, *args: Any, **kwargs: Any) -> Any:
+        start = time.perf_counter()
+        response = None
+        error = None
+        try:
+            response = await original_acompletion(self, *args, **kwargs)
+            return response
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            recorder.record(
+                self,
+                modality="chat",
+                latency_seconds=time.perf_counter() - start,
+                success=response is not None,
+                usage=getattr(response, "usage", None),
+                error=error,
+            )
+
+    ModelFacade.completion = completion_with_latency
+    ModelFacade.acompletion = acompletion_with_latency
+    try:
+        yield
+    finally:
+        ModelFacade.completion = original_completion
+        ModelFacade.acompletion = original_acompletion
+
+
+def capture_experiment(
+    name: str,
+    runner: Callable[[], ExperimentResult],
+    recorder: ModelLatencyRecorder,
+) -> ExperimentResult:
+    start = time.perf_counter()
+    with recorder.experiment(name):
+        try:
+            result = runner()
+        except Exception as exc:
+            result = ExperimentResult(
+                name=name,
+                status="failed",
+                duration_seconds=time.perf_counter() - start,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+    result.metrics.update(recorder.experiment_metrics(name))
+    return result
+
+
+def build_payload(args: argparse.Namespace, recorder: ModelLatencyRecorder) -> dict[str, Any]:
+    started_at = datetime.now(UTC)
+    experiments = []
+    if args.experiments in {"all", "rewrite"}:
+        experiments.append(
+            capture_experiment(
+                "rewrite_preview",
+                lambda: run_rewrite_preview(
+                    num_records=args.num_records,
+                    require_api_key=args.require_api_key,
+                    trace_dir=args.trace_dir,
+                ),
+                recorder,
+            )
+        )
+    if args.experiments in {"all", "redact"}:
+        experiments.append(
+            capture_experiment(
+                "redact_preview",
+                lambda: run_redact_preview(
+                    num_records=args.num_records,
+                    require_api_key=args.require_api_key,
+                    trace_dir=args.trace_dir,
+                ),
+                recorder,
+            )
+        )
+    if args.run_sync_async:
+        experiments.append(
+            capture_experiment(
+                "mock_sync_async",
+                lambda: run_sync_async_benchmark(
+                    num_records=args.sync_async_records,
+                    iterations=args.sync_async_iterations,
+                    timeout_seconds=args.sync_async_timeout_seconds,
+                ),
+                recorder,
+            )
+        )
+    status = "failed" if any(experiment.status == "failed" for experiment in experiments) else "completed"
+    return {
+        "meta": {
+            "started_at": started_at.isoformat(),
+            "finished_at": datetime.now(UTC).isoformat(),
+            "sut_ref": args.sut_ref,
+            "sut_commit": args.sut_commit,
+            "sut_version": __version__,
+            "harness_commit": git_output(["rev-parse", "HEAD"]),
+            "python": sys.version.split()[0],
+            "status": status,
+            "dd_trace": args.dd_trace,
+            "experiments": args.experiments,
+        },
+        "experiments": [asdict(experiment) for experiment in experiments],
+        "model_latency": {
+            "summary": recorder.aggregate(),
+            "calls": recorder.records(),
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the benchmark CI scaffold.")
+    parser.add_argument("--num-records", type=int, default=3)
+    parser.add_argument("--experiments", choices=["all", "rewrite", "redact"], default="all")
+    parser.add_argument("--run-sync-async", action="store_true")
+    parser.add_argument("--sync-async-records", type=int, default=20)
+    parser.add_argument("--sync-async-iterations", type=int, default=1)
+    parser.add_argument("--sync-async-timeout-seconds", type=int, default=120)
+    parser.add_argument("--sut-ref", default="HEAD")
+    parser.add_argument("--sut-commit", default="HEAD")
+    parser.add_argument("--out", type=Path, default=Path("benchmark-results/results.json"))
+    parser.add_argument("--summary-out", type=Path, default=Path("benchmark-results/summary.md"))
+    parser.add_argument("--trace-dir", type=Path, default=None)
+    parser.add_argument("--dd-trace", choices=["none", "last_message", "all_messages"], default="none")
+    parser.add_argument("--require-api-key", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    recorder = ModelLatencyRecorder()
+    with data_designer_trace(args.dd_trace), model_latency_probe(recorder):
+        payload = build_payload(args, recorder)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    args.summary_out.write_text(build_markdown_summary(payload))
+    if payload["meta"]["status"] == "failed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_ci.py
+++ b/scripts/benchmark_ci.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import hashlib
 import json
 import os
 import re
@@ -12,6 +14,8 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.parse
+import urllib.request
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
@@ -22,7 +26,7 @@ from typing import Any
 from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Redact, Rewrite, __version__, configure_logging
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DATA_PATH = REPO_ROOT / "docs" / "data" / "NVIDIA_synthetic_biographies.csv"
+DEFAULT_CONFIG_PATH = REPO_ROOT / "benchmarks" / "configs" / "smoke.json"
 SYNC_MEAN_RE = re.compile(r"^\s*sync\s+mean:\s+(?P<seconds>[0-9.]+)s", re.MULTILINE)
 ASYNC_MEAN_RE = re.compile(r"^\s*async\s+mean:\s+(?P<seconds>[0-9.]+)s", re.MULTILINE)
 SPEEDUP_RE = re.compile(r"^\s*speedup:\s+(?P<speedup>[0-9.]+)x", re.MULTILINE)
@@ -38,6 +42,28 @@ class ExperimentResult:
     duration_seconds: float
     metrics: dict[str, MetricValue] = field(default_factory=dict)
     reason: str | None = None
+
+
+@dataclass(frozen=True)
+class DatasetInput:
+    name: str
+    path: Path
+    source: str
+    text_column: str
+    data_summary: str
+    sha256: str
+    rows: int | None
+
+    def metadata(self) -> dict[str, MetricValue]:
+        return {
+            "name": self.name,
+            "source": self.source,
+            "path": str(self.path),
+            "text_column": self.text_column,
+            "data_summary": self.data_summary,
+            "sha256": self.sha256,
+            "rows": self.rows,
+        }
 
 
 @dataclass(frozen=True)
@@ -187,6 +213,8 @@ def build_markdown_summary(payload: dict[str, Any]) -> str:
         f"- SUT commit: `{payload['meta']['sut_commit']}`",
         f"- SUT version: `{payload['meta']['sut_version']}`",
         f"- Harness commit: `{payload['meta']['harness_commit']}`",
+        f"- Config: `{payload['meta'].get('config_name', 'n/a')}`",
+        f"- Config hash: `{payload['meta'].get('config_sha256', 'n/a')}`",
         f"- DD trace: `{payload['meta']['dd_trace']}`",
         "",
         "| Experiment | Status | Duration | Key metrics |",
@@ -203,6 +231,21 @@ def build_markdown_summary(payload: dict[str, Any]) -> str:
             f"{experiment['duration_seconds']:.2f}s | {metric_text or 'n/a'} |"
         )
     lines.append("")
+    if payload.get("datasets"):
+        lines.extend(
+            [
+                "## Datasets",
+                "",
+                "| Name | Rows | Text column | SHA-256 | Source |",
+                "| --- | ---: | --- | --- | --- |",
+            ]
+        )
+        for dataset in payload["datasets"]:
+            lines.append(
+                f"| `{dataset['name']}` | {dataset['rows'] or 'n/a'} | `{dataset['text_column']}` | "
+                f"`{str(dataset['sha256'])[:12]}` | `{dataset['source']}` |"
+            )
+        lines.append("")
     if payload.get("model_latency", {}).get("summary"):
         lines.extend(
             [
@@ -230,20 +273,137 @@ def format_metric(value: MetricValue) -> str:
     return str(value)
 
 
-def run_rewrite_preview(num_records: int, require_api_key: bool, trace_dir: Path | None) -> ExperimentResult:
+def load_benchmark_config(path: Path) -> dict[str, Any]:
+    config = json.loads(path.read_text())
+    validate_benchmark_config(config)
+    return config
+
+
+def validate_benchmark_config(config: dict[str, Any]) -> None:
+    if not isinstance(config, dict):
+        raise ValueError("Benchmark config must be an object.")
+    if not isinstance(config.get("datasets"), dict) or not config["datasets"]:
+        raise ValueError("Benchmark config must define at least one dataset.")
+    if not isinstance(config.get("experiments"), list) or not config["experiments"]:
+        raise ValueError("Benchmark config must define at least one experiment.")
+
+    for name, dataset in config["datasets"].items():
+        if not isinstance(dataset, dict):
+            raise ValueError(f"Dataset {name!r} must be an object.")
+        has_path = bool(dataset.get("path"))
+        has_url = bool(dataset.get("url"))
+        if has_path == has_url:
+            raise ValueError(f"Dataset {name!r} must define exactly one of path or url.")
+        if has_url and not dataset.get("sha256"):
+            raise ValueError(f"Remote dataset {name!r} must define sha256.")
+        for key in ("text_column", "data_summary"):
+            if not dataset.get(key):
+                raise ValueError(f"Dataset {name!r} must define {key}.")
+
+    dataset_names = set(config["datasets"])
+    for experiment in config["experiments"]:
+        if not isinstance(experiment, dict):
+            raise ValueError("Benchmark experiments must be objects.")
+        for key in ("name", "pipeline", "dataset"):
+            if not experiment.get(key):
+                raise ValueError(f"Benchmark experiment must define {key}.")
+        if experiment["pipeline"] not in {"redact", "rewrite"}:
+            raise ValueError(f"Unsupported pipeline {experiment['pipeline']!r}.")
+        if experiment["dataset"] not in dataset_names:
+            raise ValueError(f"Unknown dataset {experiment['dataset']!r}.")
+
+
+def select_experiment_specs(config: dict[str, Any], experiment_filter: str) -> list[dict[str, Any]]:
+    experiments = config["experiments"]
+    if experiment_filter == "all":
+        return list(experiments)
+    return [experiment for experiment in experiments if experiment["pipeline"] == experiment_filter]
+
+
+def resolve_benchmark_datasets(config: dict[str, Any], cache_dir: Path) -> dict[str, DatasetInput]:
+    return {
+        name: resolve_dataset(name=name, spec=spec, cache_dir=cache_dir)
+        for name, spec in sorted(config["datasets"].items())
+    }
+
+
+def resolve_dataset(name: str, spec: dict[str, Any], cache_dir: Path) -> DatasetInput:
+    if spec.get("url"):
+        path = download_dataset(name=name, url=str(spec["url"]), sha256=str(spec["sha256"]), cache_dir=cache_dir)
+        source = str(spec["url"])
+    else:
+        path = resolve_repo_path(str(spec["path"]))
+        source = str(spec["path"])
+
+    expected_sha256 = spec.get("sha256")
+    actual_sha256 = file_sha256(path)
+    if expected_sha256 and actual_sha256 != expected_sha256:
+        raise ValueError(f"Dataset {name!r} SHA-256 mismatch: expected {expected_sha256}, got {actual_sha256}.")
+
+    return DatasetInput(
+        name=name,
+        path=path,
+        source=source,
+        text_column=str(spec["text_column"]),
+        data_summary=str(spec["data_summary"]),
+        sha256=actual_sha256,
+        rows=count_csv_rows(path) if path.suffix == ".csv" else None,
+    )
+
+
+def resolve_repo_path(path: str) -> Path:
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = REPO_ROOT / resolved
+    if not resolved.exists():
+        raise FileNotFoundError(f"Dataset file does not exist: {resolved}")
+    return resolved
+
+
+def download_dataset(name: str, url: str, sha256: str, cache_dir: Path) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    suffix = Path(urllib.parse.urlparse(url).path).suffix or ".data"
+    path = cache_dir / f"{name}-{sha256[:12]}{suffix}"
+    if not path.exists():
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def count_csv_rows(path: Path) -> int:
+    with path.open(newline="") as handle:
+        return sum(1 for _ in csv.DictReader(handle))
+
+
+def run_preview_experiment(
+    *,
+    name: str,
+    pipeline: str,
+    dataset: DatasetInput,
+    num_records: int,
+    require_api_key: bool,
+    trace_dir: Path | None,
+) -> ExperimentResult:
     if not os.getenv("NVIDIA_API_KEY"):
         reason = "NVIDIA_API_KEY is not set"
         if require_api_key:
             raise RuntimeError(reason)
-        return ExperimentResult(name="rewrite_preview", status="skipped", duration_seconds=0.0, reason=reason)
+        return ExperimentResult(name=name, status="skipped", duration_seconds=0.0, reason=reason)
 
     configure_logging()
     input_data = AnonymizerInput(
-        source=str(DATA_PATH),
-        text_column="biography",
-        data_summary="Biographical profiles",
+        source=str(dataset.path),
+        text_column=dataset.text_column,
+        data_summary=dataset.data_summary,
     )
-    config = AnonymizerConfig(rewrite=Rewrite(max_repair_iterations=1))
+    config = build_anonymizer_config(pipeline)
 
     start = time.perf_counter()
     result = Anonymizer().preview(config=config, data=input_data, num_records=num_records)
@@ -251,50 +411,36 @@ def run_rewrite_preview(num_records: int, require_api_key: bool, trace_dir: Path
 
     frame = result.dataframe
     metrics = {
+        "dataset": dataset.name,
         "rows": len(frame),
         "failed_records": len(result.failed_records),
-        "utility_score_mean": mean_column(frame, "utility_score"),
-        "leakage_mass_mean": mean_column(frame, "leakage_mass"),
-        "weighted_leakage_rate_mean": mean_column(frame, "weighted_leakage_rate"),
-        "any_high_leaked": sum_bool_column(frame, "any_high_leaked"),
-        "needs_human_review": sum_bool_column(frame, "needs_human_review"),
     }
-    metrics.update(trace_metrics(result.trace_dataframe, experiment_name="rewrite_preview", trace_dir=trace_dir))
-    return ExperimentResult(name="rewrite_preview", status="completed", duration_seconds=duration, metrics=metrics)
+    if pipeline == "rewrite":
+        metrics.update(
+            {
+                "utility_score_mean": mean_column(frame, "utility_score"),
+                "leakage_mass_mean": mean_column(frame, "leakage_mass"),
+                "weighted_leakage_rate_mean": mean_column(frame, "weighted_leakage_rate"),
+                "any_high_leaked": sum_bool_column(frame, "any_high_leaked"),
+                "needs_human_review": sum_bool_column(frame, "needs_human_review"),
+            }
+        )
+    else:
+        output_column = f"{result.resolved_text_column}_replaced"
+        changed_rows = None
+        if output_column in frame.columns and result.resolved_text_column in frame.columns:
+            changed_rows = int((frame[output_column] != frame[result.resolved_text_column]).sum())
+        metrics["changed_rows"] = changed_rows
+    metrics.update(trace_metrics(result.trace_dataframe, experiment_name=name, trace_dir=trace_dir))
+    return ExperimentResult(name=name, status="completed", duration_seconds=duration, metrics=metrics)
 
 
-def run_redact_preview(num_records: int, require_api_key: bool, trace_dir: Path | None) -> ExperimentResult:
-    if not os.getenv("NVIDIA_API_KEY"):
-        reason = "NVIDIA_API_KEY is not set"
-        if require_api_key:
-            raise RuntimeError(reason)
-        return ExperimentResult(name="redact_preview", status="skipped", duration_seconds=0.0, reason=reason)
-
-    configure_logging()
-    input_data = AnonymizerInput(
-        source=str(DATA_PATH),
-        text_column="biography",
-        data_summary="Biographical profiles",
-    )
-    config = AnonymizerConfig(replace=Redact())
-
-    start = time.perf_counter()
-    result = Anonymizer().preview(config=config, data=input_data, num_records=num_records)
-    duration = time.perf_counter() - start
-
-    frame = result.dataframe
-    output_column = f"{result.resolved_text_column}_replaced"
-    changed_rows = None
-    if output_column in frame.columns and result.resolved_text_column in frame.columns:
-        changed_rows = int((frame[output_column] != frame[result.resolved_text_column]).sum())
-
-    metrics = {
-        "rows": len(frame),
-        "failed_records": len(result.failed_records),
-        "changed_rows": changed_rows,
-    }
-    metrics.update(trace_metrics(result.trace_dataframe, experiment_name="redact_preview", trace_dir=trace_dir))
-    return ExperimentResult(name="redact_preview", status="completed", duration_seconds=duration, metrics=metrics)
+def build_anonymizer_config(pipeline: str) -> AnonymizerConfig:
+    if pipeline == "rewrite":
+        return AnonymizerConfig(rewrite=Rewrite(max_repair_iterations=1))
+    if pipeline == "redact":
+        return AnonymizerConfig(replace=Redact())
+    raise ValueError(f"Unsupported pipeline {pipeline!r}.")
 
 
 def run_sync_async_benchmark(num_records: int, iterations: int, timeout_seconds: int) -> ExperimentResult:
@@ -494,27 +640,29 @@ def capture_experiment(
 
 def build_payload(args: argparse.Namespace, recorder: ModelLatencyRecorder) -> dict[str, Any]:
     started_at = datetime.now(UTC)
+    config = load_benchmark_config(args.config)
+    datasets = resolve_benchmark_datasets(config, args.data_cache_dir)
     experiments = []
-    if args.experiments in {"all", "rewrite"}:
+    experiment_specs = select_experiment_specs(config, args.experiments)
+    if not experiment_specs and not args.run_sync_async:
+        raise ValueError(f"No experiments matched filter {args.experiments!r}.")
+
+    for experiment in experiment_specs:
+        num_records = args.num_records if args.num_records is not None else int(experiment.get("num_records", 1))
+        dataset = datasets[experiment["dataset"]]
+        name = str(experiment["name"])
         experiments.append(
             capture_experiment(
-                "rewrite_preview",
-                lambda: run_rewrite_preview(
-                    num_records=args.num_records,
-                    require_api_key=args.require_api_key,
-                    trace_dir=args.trace_dir,
-                ),
-                recorder,
-            )
-        )
-    if args.experiments in {"all", "redact"}:
-        experiments.append(
-            capture_experiment(
-                "redact_preview",
-                lambda: run_redact_preview(
-                    num_records=args.num_records,
-                    require_api_key=args.require_api_key,
-                    trace_dir=args.trace_dir,
+                name,
+                lambda experiment=experiment, dataset=dataset, name=name, num_records=num_records: (
+                    run_preview_experiment(
+                        name=name,
+                        pipeline=str(experiment["pipeline"]),
+                        dataset=dataset,
+                        num_records=num_records,
+                        require_api_key=args.require_api_key,
+                        trace_dir=args.trace_dir,
+                    )
                 ),
                 recorder,
             )
@@ -542,9 +690,13 @@ def build_payload(args: argparse.Namespace, recorder: ModelLatencyRecorder) -> d
             "harness_commit": git_output(["rev-parse", "HEAD"]),
             "python": sys.version.split()[0],
             "status": status,
+            "config_path": str(args.config),
+            "config_name": str(config.get("name", args.config.stem)),
+            "config_sha256": file_sha256(args.config),
             "dd_trace": args.dd_trace,
             "experiments": args.experiments,
         },
+        "datasets": [dataset.metadata() for dataset in datasets.values()],
         "experiments": [asdict(experiment) for experiment in experiments],
         "model_latency": {
             "summary": recorder.aggregate(),
@@ -555,7 +707,9 @@ def build_payload(args: argparse.Namespace, recorder: ModelLatencyRecorder) -> d
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the benchmark CI scaffold.")
-    parser.add_argument("--num-records", type=int, default=3)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--data-cache-dir", type=Path, default=Path(".benchmark-data-cache"))
+    parser.add_argument("--num-records", type=int, default=None)
     parser.add_argument("--experiments", choices=["all", "rewrite", "redact"], default="all")
     parser.add_argument("--run-sync-async", action="store_true")
     parser.add_argument("--sync-async-records", type=int, default=20)

--- a/tests/test_benchmark_ci.py
+++ b/tests/test_benchmark_ci.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location("benchmark_ci", REPO_ROOT / "scripts" / "benchmark_ci.py")
 assert SPEC is not None
@@ -82,3 +84,21 @@ def test_model_latency_recorder_separates_failures() -> None:
         "model_output_tokens": 4,
     }
     assert recorder.aggregate()[0]["failures"] == 1
+
+
+def test_model_latency_probe_ignores_async_bridge_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    from data_designer.engine.models.clients.errors import SyncClientUnavailableError
+    from data_designer.engine.models.facade import ModelFacade
+
+    def raise_sentinel(self: object, *args: object, **kwargs: object) -> None:
+        raise SyncClientUnavailableError("sentinel")
+
+    monkeypatch.setattr(ModelFacade, "completion", raise_sentinel)
+    recorder = benchmark_ci.ModelLatencyRecorder()
+
+    with recorder.experiment("experiment"), benchmark_ci.model_latency_probe(recorder):
+        with pytest.raises(SyncClientUnavailableError):
+            ModelFacade.completion(object())
+
+    assert recorder.experiment_metrics("experiment") == {"model_calls": 0}
+    assert recorder.aggregate() == []

--- a/tests/test_benchmark_ci.py
+++ b/tests/test_benchmark_ci.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("benchmark_ci", REPO_ROOT / "scripts" / "benchmark_ci.py")
+assert SPEC is not None
+benchmark_ci = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = benchmark_ci
+SPEC.loader.exec_module(benchmark_ci)
+
+
+def test_parse_sync_async_output() -> None:
+    output = """
+      sync  mean: 1.234s
+      async mean: 0.456s
+      speedup:    2.71x
+    """
+
+    assert benchmark_ci.parse_sync_async_output(output) == {
+        "sync_mean_seconds": 1.234,
+        "async_mean_seconds": 0.456,
+        "speedup": 2.71,
+    }
+
+
+def test_build_markdown_summary() -> None:
+    summary = benchmark_ci.build_markdown_summary(
+        {
+            "meta": {
+                "sut_ref": "abc123",
+                "sut_commit": "abc123",
+                "sut_version": "0.1.0",
+                "harness_commit": "def456",
+                "dd_trace": "none",
+            },
+            "experiments": [
+                {
+                    "name": "rewrite_preview",
+                    "status": "completed",
+                    "duration_seconds": 1.25,
+                    "metrics": {"rows": 3, "utility_score_mean": 0.9},
+                }
+            ],
+        }
+    )
+
+    assert "SUT ref: `abc123`" in summary
+    assert "| `rewrite_preview` | completed | 1.25s | rows=3, utility_score_mean=0.9 |" in summary
+
+
+def test_model_latency_recorder_separates_failures() -> None:
+    recorder = benchmark_ci.ModelLatencyRecorder()
+    model = SimpleNamespace(model_alias="alias", model_name="model", model_provider_name="provider")
+
+    with recorder.experiment("experiment"):
+        recorder.record(
+            model,
+            modality="chat",
+            latency_seconds=2.0,
+            success=True,
+            usage=SimpleNamespace(input_tokens=3, output_tokens=4, total_tokens=7),
+        )
+        recorder.record(model, modality="chat", latency_seconds=0.1, success=False)
+
+    assert recorder.experiment_metrics("experiment") == {
+        "model_calls": 2,
+        "model_failures": 1,
+        "model_latency_mean_seconds": 2.0,
+        "model_latency_p50_seconds": 2.0,
+        "model_latency_p95_seconds": 2.0,
+        "model_latency_max_seconds": 2.0,
+        "slowest_model_alias": "alias",
+        "model_input_tokens": 3,
+        "model_output_tokens": 4,
+    }
+    assert recorder.aggregate()[0]["failures"] == 1

--- a/tests/test_benchmark_ci.py
+++ b/tests/test_benchmark_ci.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from data_designer.engine.models.clients.errors import SyncClientUnavailableError
+from data_designer.engine.models.facade import ModelFacade
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location("benchmark_ci", REPO_ROOT / "scripts" / "benchmark_ci.py")
@@ -87,9 +90,6 @@ def test_model_latency_recorder_separates_failures() -> None:
 
 
 def test_model_latency_probe_ignores_async_bridge_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
-    from data_designer.engine.models.clients.errors import SyncClientUnavailableError
-    from data_designer.engine.models.facade import ModelFacade
-
     def raise_sentinel(self: object, *args: object, **kwargs: object) -> None:
         raise SyncClientUnavailableError("sentinel")
 
@@ -102,3 +102,54 @@ def test_model_latency_probe_ignores_async_bridge_sentinel(monkeypatch: pytest.M
 
     assert recorder.experiment_metrics("experiment") == {"model_calls": 0}
     assert recorder.aggregate() == []
+
+
+def test_load_config_and_resolve_local_dataset(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("text\nhello\nworld\n")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "datasets": {
+                    "sample": {
+                        "path": str(data_path),
+                        "sha256": benchmark_ci.file_sha256(data_path),
+                        "text_column": "text",
+                        "data_summary": "Sample rows",
+                    }
+                },
+                "experiments": [
+                    {
+                        "name": "redact_sample",
+                        "pipeline": "redact",
+                        "dataset": "sample",
+                    }
+                ],
+            }
+        )
+    )
+
+    config = benchmark_ci.load_benchmark_config(config_path)
+    datasets = benchmark_ci.resolve_benchmark_datasets(config, tmp_path / "cache")
+
+    assert benchmark_ci.select_experiment_specs(config, "redact")[0]["name"] == "redact_sample"
+    assert datasets["sample"].rows == 2
+    assert datasets["sample"].metadata()["text_column"] == "text"
+
+
+def test_resolve_dataset_rejects_bad_hash(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("text\nhello\n")
+
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        benchmark_ci.resolve_dataset(
+            name="sample",
+            spec={
+                "path": str(data_path),
+                "sha256": "0" * 64,
+                "text_column": "text",
+                "data_summary": "Sample rows",
+            },
+            cache_dir=tmp_path / "cache",
+        )


### PR DESCRIPTION
## Summary
Adds a manually-triggered benchmark CI scaffold for the self-hosted `anonymizer-evals` runner. The workflow can benchmark any commit/ref, run rewrite and/or redact smoke experiments, capture model latency by alias/model/provider/endpoint, optionally save DataDesigner LLM traces, and upload JSON/Markdown artifacts.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

Additional validation run locally:
- `.venv/bin/ruff check --fix .`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check scripts/benchmark_ci.py tests/test_benchmark_ci.py`
- `.venv/bin/ruff format --check scripts/benchmark_ci.py tests/test_benchmark_ci.py`
- `.venv/bin/pytest tests/test_benchmark_ci.py`
- workflow YAML parse check
- `git diff --check`
- local no-secret scaffold smoke
- local real 1-row benchmark smokes using `/home/ubuntu/Code/.env` keys for `all` and `redact`

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->
