### PR TITLE
fix(detection): pass single chunk validation flag to exports

### DIFF
--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -247,6 +247,7 @@ class EntityDetectionWorkflow:
         gliner_detection_threshold: float,
         validation_max_entities_per_call: int = _DEFAULT_VALIDATION_MAX_ENTITIES_PER_CALL,
         validation_excerpt_window_chars: int = _DEFAULT_VALIDATION_EXCERPT_WINDOW_CHARS,
+        validation_single_chunk_full_text: bool = True,
         entity_labels: list[str] | None = None,
         data_summary: str | None = None,
     ) -> DataDesignerConfigBuilder:
@@ -261,6 +262,7 @@ class EntityDetectionWorkflow:
             gliner_detection_threshold=gliner_detection_threshold,
             validation_max_entities_per_call=validation_max_entities_per_call,
             validation_excerpt_window_chars=validation_excerpt_window_chars,
+            validation_single_chunk_full_text=validation_single_chunk_full_text,
             entity_labels=entity_labels,
             data_summary=data_summary,
         )
@@ -280,6 +282,7 @@ class EntityDetectionWorkflow:
         gliner_detection_threshold: float,
         validation_max_entities_per_call: int = _DEFAULT_VALIDATION_MAX_ENTITIES_PER_CALL,
         validation_excerpt_window_chars: int = _DEFAULT_VALIDATION_EXCERPT_WINDOW_CHARS,
+        validation_single_chunk_full_text: bool = True,
         entity_labels: list[str] | None = None,
         data_summary: str | None = None,
         job_index: int = 0,
@@ -300,6 +303,7 @@ class EntityDetectionWorkflow:
             gliner_detection_threshold=gliner_detection_threshold,
             validation_max_entities_per_call=validation_max_entities_per_call,
             validation_excerpt_window_chars=validation_excerpt_window_chars,
+            validation_single_chunk_full_text=validation_single_chunk_full_text,
             entity_labels=entity_labels,
             data_summary=data_summary,
         )
@@ -364,6 +368,7 @@ class EntityDetectionWorkflow:
         gliner_detection_threshold: float,
         validation_max_entities_per_call: int = _DEFAULT_VALIDATION_MAX_ENTITIES_PER_CALL,
         validation_excerpt_window_chars: int = _DEFAULT_VALIDATION_EXCERPT_WINDOW_CHARS,
+        validation_single_chunk_full_text: bool = True,
         entity_labels: list[str] | None = None,
         privacy_goal: PrivacyGoal | None = None,
         data_summary: str | None = None,
@@ -393,6 +398,7 @@ class EntityDetectionWorkflow:
                 gliner_detection_threshold=gliner_detection_threshold,
                 validation_max_entities_per_call=validation_max_entities_per_call,
                 validation_excerpt_window_chars=validation_excerpt_window_chars,
+                validation_single_chunk_full_text=validation_single_chunk_full_text,
                 entity_labels=entity_labels,
                 data_summary=data_summary,
                 preview_num_records=preview_num_records,

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -117,6 +117,7 @@ class EntityDetectionWorkflow:
             gliner_detection_threshold=gliner_detection_threshold,
             validation_max_entities_per_call=validation_max_entities_per_call,
             validation_excerpt_window_chars=validation_excerpt_window_chars,
+            validation_single_chunk_full_text=validation_single_chunk_full_text,
             entity_labels=entity_labels,
             data_summary=data_summary,
         )
@@ -138,6 +139,7 @@ class EntityDetectionWorkflow:
         gliner_detection_threshold: float,
         validation_max_entities_per_call: int = _DEFAULT_VALIDATION_MAX_ENTITIES_PER_CALL,
         validation_excerpt_window_chars: int = _DEFAULT_VALIDATION_EXCERPT_WINDOW_CHARS,
