### PR TITLE
feat: Make anonymizer evaluation mode-independent

### DIFF
--- a/docs/notebooks/evaluate-replace-demo.ipynb
+++ b/docs/notebooks/evaluate-replace-demo.ipynb
@@ -4,20 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# evaluate_replace demo\n",
+    "# evaluate demo\n",
     "\n",
     "A clean walkthrough of the new two-step anonymization workflow:\n",
     "\n",
-    "1. `anonymizer.preview(...)` (or `.run(...)`) does **detection + replacement only** — no LLM judges, no evaluation cost.\n",
-    "2. `anonymizer.evaluate_replace(...)` is a **separate, opt-in** call that scores the result with four LLM-as-judge metrics:\n",
-    "   - **Detection Validity** — were the detected entities correct?\n",
-    "   - **Type Fidelity** — does each synthetic preserve the entity class/format? *(Substitute only)*\n",
-    "   - **Relational Consistency** — do cross-entity relationships stay coherent? *(Substitute only)*\n",
-    "   - **Attribute Fidelity** — do salient within-entity attributes (gender, age bucket) survive? *(Substitute only)*\n",
+    "1. `anonymizer.preview(...)` (or `.run(...)`) does **detection + replacement only** \u2014 no LLM judges, no evaluation cost.\n",
+    "2. `anonymizer.evaluate(...)` is a **separate, opt-in** call that scores the result with four LLM-as-judge metrics:\n",
+    "   - **Detection Validity** \u2014 were the detected entities correct?\n",
+    "   - **Type Fidelity** \u2014 does each synthetic preserve the entity class/format? *(Substitute only)*\n",
+    "   - **Relational Consistency** \u2014 do cross-entity relationships stay coherent? *(Substitute only)*\n",
+    "   - **Attribute Fidelity** \u2014 do salient within-entity attributes (gender, age bucket) survive? *(Substitute only)*\n",
     "\n",
-    "For non-Substitute strategies (Annotate / Redact / Hash), only Detection Validity runs — the other three need a replacement map.\n",
+    "For non-Substitute strategies (Annotate / Redact / Hash), only Detection Validity runs \u2014 the other three need a replacement map.\n",
     "\n",
-    "The split lets you iterate on judge prompts/models without re-running the (expensive) detection + replacement step every time."
+    "The split lets you iterate on judge prompts/models without re-running the (expensive) detection + replacement step every time.\n",
+    "\n",
+    "`EvaluateConfig` mirrors `AnonymizerConfig` \u2014 pass the same mode object (e.g. `replace=Substitute()`) that produced the result. Once rewrite-side evaluation lands, it'll live in the same config as `EvaluateConfig(rewrite=...)`."
    ]
   },
   {
@@ -101,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Redact, Substitute"
+    "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, EvaluateConfig, Redact, Substitute"
    ]
   },
   {
@@ -150,7 +152,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 1 — Anonymize (detection + replacement only)\n",
+    "## Step 1 \u2014 Anonymize (detection + replacement only)\n",
     "\n",
     "This step runs the GLiNER detector, validation / augmentation, and (for Substitute) the LLM that generates the replacement map. **No evaluation judges fire here**, so this is the cheap step you can iterate on freely."
    ]
@@ -176,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Render one record — replaced text, entity highlights, replacement table.\n",
+    "# Render one record \u2014 replaced text, entity highlights, replacement table.\n",
     "# No LLM judgee yet because we haven't evaluated.\n",
     "substitute_preview.display_record(0)"
    ]
@@ -185,11 +187,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 2 — Evaluate replacement quality\n",
+    "## Step 2 \u2014 Evaluate replacement quality\n",
     "\n",
-    "`evaluate_replace` runs the four judges as columns of a **single DataDesigner workflow**, scheduled in parallel by DD (bounded by each model's `max_parallel_requests`). The text-column name is read automatically from the preview/run result — you don't pass it again.\n",
+    "`anonymizer.evaluate(config=EvaluateConfig(replace=...), result=...)` runs the four judges as columns of a **single DataDesigner workflow**, scheduled in parallel by DD (bounded by each model's `max_parallel_requests`). The text-column name is read automatically from the preview/run result \u2014 you don't pass it again.\n",
     "\n",
