### PR TITLE
chore: collapse greptile diagram by default

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,7 @@
+{
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  }
+}


### PR DESCRIPTION
## Summary
Following up on [this slack thread](https://nvidia.slack.com/archives/C096DGNMAGN/p1779923070377319), we decided to collapse greptile diagrams by default. We can always open the diagram if needed.

This provides more space in the PR for review feedback and reduces the space occupied by the Greprile diagram, which is not always read or used.

Similar [PR](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/pull/534) for this in NSS.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->