+        validation_single_chunk_full_text: bool = True,
         entity_labels: list[str] | None = None,
         data_summary: str | None = None,
     ) -> tuple[list[ModelConfig], list[ColumnConfigT]]:

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -543,6 +543,52 @@ def test_validator_pool_kwargs_thread_through_to_generator_params(
     assert params.excerpt_window_chars == 42
 
 
+def test_validation_single_chunk_full_text_threads_to_generator_params(
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> None:
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Alice"],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
+            }
+        ),
+        failed_records=[],
+    )
+    workflow = EntityDetectionWorkflow(adapter=adapter)
+    workflow.detect_and_validate_entities(
+        pd.DataFrame({COL_TEXT: ["Alice"]}),
+        model_configs=stub_detector_model_configs,
+        selected_models=stub_detection_model_selection,
+        gliner_detection_threshold=0.5,
+        validation_single_chunk_full_text=False,
+    )
+    columns = adapter.run_workflow.call_args.kwargs["columns"]
+    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
+    assert params.single_chunk_full_text is False
+
+
+def test_build_detection_config_uses_default_validation_single_chunk_full_text(
+    tmp_path,
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> None:
+    adapter = Mock()
+    workflow = EntityDetectionWorkflow(adapter=adapter)
+    workflow.build_detection_config(
+        pd.DataFrame({COL_TEXT: ["Alice"]}),
+        seed_path=tmp_path / "seed.parquet",
+        model_configs=stub_detector_model_configs,
+        selected_models=stub_detection_model_selection,
+        gliner_detection_threshold=0.5,
+    )
+    columns = adapter.build_config.call_args.kwargs["columns"]
+    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
+    assert params.single_chunk_full_text is True
+
+
 def test_pool_size_greater_than_one_emits_warning(
     stub_detector_model_configs: list[ModelConfig],
     stub_detection_model_selection: DetectionModelSelection,

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -558,14 +558,54 @@ def test_validation_single_chunk_full_text_threads_to_generator_params(
         failed_records=[],
     )
     workflow = EntityDetectionWorkflow(adapter=adapter)
-    workflow.detect_and_validate_entities(
+    workflow.run(
         pd.DataFrame({COL_TEXT: ["Alice"]}),
         model_configs=stub_detector_model_configs,
         selected_models=stub_detection_model_selection,
         gliner_detection_threshold=0.5,
         validation_single_chunk_full_text=False,
+        tag_latent_entities=False,
     )
     columns = adapter.run_workflow.call_args.kwargs["columns"]
+    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
+    assert params.single_chunk_full_text is False
+
+
+def test_build_detection_config_threads_validation_single_chunk_full_text(
+    tmp_path,
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> None:
+    adapter = Mock()
+    workflow = EntityDetectionWorkflow(adapter=adapter)
+    workflow.build_detection_config(
+        pd.DataFrame({COL_TEXT: ["Alice"]}),
+        seed_path=tmp_path / "seed.parquet",
+        model_configs=stub_detector_model_configs,
+        selected_models=stub_detection_model_selection,
+        gliner_detection_threshold=0.5,
+        validation_single_chunk_full_text=False,
+    )
+    columns = adapter.build_config.call_args.kwargs["columns"]
+    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
+    assert params.single_chunk_full_text is False
+
+
+def test_build_detection_builder_for_seed_threads_validation_single_chunk_full_text(
+    tmp_path,
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> None:
+    adapter = Mock()
+    workflow = EntityDetectionWorkflow(adapter=adapter)
+    workflow.build_detection_builder_for_seed(
+        seed_path=tmp_path / "seed.parquet",
+        model_configs=stub_detector_model_configs,
+        selected_models=stub_detection_model_selection,
+        gliner_detection_threshold=0.5,
+        validation_single_chunk_full_text=False,
+    )
+    columns = adapter.build_config_for_seed.call_args.kwargs["columns"]
     params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
     assert params.single_chunk_full_text is False
 


### PR DESCRIPTION
## Summary
Fixes the integrated `main` regression where detection workflow construction referenced `validation_single_chunk_full_text` inside `_build_detection_spec(...)` without defining or passing that parameter. This broke `EntityDetectionWorkflow.run(...)` and `Anonymizer.export_detection_config(...)` after PR #177 merged on top of PR #182.

This PR threads the existing `validation_single_chunk_full_text` argument into `_build_detection_spec(...)` and adds regression coverage for both the direct detection path and the external detection config path.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [x] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

Ran:

```bash
uv run pytest tests/engine/test_detection_workflow.py
make format-check
make test
make check
```

Notes:
- `make test`: `914 passed, 94 warnings`
- `make check`: exited successfully. The `typecheck` substep is advisory and printed existing ty diagnostics, then make continued through `uv lock --check` and copyright checks.

Also reproduced the failure on merged `main` commit `f6dd05d` in a temporary worktree: `tests/engine/test_detection_workflow.py` failed with `NameError: name 'validation_single_chunk_full_text' is not defined`.

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

No docs changes.

## Related Issues
Follow-up fix for the stacked PR integration of #177 and #182.