-    "Pass either a `PreviewResult` or an `AnonymizerResult`; both carry the trace dataframe and `resolved_text_column`."
+    "Pass either a `PreviewResult` or an `AnonymizerResult` as `result`; both carry the trace dataframe and `resolved_text_column`. `EvaluateConfig` takes the same `replace=` mode object you used to produce the result."
    ]
   },
   {
@@ -198,8 +200,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluated = anonymizer.evaluate_replace(\n",
-    "    config=substitute_config,\n",
+    "evaluated = anonymizer.evaluate(\n",
+    "    config=EvaluateConfig(replace=substitute_config.replace),\n",
     "    result=substitute_preview,\n",
     ")"
    ]
@@ -253,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Drill into one of the lists — e.g., which entities the detection judge flagged as invalid.\n",
+    "# Drill into one of the lists \u2014 e.g., which entities the detection judge flagged as invalid.\n",
     "evaluated.trace_dataframe[\"detection_invalid_entities\"].iloc[0]"
    ]
   },
@@ -261,7 +263,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save + reload pattern — iterate on evaluations without re-running detection/replacement\n",
+    "## Save + reload pattern \u2014 iterate on evaluations without re-running detection/replacement\n",
     "\n",
     "Pickle preserves the full result object (trace dataframe + `resolved_text_column`). Reloading and re-evaluating skips the (expensive) preview step entirely."
    ]
@@ -283,9 +285,9 @@
     "with cache_path.open(\"rb\") as f:\n",
     "    loaded_preview = pickle.load(f)\n",
     "\n",
-    "# Re-evaluate from the loaded result — same API, no detection/replacement re-run.\n",
-    "re_evaluated = anonymizer.evaluate_replace(\n",
-    "    config=substitute_config,\n",
+    "# Re-evaluate from the loaded result \u2014 same API, no detection/replacement re-run.\n",
+    "re_evaluated = anonymizer.evaluate(\n",
+    "    config=EvaluateConfig(replace=substitute_config.replace),\n",
     "    result=loaded_preview,\n",
     ")\n",
     "re_evaluated.display_record(0)"
@@ -295,9 +297,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Non-Substitute strategies — only Detection Validity is computed\n",
+    "## Non-Substitute strategies \u2014 only Detection Validity is computed\n",
     "\n",
