### PR TITLE
chore: Use uv and pip ecosystem for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This project is uv-managed (pyproject.toml + uv.lock). The `pip` ecosystem
+# alone parses pyproject.toml but cannot update uv.lock, leaving transitive
+# dependencies invisible to both version updates and security alerts.
+# Pair `pip` and `uv` in a multi-ecosystem group so a single PR updates
+# pyproject.toml and uv.lock together.
+# Refs: https://github.com/dependabot/dependabot-core/issues/12609,
+#       https://github.com/dependabot/dependabot-core/issues/11913
+
 version: 2
+
+multi-ecosystem-groups:
+  python:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: python
+    patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    multi-ecosystem-group: python
+    patterns: ["*"]
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Enable dependabot to work with pyproject.toml and uv.lock for scanning and updates. See https://github.com/dependabot/dependabot-core/issues/12609

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