-    "For Annotate / Redact / Hash there is no replacement map, so the type / relational / attribute judges have nothing to evaluate. `evaluate_replace` skips them and runs only the Detection-Validity judge."
+    "For Annotate / Redact / Hash there is no replacement map, so the type / relational / attribute judges have nothing to evaluate. `evaluate` skips them and runs only the Detection-Validity judge."
    ]
   },
   {
@@ -314,8 +316,8 @@
     "    num_records=15,\n",
     ")\n",
     "\n",
-    "redact_evaluated = anonymizer.evaluate_replace(\n",
-    "    config=redact_config,\n",
+    "redact_evaluated = anonymizer.evaluate(\n",
+    "    config=EvaluateConfig(replace=redact_config.replace),\n",
     "    result=redact_preview,\n",
     ")\n",
     "redact_evaluated.display_record(0)"

--- a/docs/notebooks/evaluate-replace-demo.ipynb
+++ b/docs/notebooks/evaluate-replace-demo.ipynb
@@ -9,7 +9,7 @@
     "A clean walkthrough of the new two-step anonymization workflow:\n",
     "\n",
     "1. `anonymizer.preview(...)` (or `.run(...)`) does **detection + replacement only** \u2014 no LLM judges, no evaluation cost.\n",
-    "2. `anonymizer.evaluate(...)` is a **separate, opt-in** call that scores the result with four LLM-as-judge metrics:\n",
+    "2. `anonymizer.evaluate(preview)` is a **separate, opt-in** call that scores the result with four LLM-as-judge metrics:\n",
     "   - **Detection Validity** \u2014 were the detected entities correct?\n",
     "   - **Type Fidelity** \u2014 does each synthetic preserve the entity class/format? *(Substitute only)*\n",
     "   - **Relational Consistency** \u2014 do cross-entity relationships stay coherent? *(Substitute only)*\n",
@@ -19,7 +19,7 @@
     "\n",
     "The split lets you iterate on judge prompts/models without re-running the (expensive) detection + replacement step every time.\n",
     "\n",
-    "`EvaluateConfig` mirrors `AnonymizerConfig` \u2014 pass the same mode object (e.g. `replace=Substitute()`) that produced the result. Once rewrite-side evaluation lands, it'll live in the same config as `EvaluateConfig(rewrite=...)`."
+    "The strategy is carried on the `preview` / `result` object itself, so `evaluate(preview)` knows what to dispatch \u2014 you don't restate the mode."
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, EvaluateConfig, Redact, Substitute"
+    "from anonymizer import Anonymizer, AnonymizerConfig, AnonymizerInput, Redact, Substitute"
    ]
   },
   {
@@ -189,9 +189,9 @@
    "source": [
     "## Step 2 \u2014 Evaluate replacement quality\n",
     "\n",
-    "`anonymizer.evaluate(config=EvaluateConfig(replace=...), result=...)` runs the four judges as columns of a **single DataDesigner workflow**, scheduled in parallel by DD (bounded by each model's `max_parallel_requests`). The text-column name is read automatically from the preview/run result \u2014 you don't pass it again.\n",
+    "`anonymizer.evaluate(output)` runs the four judges as columns of a **single DataDesigner workflow**, scheduled in parallel by DD (bounded by each model's `max_parallel_requests`). The text-column name and replace strategy are read from the result \u2014 you don't pass them again.\n",
     "\n",
-    "Pass either a `PreviewResult` or an `AnonymizerResult` as `result`; both carry the trace dataframe and `resolved_text_column`. `EvaluateConfig` takes the same `replace=` mode object you used to produce the result."
+    "Pass either a `PreviewResult` or an `AnonymizerResult`; both carry the trace dataframe, `resolved_text_column`, and `replace_method`."
    ]
   },
   {
@@ -200,10 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluated = anonymizer.evaluate(\n",
-    "    config=EvaluateConfig(replace=substitute_config.replace),\n",
-    "    result=substitute_preview,\n",
-    ")"
+    "evaluated = anonymizer.evaluate(substitute_preview)"
    ]
   },
   {
@@ -285,11 +282,8 @@
     "with cache_path.open(\"rb\") as f:\n",
     "    loaded_preview = pickle.load(f)\n",
     "\n",
-    "# Re-evaluate from the loaded result \u2014 same API, no detection/replacement re-run.\n",
-    "re_evaluated = anonymizer.evaluate(\n",
-    "    config=EvaluateConfig(replace=substitute_config.replace),\n",
-    "    result=loaded_preview,\n",
-    ")\n",
+    "# Re-evaluate from the loaded preview \u2014 same API, no detection/replacement re-run.\n",
+    "re_evaluated = anonymizer.evaluate(loaded_preview)\n",
     "re_evaluated.display_record(0)"
    ]
   },
@@ -316,10 +310,7 @@
     "    num_records=15,\n",
     ")\n",
     "\n",
-    "redact_evaluated = anonymizer.evaluate(\n",
-    "    config=EvaluateConfig(replace=redact_config.replace),\n",
-    "    result=redact_preview,\n",
-    ")\n",
+    "redact_evaluated = anonymizer.evaluate(redact_preview)\n",
     "redact_evaluated.display_record(0)"
    ]
   },

--- a/src/anonymizer/__init__.py
+++ b/src/anonymizer/__init__.py
@@ -9,7 +9,14 @@ __version__ = version("nemo-anonymizer")
 
 from data_designer.config.models import ModelProvider as ModelProvider
 
-from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Detect, Rewrite, RiskTolerance
+from anonymizer.config.anonymizer_config import (
+    AnonymizerConfig,
+    AnonymizerInput,
+    Detect,
+    EvaluateConfig,
+    Rewrite,
+    RiskTolerance,
+)
 from anonymizer.config.replace_strategies import Annotate, Hash, Redact, Substitute
 from anonymizer.config.rewrite import PrivacyGoal
 from anonymizer.engine.constants import DEFAULT_ENTITY_LABELS as _DEFAULT_ENTITY_LABELS
@@ -35,6 +42,7 @@ __all__ = [
     "Annotate",
     "DEFAULT_ENTITY_LABELS",
     "Detect",
+    "EvaluateConfig",
     "Hash",
     "InvalidConfigError",
     "InvalidInputError",

--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -197,3 +197,40 @@ class AnonymizerConfig(BaseModel):
                 " Use replace=Redact() for entity replacement, or rewrite=Rewrite() for LLM rewriting."
             )
         return self
+
+
+class EvaluateConfig(BaseModel):
+    """User-facing config for the evaluation step.
+
+    Mirrors :class:`AnonymizerConfig` so the same mode object (e.g.
+    ``Substitute()``) can be passed back into ``Anonymizer.evaluate(...)``.
+    At least one mode must be set; only the modes whose pipeline produced the
+    result you're evaluating need to be filled.
+    """
+
+    replace: ReplaceMethod | None = Field(
+        default=None,
+        description=(
+            "Replacement strategy that produced the result being evaluated. "
+            "Substitute() runs all 4 LLM-as-judge metrics (Detection, Type Fidelity, "
+            "Relational Consistency, Attribute Fidelity); Redact/Annotate/Hash run "
+            "only Detection Validity (the others need a replacement map)."
+        ),
+    )
+    rewrite: Rewrite | None = Field(
+        default=None,
+        description=(
+            "Forward-looking slot for evaluating the rewrite pipeline output. "
+            "Not yet implemented — passing this raises NotImplementedError."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_at_least_one_mode(self) -> EvaluateConfig:
+        if self.replace is None and self.rewrite is None:
+            raise ValueError(
+                "EvaluateConfig requires at least one of replace= or rewrite= to be set. "
+                "Pass the same mode object you used to produce the result (e.g. "
+                "EvaluateConfig(replace=Substitute()))."
+            )
+        return self

--- a/src/anonymizer/config/anonymizer_config.py
+++ b/src/anonymizer/config/anonymizer_config.py
@@ -200,37 +200,17 @@ class AnonymizerConfig(BaseModel):
 
 
 class EvaluateConfig(BaseModel):
-    """User-facing config for the evaluation step.
+    """Optional knobs for :meth:`Anonymizer.evaluate`.
 
-    Mirrors :class:`AnonymizerConfig` so the same mode object (e.g.
-    ``Substitute()``) can be passed back into ``Anonymizer.evaluate(...)``.
-    At least one mode must be set; only the modes whose pipeline produced the
-    result you're evaluating need to be filled.
+    Reserved for genuinely evaluation-specific configuration — metric selection,
+    per-judge model/prompt overrides, scoring thresholds, etc. The anonymization
+    mode is **not** here: it travels on the ``AnonymizerResult`` /
+    ``PreviewResult`` produced by ``run()`` / ``preview()`` and is read directly
+    by ``evaluate()``, so users don't restate it and can't mis-state it.
+
+    Today this is an empty placeholder; fields will be added as evaluation
+    knobs are introduced.
     """
 
-    replace: ReplaceMethod | None = Field(
-        default=None,
-        description=(
-            "Replacement strategy that produced the result being evaluated. "
-            "Substitute() runs all 4 LLM-as-judge metrics (Detection, Type Fidelity, "
-            "Relational Consistency, Attribute Fidelity); Redact/Annotate/Hash run "
-            "only Detection Validity (the others need a replacement map)."
-        ),
-    )
-    rewrite: Rewrite | None = Field(
-        default=None,
-        description=(
-            "Forward-looking slot for evaluating the rewrite pipeline output. "
-            "Not yet implemented — passing this raises NotImplementedError."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def validate_at_least_one_mode(self) -> EvaluateConfig:
-        if self.replace is None and self.rewrite is None:
-            raise ValueError(
-                "EvaluateConfig requires at least one of replace= or rewrite= to be set. "
-                "Pass the same mode object you used to produce the result (e.g. "
-                "EvaluateConfig(replace=Substitute()))."
-            )
-        return self
+    # Intentionally empty for now. New fields land here as evaluation
+    # configurability is introduced.

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -224,6 +224,7 @@ class Anonymizer:
                 resolved_text_column=result.resolved_text_column,
                 failed_records=result.failed_records,
                 preview_num_records=num_records,
+                replace_method=config.replace,
             )
         except KeyboardInterrupt:
             status = TaskStatusEnum.CANCELED
@@ -244,75 +245,68 @@ class Anonymizer:
 
     def evaluate(
         self,
+        output: AnonymizerResult | PreviewResult,
         *,
-        config: EvaluateConfig,
-        result: AnonymizerResult | PreviewResult,
+        config: EvaluateConfig | None = None,
     ) -> AnonymizerResult:
-        """Run LLM-as-judge evaluation on a prior ``preview()`` / ``run()`` result.
+        """Run LLM-as-judge evaluation on a prior ``preview()`` / ``run()`` output.
 
-        :class:`EvaluateConfig` mirrors :class:`AnonymizerConfig` — pass the same
-        mode object that produced the result (e.g.
-        ``EvaluateConfig(replace=Substitute())``). The text-column name is read
-        from ``result.resolved_text_column``; you don't pass it again.
+        The anonymization strategy is read from ``output.replace_method`` (set
+        when ``run()`` / ``preview()`` produced the result), so users don't
+        restate it and can't mis-state it.
 
         Typical flow::
 
             preview = anonymizer.preview(config=cfg, data=src, num_records=15)
-            evaluated = anonymizer.evaluate(
-                config=EvaluateConfig(replace=cfg.replace),
-                result=preview,
-            )
+            evaluated = anonymizer.evaluate(preview)
             evaluated.display_record(0)
 
         Save/reload across sessions::
 
             import pickle
 
-            with open("/tmp/run.pkl", "wb") as f:
+            with open("/tmp/preview.pkl", "wb") as f:
                 pickle.dump(preview, f)
             # … later …
-            with open("/tmp/run.pkl", "rb") as f:
+            with open("/tmp/preview.pkl", "rb") as f:
                 loaded = pickle.load(f)
-            evaluated = anonymizer.evaluate(
-                config=EvaluateConfig(replace=cfg.replace),
-                result=loaded,
-            )
+            evaluated = anonymizer.evaluate(loaded)
 
         Args:
-            config: Mode(s) to evaluate. ``replace=`` triggers replace-pipeline
-                judges (Substitute → all 4 metrics; Redact/Annotate/Hash →
-                Detection Validity only). ``rewrite=`` is a forward-looking
-                slot and currently raises ``NotImplementedError``.
-            result: An :class:`AnonymizerResult` or :class:`PreviewResult` from
-                a prior ``preview()`` / ``run()``. Carries the trace dataframe
-                *and* the resolved text-column name.
+            output: An :class:`AnonymizerResult` or :class:`PreviewResult` from
+                a prior ``preview()`` / ``run()``. Carries the trace dataframe,
+                the resolved text-column name, and the replace strategy.
+            config: Optional :class:`EvaluateConfig` for evaluation-specific
+                knobs (placeholder today; reserved for metric selection,
+                per-judge model/prompt overrides, etc.).
         """
-        if config.rewrite is not None:
-            raise NotImplementedError(
-                "Evaluation for the rewrite pipeline is not yet implemented. "
-                "Only EvaluateConfig(replace=...) is supported today."
+        _ = config  # placeholder; no knobs to read yet
+        replace_method = output.replace_method
+        if replace_method is None:
+            raise ValueError(
+                "Cannot evaluate this output — it has no associated replace strategy. "
+                "Pass an AnonymizerResult / PreviewResult produced by run() / preview() "
+                "on this branch (the strategy is recorded then). Hand-built or legacy "
+                "results need their `replace_method` attribute set before calling evaluate()."
             )
-        # The EvaluateConfig validator guarantees at least one mode is set, and
-        # rewrite is rejected above, so replace must be set here.
-        assert config.replace is not None
         try:
             validate_model_alias_references(
                 self._model_configs,
                 self._selected_models,
-                check_substitute=isinstance(config.replace, Substitute),
+                check_substitute=isinstance(replace_method, Substitute),
                 check_rewrite=False,
             )
         except ValueError as exc:
             raise InvalidConfigError(str(exc)) from exc
-        text_column = result.resolved_text_column
+        text_column = output.resolved_text_column
         # trace_dataframe is in user-facing form (e.g., 'biography' instead of
         # '__nemo_anonymizer_text_input__'). The judge prompts reference the
         # internal names, so reverse the rename before the DD call and re-apply
         # it on the result.
-        internal_df = _unrename_output_columns(result.trace_dataframe, resolved_text_column=text_column)
+        internal_df = _unrename_output_columns(output.trace_dataframe, resolved_text_column=text_column)
         replace_result = self._replace_runner.evaluate(
             internal_df,
-            replace_method=config.replace,
+            replace_method=replace_method,
             model_configs=self._model_configs,
             selected_models=self._selected_models.replace,
         )
@@ -322,6 +316,7 @@ class Anonymizer:
             trace_dataframe=renamed_trace,
             resolved_text_column=text_column,
             failed_records=replace_result.failed_records,
+            replace_method=replace_method,
         )
 
     def validate_config(self, config: AnonymizerConfig) -> None:
@@ -464,6 +459,7 @@ class Anonymizer:
             trace_dataframe=renamed_trace,
             resolved_text_column=text_col,
             failed_records=all_failures,
+            replace_method=config.replace,
         )
 
     def _validate_preflight_config(self, config: AnonymizerConfig) -> None:

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -19,6 +19,7 @@ from data_designer.interface.data_designer import DataDesigner
 from anonymizer.config.anonymizer_config import (
     AnonymizerConfig,
     AnonymizerInput,
+    EvaluateConfig,
 )
 from anonymizer.config.replace_strategies import Substitute
 from anonymizer.engine.constants import (
@@ -159,7 +160,7 @@ class Anonymizer:
     ) -> AnonymizerResult:
         """Run the full anonymization pipeline (detection + replacement).
 
-        No LLM evaluation judges run here — call :meth:`evaluate_replace` on the
+        No LLM evaluation judges run here — call :meth:`evaluate` on the
         result's ``trace_dataframe`` when you want the LLM alignment scores.
 
         Args:
@@ -201,7 +202,7 @@ class Anonymizer:
     ) -> PreviewResult:
         """Run the pipeline on a subset of records for quick inspection.
 
-        No LLM evaluation judges run here — call :meth:`evaluate_replace` on the
+        No LLM evaluation judges run here — call :meth:`evaluate` on the
         result's ``trace_dataframe`` when you want the LLM alignment scores.
 
         Args:
@@ -241,22 +242,26 @@ class Anonymizer:
                 duration_sec=time.perf_counter() - t_start,
             )
 
-    def evaluate_replace(
+    def evaluate(
         self,
         *,
-        config: AnonymizerConfig,
+        config: EvaluateConfig,
         result: AnonymizerResult | PreviewResult,
     ) -> AnonymizerResult:
-        """Run the LLM evaluation judges on an already-replaced result.
+        """Run LLM-as-judge evaluation on a prior ``preview()`` / ``run()`` result.
 
-        Use this to score (or re-score) an anonymization run without paying the
-        detection + replacement cost again. The text-column name is taken from
-        ``result.resolved_text_column`` — you don't need to pass it again.
+        :class:`EvaluateConfig` mirrors :class:`AnonymizerConfig` — pass the same
+        mode object that produced the result (e.g.
+        ``EvaluateConfig(replace=Substitute())``). The text-column name is read
+        from ``result.resolved_text_column``; you don't pass it again.
 
         Typical flow::
 
-            result = anonymizer.preview(config=cfg, data=src, num_records=15)
-            evaluated = anonymizer.evaluate_replace(config=cfg, result=result)
+            preview = anonymizer.preview(config=cfg, data=src, num_records=15)
+            evaluated = anonymizer.evaluate(
+                config=EvaluateConfig(replace=cfg.replace),
+                result=preview,
+            )
             evaluated.display_record(0)
 
         Save/reload across sessions::
@@ -264,23 +269,41 @@ class Anonymizer:
             import pickle
 
             with open("/tmp/run.pkl", "wb") as f:
-                pickle.dump(result, f)
+                pickle.dump(preview, f)
             # … later …
             with open("/tmp/run.pkl", "rb") as f:
                 loaded = pickle.load(f)
-            evaluated = anonymizer.evaluate_replace(config=cfg, result=loaded)
+            evaluated = anonymizer.evaluate(
+                config=EvaluateConfig(replace=cfg.replace),
+                result=loaded,
+            )
 
         Args:
-            config: Same config used to produce the result (needed to know
-                the replace strategy — Substitute triggers all 4 judges; other
-                strategies trigger detection only).
+            config: Mode(s) to evaluate. ``replace=`` triggers replace-pipeline
+                judges (Substitute → all 4 metrics; Redact/Annotate/Hash →
+                Detection Validity only). ``rewrite=`` is a forward-looking
+                slot and currently raises ``NotImplementedError``.
             result: An :class:`AnonymizerResult` or :class:`PreviewResult` from
                 a prior ``preview()`` / ``run()``. Carries the trace dataframe
                 *and* the resolved text-column name.
         """
-        self._validate_preflight_config(config)
-        if config.replace is None:
-            raise ValueError("evaluate_replace() requires config.replace to be set.")
+        if config.rewrite is not None:
+            raise NotImplementedError(
+                "Evaluation for the rewrite pipeline is not yet implemented. "
+                "Only EvaluateConfig(replace=...) is supported today."
+            )
+        # The EvaluateConfig validator guarantees at least one mode is set, and
+        # rewrite is rejected above, so replace must be set here.
+        assert config.replace is not None
+        try:
+            validate_model_alias_references(
+                self._model_configs,
+                self._selected_models,
+                check_substitute=isinstance(config.replace, Substitute),
+                check_rewrite=False,
+            )
+        except ValueError as exc:
+            raise InvalidConfigError(str(exc)) from exc
         text_column = result.resolved_text_column
         # trace_dataframe is in user-facing form (e.g., 'biography' instead of
         # '__nemo_anonymizer_text_input__'). The judge prompts reference the

--- a/src/anonymizer/interface/results.py
+++ b/src/anonymizer/interface/results.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 import pandas as pd
 
+from anonymizer.config.replace_strategies import ReplaceMethod
 from anonymizer.engine.ndd.adapter import FailedRecord
 from anonymizer.interface.display import render_record_html
 
@@ -54,12 +55,17 @@ class AnonymizerResult(_DisplayMixin):
             to avoid colliding with an Anonymizer output column, in which case
             it is the post-rename identifier (e.g. ``"final_entities__input"``).
         failed_records: Records that failed during pipeline processing.
+        replace_method: The replace strategy that produced this result. Set by
+            ``run()`` / ``preview()``; consumed by ``evaluate()`` to dispatch the
+            right judges. ``None`` on results that were constructed by hand or
+            loaded from a pre-strategy-tracking format.
     """
 
     dataframe: pd.DataFrame
     trace_dataframe: pd.DataFrame
     resolved_text_column: str
     failed_records: list[FailedRecord]
+    replace_method: ReplaceMethod | None = None
     _display_cycle_index: int = field(default=0, init=False, repr=False)
 
     def __repr__(self) -> str:
@@ -86,6 +92,10 @@ class PreviewResult(_DisplayMixin):
             it is the post-rename identifier (e.g. ``"final_entities__input"``).
         failed_records: Records that failed during pipeline processing.
         preview_num_records: Number of records requested for the preview.
+        replace_method: The replace strategy that produced this preview. Set by
+            ``preview()``; consumed by ``evaluate()`` to dispatch the right
+            judges. ``None`` on results that were constructed by hand or loaded
+            from a pre-strategy-tracking format.
     """
 
     dataframe: pd.DataFrame
@@ -93,6 +103,7 @@ class PreviewResult(_DisplayMixin):
     resolved_text_column: str
     failed_records: list[FailedRecord]
     preview_num_records: int
+    replace_method: ReplaceMethod | None = None
     _display_cycle_index: int = field(default=0, init=False, repr=False)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary
- **Public method renamed:** `Anonymizer.evaluate_replace` → `Anonymizer.evaluate`. Verb is no longer mode-dependent.

- **New call shape (single-argument default):**
  ```python
  anonymizer.evaluate(preview)                              # default path
  anonymizer.evaluate(preview, config=EvaluateConfig(...))  # extensible path
  output is positional, config is keyword-only and optional.

- Strategy travels on the result, not in a config. `AnonymizerResult` and `PreviewResult` gained a `replace_method: ReplaceMethod | None = None` field, populated by `run() / preview()`. `evaluate(`) reads it directly — eliminates the "result says Substitute, config says Redact" mismatch risk.
- `EvaluateConfig` is now an empty placeholder. Dropped its replace= / rewrite= fields and the validate_at_least_one_mode validator. Reserved for future evaluation-specific knobs (metric selection, per-judge model/prompt overrides, thresholds). Still exported from the top-level package so a future migration is just adding fields.
- Parameter renamed `result` → `output` in `evaluate()` for clearer naming.
- Clear error for hand-built / pre-tracking outputs. evaluate() raises a descriptive `ValueError` when `output.replace_method` is None, with guidance on how to set it.
- Demo notebook updated (`docs/notebooks/evaluate-replace-demo.ipynb`): all three evaluate(config=..., result=...) sites became single-arg evaluate(preview); `EvaluateConfig` removed from imports; intro paragraph rewritten to explain "strategy travels on the result."
- No test churn. The lower-level `ReplacementWorkflow.evaluate(dataframe, replace_method=...)` is unchanged, so existing tests pass without edits. 818 / 818 green.


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->
