### PR TITLE
feat: add detection workflow column plugins

### DIFF
--- a/plans/custom-column-plugins/anonymizer-workflow-columns.md
+++ b/plans/custom-column-plugins/anonymizer-workflow-columns.md
@@ -1,0 +1,145 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Anonymizer Workflow Columns
+
+## Context
+
+Anonymizer currently uses DataDesigner `CustomColumnConfig` for private pipeline steps. This works in-process, but custom functions serialize poorly and complicate distributed execution. The goal is to make Anonymizer workflows portable when `nemo-anonymizer` is installed, without exposing implementation details as user-facing API.
+
+## Goal
+
+Remove `CustomColumnConfig` from production Anonymizer workflow builders and replace it with Anonymizer-owned plugin column configs that DataDesigner can discover through entry points.
+
+## Naming
+
+Use `anonymizer.engine.workflow_columns` for the implementation package.
+
+Rationale:
+
+- It describes the Anonymizer concept, not the host engine.
+- It avoids names like `dd_plugins`.
+- It keeps these classes internal to the Anonymizer engine while still allowing DataDesigner to load them by entry point.
+
+Entry point names should use the Anonymizer domain:
+
+```toml
+[project.entry-points."data_designer.plugins"]
+anonymizer-detection-transform = "anonymizer.engine.workflow_columns.detection.plugins:detection_transform_plugin"
+anonymizer-chunked-validation = "anonymizer.engine.workflow_columns.detection.plugins:chunked_validation_plugin"
+```
+
+## Design
+
+Use one installable package, `nemo-anonymizer`, with multiple DataDesigner plugin entry points. Each entry point exposes one `Plugin` object. This gives us one package with multiple submodules, rather than one distribution per plugin.
+
+Do not create a 1:1 plugin for every current helper function unless it is clearer. Prefer a small set of role-based column types:
+
+- Detection transforms for parse, validation prep, merge, and finalize operations.
+- Chunked validation for model-backed validation.
+- Rewrite transforms for prompt prep, extraction, metrics, and postprocess operations.
+- Rewrite model-call columns for evaluator and repair calls that need parser context or dynamic model aliases.
+
+Keep the existing pure helper functions as implementation cores. The plugin generators should adapt DataDesigner row input to those helpers, not rewrite the business logic.
+
+## Native NER Transport
+
+Moving custom columns into plugins does not by itself remove the need for a chat-completions-compatible NER endpoint. The current detector remains an `LLMTextColumnConfig`, so DataDesigner routes it through chat completion generation.
+
+To remove the extra chat completions head on NER models, the detector call itself must become an Anonymizer workflow column that talks to a native NER endpoint or client. That is a separate design slice because it needs a stable endpoint contract, provider configuration, and response normalization.
+
+## Stage 1: Detection Plugins
+
+Move the detection workflow off custom columns first.
+
+Tasks:
+
+1. Add `src/anonymizer/engine/workflow_columns/`.
+2. Add detection plugin configs and generators:
+   - `DetectionTransformConfig`
+   - `ChunkedValidationConfig`
+3. Add DataDesigner entry points in `pyproject.toml`.
+4. Replace detection `CustomColumnConfig` usage in `EntityDetectionWorkflow`.
+5. Keep `chunked_validate_row(...)` as the core validator implementation.
+6. Add a serialization test that builds the detection workflow and confirms config JSON contains no serialized function names.
+
+Validation:
+
+```bash
+.venv/bin/ruff check src/anonymizer/engine/detection src/anonymizer/engine/workflow_columns tests/engine/test_detection_workflow.py tests/engine/test_chunked_validation.py
+.venv/bin/pytest tests/engine/test_detection_postprocess.py tests/engine/test_chunked_validation.py tests/engine/test_detection_workflow.py
+```
+
+Exit criteria:
+
+- Detection behavior is unchanged.
+- Detection builder configs serialize without custom generator functions.
+- No production detection workflow path instantiates `CustomColumnConfig`.
+
+## Stage 2: Rewrite Plugins
+
+Move rewrite, evaluation, repair, and final judge postprocess columns.
+
+Tasks:
+
+1. Add rewrite plugin configs and generators:
+   - `RewriteTransformConfig`
+   - `RewriteEvaluatorCallConfig`
+   - `RewriteRepairCallConfig`
+   - `FinalJudgeTransformConfig`
+2. Replace custom columns in:
+   - `domain_classification.py`
+   - `qa_generation.py`
+   - `rewrite_generation.py`
+   - `evaluate.py`
+   - `repair.py`
+   - `final_judge.py`
+3. Preserve current parser-context behavior in evaluator columns.
+4. Add tests that workflow column lists contain plugin configs, not `CustomColumnConfig`.
+
+Validation:
+
+```bash
+.venv/bin/ruff check src/anonymizer/engine/rewrite src/anonymizer/engine/workflow_columns tests/engine/test_rewrite_workflow.py
+.venv/bin/pytest tests/engine/test_domain_classification.py tests/engine/test_qa_generation.py tests/engine/test_rewrite_generation.py tests/engine/test_evaluate.py tests/engine/test_repair.py tests/engine/test_final_judge.py tests/engine/test_rewrite_workflow.py
+```
+
+Exit criteria:
+
+- Rewrite behavior is unchanged.
+- Repair loop still runs only on failing rows.
+- Evaluator calls still enforce expected QA IDs.
+- Rewrite builder configs serialize without custom generator functions.
+
+## Stage 3: Distribution Guardrails
+
+Make the new path hard to regress.
+
+Tasks:
+
+1. Add a test that production code under `src/anonymizer/engine` no longer creates `CustomColumnConfig`.
+2. Add export tests for distributed builder factories.
+3. Update any docs or comments that describe custom columns as the distributed limitation.
+4. Bump the DataDesigner dependency only when the needed plugin and serialization behavior is available in the supported release.
+5. Consider a native detector workflow column if we want NER models to avoid chat-completions-compatible serving.
+
+Validation:
+
+```bash
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/pytest tests/engine tests/interface
+```
+
+Exit criteria:
+
+- Runtime Anonymizer workflows use Anonymizer plugin columns only.
+- Serialized configs are portable across machines where `nemo-anonymizer` is installed.
+- Tests prevent reintroducing custom columns into production workflow builders.
+
+## Open Questions
+
+1. Should plugin configs live under `anonymizer.engine.workflow_columns` or a shorter `anonymizer.workflow_columns` namespace?
+2. Should `DetectionTransformConfig` use an operation enum, or should parse, prep, merge, and finalize each get a distinct config class?
+3. Which DataDesigner release should become the minimum supported version for this migration?
+4. Is native NER transport in scope for this migration, or should it be a separate provider/client project?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
 [project.scripts]
 anonymizer = "anonymizer.interface.cli.main:main"
 
+[project.entry-points."data_designer.plugins"]
+anonymizer-detection-transform = "anonymizer.engine.workflow_columns.detection.plugins:detection_transform_plugin"
+anonymizer-chunked-validation = "anonymizer.engine.workflow_columns.detection.plugins:chunked_validation_plugin"
+
 [dependency-groups]
 dev = [
     "pre-commit>=4.0.0,<5",

--- a/src/anonymizer/__init__.py
+++ b/src/anonymizer/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from importlib.metadata import version
+from typing import TYPE_CHECKING
 
 __version__ = version("nemo-anonymizer")
 
@@ -20,7 +21,6 @@ from anonymizer.config.anonymizer_config import (
 from anonymizer.config.replace_strategies import Annotate, Hash, Redact, Substitute
 from anonymizer.config.rewrite import PrivacyGoal
 from anonymizer.engine.constants import DEFAULT_ENTITY_LABELS as _DEFAULT_ENTITY_LABELS
-from anonymizer.interface.anonymizer import Anonymizer
 from anonymizer.interface.errors import (
     AnonymizerError,
     AnonymizerIOError,
@@ -29,9 +29,21 @@ from anonymizer.interface.errors import (
 )
 from anonymizer.logging import LoggingConfig, configure_logging
 
+if TYPE_CHECKING:
+    from anonymizer.interface.anonymizer import Anonymizer as Anonymizer
+
 # Export as an immutable public constant so callers can inspect defaults
 # without mutating the internal source-of-truth list.
 DEFAULT_ENTITY_LABELS: tuple[str, ...] = tuple(_DEFAULT_ENTITY_LABELS)
+
+
+def __getattr__(name: str) -> object:
+    if name == "Anonymizer":
+        from anonymizer.interface.anonymizer import Anonymizer
+
+        return Anonymizer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "Anonymizer",

--- a/src/anonymizer/engine/detection/chunked_validation.py
+++ b/src/anonymizer/engine/detection/chunked_validation.py
@@ -12,7 +12,8 @@ validator pool. The per-chunk decisions are merged into a
 
 Public entry point: :func:`make_chunked_validation_generator`, which
 produces a ``@custom_column_generator``-decorated function bound to a
-concrete pool. The helpers below are exposed for unit testing.
+concrete pool. Plugin columns call :func:`chunked_validate_row_async`
+directly. The helpers below are exposed for unit testing.
 
 Failure contract. Each chunk attempts its round-robin primary first and
 fails over sequentially to the rest of the pool; a chunk only fails when
@@ -21,20 +22,16 @@ the generator, DataDesigner drops the row, and
 ``NddAdapter._detect_missing_records`` surfaces it as a ``FailedRecord``.
 Raw text never silently leaks through as unscrubbed output.
 
-Concurrency. Chunks dispatch through a ``ThreadPoolExecutor``. Per-alias
-concurrency is already enforced downstream by each facade's
-``ThrottledModelClient`` (AIMD on 429), so there is no row-level cap
-here; the pool exists purely to overlap this row's chunks.
-
-TODO(async-native): once DataDesigner's async engine becomes the default
-(``DATA_DESIGNER_ASYNC_ENGINE`` flips off), replace the
-``ThreadPoolExecutor`` + sync ``facade.generate()`` pattern with
-``async def`` functions calling ``facade.agenerate()`` under
-``asyncio.gather``.
+Concurrency. Plugin columns dispatch chunks with ``asyncio.gather`` and
+``facade.agenerate()``. The legacy custom-column wrapper still uses a
+``ThreadPoolExecutor`` and ``facade.generate()``. Per-alias concurrency is
+enforced downstream by DataDesigner's request-admission layer, so the
+optional row-level cap only bounds local fan-out pressure.
 """
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import logging
 from collections.abc import Sequence
@@ -102,6 +99,9 @@ class ChunkedValidationParams(BaseModel):
         max_entities_per_call: Upper bound on candidates per chunk.
         excerpt_window_chars: Chars of surrounding raw text included in each
             chunk's excerpt on either side of the chunk span.
+        max_parallel_chunks: Optional row-local cap on concurrently dispatched
+            chunks. Defaults to all chunks for the legacy custom-column path;
+            plugin generators derive a cap from validator model capacity.
         single_chunk_full_text: If True, a row with one validation chunk sees
             the full tagged document. If False, even a single chunk uses the
             excerpt window. The default preserves production parity with the
@@ -124,6 +124,7 @@ class ChunkedValidationParams(BaseModel):
     pool: list[str] = Field(min_length=1)
     max_entities_per_call: int = Field(gt=0)
     excerpt_window_chars: int = Field(gt=0)
+    max_parallel_chunks: int | None = Field(default=None, gt=0)
     single_chunk_full_text: bool = True
     prompt_template: str = Field(repr=False)
     system_prompt: str | None = Field(default=None, repr=False)
@@ -386,17 +387,70 @@ def _dispatch_chunk(
     raise last_exc
 
 
-def chunked_validate_row(
+async def _dispatch_chunk_async(
+    *,
+    facades: list[tuple[str, Any]],
+    prompt: str,
+    system_prompt: str | None,
+    chunk_index: int,
+) -> RawValidationDecisionsSchema:
+    """Async equivalent of :func:`_dispatch_chunk`, preserving failover order."""
+    recipe = PydanticResponseRecipe(data_type=RawValidationDecisionsSchema)
+    final_prompt = recipe.apply_recipe_to_user_prompt(prompt)
+    final_system = recipe.apply_recipe_to_system_prompt(system_prompt)
+
+    last_exc: BaseException | None = None
+    for attempt_index, (alias, facade) in enumerate(facades):
+        try:
+            output, _messages = await facade.agenerate(
+                prompt=final_prompt,
+                parser=recipe.parse,
+                system_prompt=final_system,
+                purpose=f"entity-validation-chunk-{chunk_index}-attempt-{attempt_index}",
+            )
+            if attempt_index > 0:
+                logger.info(
+                    "validator chunk %d: recovered on failover alias=%s (attempt %d of %d)",
+                    chunk_index,
+                    alias,
+                    attempt_index + 1,
+                    len(facades),
+                )
+            return output
+        except Exception as exc:  # noqa: BLE001 — we classify by failover position, not type
+            last_exc = exc
+            remaining = len(facades) - attempt_index - 1
+            if remaining > 0:
+                logger.warning(
+                    "validator chunk %d: alias=%s raised %s (%s); failing over to next pool member (%d remaining)",
+                    chunk_index,
+                    alias,
+                    type(exc).__name__,
+                    exc,
+                    remaining,
+                )
+            else:
+                logger.error(
+                    "validator chunk %d: alias=%s raised %s (%s); pool exhausted — row will be dropped",
+                    chunk_index,
+                    alias,
+                    type(exc).__name__,
+                    exc,
+                )
+
+    if last_exc is None:
+        raise RuntimeError(
+            "_dispatch_chunk_async was called with an empty facades list; "
+            "this violates the caller contract (a non-empty validator pool)."
+        )
+    raise last_exc
+
+
+def _build_dispatch_kwargs_per_chunk(
     row: dict[str, Any],
     params: ChunkedValidationParams,
     models: dict[str, Any],
-) -> dict[str, Any]:
-    """Run chunked validation for a single row and write ``COL_VALIDATION_DECISIONS``.
-
-    This is the workhorse. Call it directly in tests with fake ``models``;
-    the DataDesigner-decorated wrapper produced by
-    :func:`make_chunked_validation_generator` just forwards to it.
-    """
+) -> tuple[ValidationCandidatesSchema, list[dict[str, Any]]]:
     missing_aliases = [alias for alias in params.pool if alias not in models]
     if missing_aliases:
         raise KeyError(
@@ -411,10 +465,8 @@ def chunked_validate_row(
     notation_raw = row.get(COL_TAG_NOTATION) or TagNotation.sentinel.value
     notation = TagNotation(str(notation_raw))
 
-    # Short-circuit: a row with no candidates has no decisions to make.
     if not candidates.candidates:
-        row[COL_VALIDATION_DECISIONS] = ValidationDecisionsSchema().model_dump(mode="json")
-        return row
+        return candidates, []
 
     all_spans = [
         EntitySpan(
@@ -500,19 +552,66 @@ def chunked_validate_row(
             }
         )
 
+    return candidates, dispatch_kwargs_per_chunk
+
+
+def _chunk_worker_count(params: ChunkedValidationParams, chunk_count: int) -> int:
+    if chunk_count == 0:
+        return 0
+    if params.max_parallel_chunks is None:
+        return chunk_count
+    return min(chunk_count, params.max_parallel_chunks)
+
+
+async def _bounded_dispatch_chunk_async(
+    semaphore: asyncio.Semaphore,
+    kwargs: dict[str, Any],
+) -> RawValidationDecisionsSchema:
+    async with semaphore:
+        return await _dispatch_chunk_async(**kwargs)
+
+
+def chunked_validate_row(
+    row: dict[str, Any],
+    params: ChunkedValidationParams,
+    models: dict[str, Any],
+) -> dict[str, Any]:
+    """Run chunked validation for a single row and write ``COL_VALIDATION_DECISIONS``.
+
+    This sync path is kept for the legacy DataDesigner custom-column wrapper.
+    Plugin columns should call :func:`chunked_validate_row_async`.
+    """
+    candidates, dispatch_kwargs_per_chunk = _build_dispatch_kwargs_per_chunk(row, params, models)
+
     # Dispatch all chunks concurrently via a ThreadPoolExecutor. Per-alias
     # concurrency is still capped downstream by each facade's
-    # ``ThrottledModelClient`` (AIMD on 429), so the pool's only job here is
-    # to overlap one row's chunks. ``f.result()`` re-raises the first chunk
-    # exception, which is what we want: a single terminal chunk failure
-    # fails the row. Pending workers finish naturally as the ``with`` block
-    # exits — we just stop observing their results once we re-raise.
-    if not chunks:
+    # request-admission layer. ``f.result()`` re-raises the first chunk
+    # exception; a single terminal chunk failure fails the row.
+    if not dispatch_kwargs_per_chunk:
         chunk_results: list[RawValidationDecisionsSchema] = []
     else:
-        with ThreadPoolExecutor(max_workers=len(chunks)) as executor:
+        with ThreadPoolExecutor(max_workers=_chunk_worker_count(params, len(dispatch_kwargs_per_chunk))) as executor:
             futures = [executor.submit(_dispatch_chunk, **kwargs) for kwargs in dispatch_kwargs_per_chunk]
             chunk_results = [f.result() for f in futures]
+
+    row[COL_VALIDATION_DECISIONS] = merge_chunk_decisions(chunk_results, candidates)
+    return row
+
+
+async def chunked_validate_row_async(
+    row: dict[str, Any],
+    params: ChunkedValidationParams,
+    models: dict[str, Any],
+) -> dict[str, Any]:
+    """Async-native chunked validation for plugin column generators."""
+    candidates, dispatch_kwargs_per_chunk = _build_dispatch_kwargs_per_chunk(row, params, models)
+    if not dispatch_kwargs_per_chunk:
+        chunk_results: list[RawValidationDecisionsSchema] = []
+    else:
+        semaphore = asyncio.Semaphore(_chunk_worker_count(params, len(dispatch_kwargs_per_chunk)))
+        chunk_results = await asyncio.gather(
+            *[_bounded_dispatch_chunk_async(semaphore, kwargs) for kwargs in dispatch_kwargs_per_chunk]
+        )
 
     row[COL_VALIDATION_DECISIONS] = merge_chunk_decisions(chunk_results, candidates)
     return row

--- a/src/anonymizer/engine/detection/detection_workflow.py
+++ b/src/anonymizer/engine/detection/detection_workflow.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
-from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig, LLMTextColumnConfig
+from data_designer.config.column_configs import LLMStructuredColumnConfig, LLMTextColumnConfig
 from data_designer.config.column_types import ColumnConfigT
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.models import ModelConfig
@@ -40,18 +40,6 @@ from anonymizer.engine.constants import (
     ENTITY_LABEL_EXAMPLES,
     _jinja,
 )
-from anonymizer.engine.detection.chunked_validation import (
-    ChunkedValidationParams,
-    make_chunked_validation_generator,
-)
-from anonymizer.engine.detection.custom_columns import (
-    apply_validation_and_finalize,
-    apply_validation_to_seed_entities,
-    enrich_validation_decisions,
-    merge_and_build_candidates,
-    parse_detected_entities,
-    prepare_validation_inputs,
-)
 from anonymizer.engine.detection.postprocess import EntitySpan, group_entities_by_value
 from anonymizer.engine.ndd.adapter import FailedRecord, NddAdapter
 from anonymizer.engine.ndd.model_loader import resolve_model_alias, resolve_model_aliases
@@ -61,6 +49,11 @@ from anonymizer.engine.schemas import (
     EntitiesByValueSchema,
     EntitiesSchema,
     LatentEntitiesSchema,
+)
+from anonymizer.engine.workflow_columns.detection.config import (
+    ChunkedValidationConfig,
+    DetectionTransformConfig,
+    DetectionTransformOperation,
 )
 from anonymizer.measurement import stage_timer
 
@@ -84,7 +77,7 @@ class EntityDetectionResult:
 
 
 class EntityDetectionWorkflow:
-    """Detection workflow using NDD LLM + custom-column steps."""
+    """Detection workflow using NDD LLM and Anonymizer workflow columns."""
 
     def __init__(self, adapter: NddAdapter) -> None:
         self._adapter = adapter
@@ -181,42 +174,36 @@ class EntityDetectionWorkflow:
                 validator_aliases,
             )
 
-        validator_generator = make_chunked_validation_generator(validator_aliases)
-        validator_params = ChunkedValidationParams(
-            pool=list(validator_aliases),
-            max_entities_per_call=validation_max_entities_per_call,
-            excerpt_window_chars=validation_excerpt_window_chars,
-            single_chunk_full_text=validation_single_chunk_full_text,
-            prompt_template=_get_validation_prompt(data_summary=data_summary, labels=labels),
-        )
-
         columns: list[ColumnConfigT] = [
             LLMTextColumnConfig(
                 name=COL_RAW_DETECTED,
                 prompt=_jinja(COL_TEXT),
                 model_alias=detection_alias,
             ),
-            CustomColumnConfig(
+            DetectionTransformConfig(
                 name=COL_SEED_ENTITIES,
-                generator_function=parse_detected_entities,
+                operation=DetectionTransformOperation.PARSE_DETECTED_ENTITIES,
             ),
-            CustomColumnConfig(
+            DetectionTransformConfig(
                 name=COL_SEED_VALIDATION_CANDIDATES,
-                generator_function=prepare_validation_inputs,
+                operation=DetectionTransformOperation.PREPARE_VALIDATION_INPUTS,
             ),
-            CustomColumnConfig(
+            ChunkedValidationConfig(
                 name=COL_VALIDATION_DECISIONS,
-                generator_function=validator_generator,
-                generator_params=validator_params,
+                pool=list(validator_aliases),
+                max_entities_per_call=validation_max_entities_per_call,
+                excerpt_window_chars=validation_excerpt_window_chars,
+                single_chunk_full_text=validation_single_chunk_full_text,
+                prompt_template=_get_validation_prompt(data_summary=data_summary, labels=labels),
                 drop=True,
             ),
-            CustomColumnConfig(
+            DetectionTransformConfig(
                 name=COL_VALIDATED_ENTITIES,
-                generator_function=enrich_validation_decisions,
+                operation=DetectionTransformOperation.ENRICH_VALIDATION_DECISIONS,
             ),
-            CustomColumnConfig(
+            DetectionTransformConfig(
                 name=COL_SEED_ENTITIES_JSON,
-                generator_function=apply_validation_to_seed_entities,
+                operation=DetectionTransformOperation.APPLY_VALIDATION_TO_SEED_ENTITIES,
             ),
             LLMStructuredColumnConfig(
                 name=COL_AUGMENTED_ENTITIES,
@@ -226,13 +213,13 @@ class EntityDetectionWorkflow:
                 model_alias=augmenter_alias,
                 output_format=AugmentedEntitiesSchema,
             ),
-            CustomColumnConfig(
+            DetectionTransformConfig(
                 name=COL_MERGED_ENTITIES,
-                generator_function=merge_and_build_candidates,
+                operation=DetectionTransformOperation.MERGE_AND_BUILD_CANDIDATES,
             ),
-            CustomColumnConfig(
+            DetectionTransformConfig(
                 name=COL_DETECTED_ENTITIES,
-                generator_function=apply_validation_and_finalize,
+                operation=DetectionTransformOperation.APPLY_VALIDATION_AND_FINALIZE,
             ),
         ]
         return workflow_model_configs, columns
@@ -293,9 +280,8 @@ class EntityDetectionWorkflow:
         Same columns as :meth:`build_detection_config`, but the seed dataset points at an
         already-written ``seed_path`` and optionally selects this worker's ordered
         partition (``job_index`` of ``num_jobs``). For a distributed executor (e.g. a SLURM
-        orchestrator) that builds this workflow *in-process on the worker* — the
-        custom-column callables stay live (they can't survive JSON serialization) and the
-        model aliases are resolved by the runtime's providers.
+        orchestrator), the plugin column configs remain serializable and the model aliases
+        are resolved by the runtime's providers.
         """
         workflow_model_configs, columns = self._build_detection_spec(
             model_configs=model_configs,

--- a/src/anonymizer/engine/workflow_columns/__init__.py
+++ b/src/anonymizer/engine/workflow_columns/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/src/anonymizer/engine/workflow_columns/detection/__init__.py
+++ b/src/anonymizer/engine/workflow_columns/detection/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/src/anonymizer/engine/workflow_columns/detection/config.py
+++ b/src/anonymizer/engine/workflow_columns/detection/config.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import ClassVar, Literal
+
+from data_designer.config.base import SingleColumnConfig
+from pydantic import Field
+
+from anonymizer.engine.constants import (
+    COL_AUGMENTED_ENTITIES,
+    COL_INITIAL_TAGGED_TEXT,
+    COL_MERGED_ENTITIES,
+    COL_MERGED_TAGGED_TEXT,
+    COL_RAW_DETECTED,
+    COL_SEED_ENTITIES,
+    COL_SEED_ENTITIES_JSON,
+    COL_SEED_TAGGED_TEXT,
+    COL_SEED_VALIDATION_CANDIDATES,
+    COL_TAG_NOTATION,
+    COL_TAGGED_TEXT,
+    COL_TEXT,
+    COL_VALIDATED_ENTITIES,
+    COL_VALIDATED_SEED_ENTITIES,
+    COL_VALIDATION_CANDIDATES,
+    COL_VALIDATION_DECISIONS,
+)
+
+
+class DetectionTransformOperation(str, Enum):
+    PARSE_DETECTED_ENTITIES = "parse_detected_entities"
+    PREPARE_VALIDATION_INPUTS = "prepare_validation_inputs"
+    ENRICH_VALIDATION_DECISIONS = "enrich_validation_decisions"
+    APPLY_VALIDATION_TO_SEED_ENTITIES = "apply_validation_to_seed_entities"
+    MERGE_AND_BUILD_CANDIDATES = "merge_and_build_candidates"
+    APPLY_VALIDATION_AND_FINALIZE = "apply_validation_and_finalize"
+
+
+class DetectionTransformConfig(SingleColumnConfig):
+    column_type: Literal["anonymizer-detection-transform"] = "anonymizer-detection-transform"
+    operation: DetectionTransformOperation
+
+    _REQUIRED_COLUMNS: ClassVar[dict[DetectionTransformOperation, list[str]]] = {
+        DetectionTransformOperation.PARSE_DETECTED_ENTITIES: [COL_TEXT, COL_RAW_DETECTED],
+        DetectionTransformOperation.PREPARE_VALIDATION_INPUTS: [COL_TEXT, COL_SEED_ENTITIES],
+        DetectionTransformOperation.ENRICH_VALIDATION_DECISIONS: [
+            COL_VALIDATION_DECISIONS,
+            COL_SEED_VALIDATION_CANDIDATES,
+        ],
+        DetectionTransformOperation.APPLY_VALIDATION_TO_SEED_ENTITIES: [
+            COL_TEXT,
+            COL_SEED_ENTITIES,
+            COL_VALIDATED_ENTITIES,
+        ],
+        DetectionTransformOperation.MERGE_AND_BUILD_CANDIDATES: [
+            COL_TEXT,
+            COL_VALIDATED_SEED_ENTITIES,
+            COL_AUGMENTED_ENTITIES,
+        ],
+        DetectionTransformOperation.APPLY_VALIDATION_AND_FINALIZE: [
+            COL_TEXT,
+            COL_MERGED_ENTITIES,
+            COL_VALIDATED_ENTITIES,
+        ],
+    }
+    _SIDE_EFFECT_COLUMNS: ClassVar[dict[DetectionTransformOperation, list[str]]] = {
+        DetectionTransformOperation.PARSE_DETECTED_ENTITIES: [COL_TAG_NOTATION],
+        DetectionTransformOperation.PREPARE_VALIDATION_INPUTS: [COL_SEED_TAGGED_TEXT],
+        DetectionTransformOperation.ENRICH_VALIDATION_DECISIONS: [],
+        DetectionTransformOperation.APPLY_VALIDATION_TO_SEED_ENTITIES: [
+            COL_INITIAL_TAGGED_TEXT,
+            COL_SEED_ENTITIES_JSON,
+            COL_VALIDATED_SEED_ENTITIES,
+        ],
+        DetectionTransformOperation.MERGE_AND_BUILD_CANDIDATES: [
+            COL_MERGED_TAGGED_TEXT,
+            COL_VALIDATION_CANDIDATES,
+        ],
+        DetectionTransformOperation.APPLY_VALIDATION_AND_FINALIZE: [COL_TAGGED_TEXT],
+    }
+
+    @staticmethod
+    def get_column_emoji() -> str:
+        return "A"
+
+    @property
+    def required_columns(self) -> list[str]:
+        return self._REQUIRED_COLUMNS[DetectionTransformOperation(self.operation)]
+
+    @property
+    def side_effect_columns(self) -> list[str]:
+        return self._SIDE_EFFECT_COLUMNS[DetectionTransformOperation(self.operation)]
+
+
+class ChunkedValidationConfig(SingleColumnConfig):
+    column_type: Literal["anonymizer-chunked-validation"] = "anonymizer-chunked-validation"
+    pool: list[str] = Field(min_length=1)
+    max_entities_per_call: int = Field(gt=0)
+    excerpt_window_chars: int = Field(gt=0)
+    max_parallel_chunks: int | None = Field(default=None, gt=0)
+    single_chunk_full_text: bool = True
+    prompt_template: str = Field(repr=False)
+    system_prompt: str | None = Field(default=None, repr=False)
+
+    @staticmethod
+    def get_column_emoji() -> str:
+        return "A"
+
+    @property
+    def required_columns(self) -> list[str]:
+        return [
+            COL_TEXT,
+            COL_SEED_ENTITIES,
+            COL_SEED_VALIDATION_CANDIDATES,
+            COL_TAG_NOTATION,
+        ]
+
+    @property
+    def side_effect_columns(self) -> list[str]:
+        return []
+
+    def get_model_aliases(self) -> list[str]:
+        return list(self.pool)

--- a/src/anonymizer/engine/workflow_columns/detection/impl.py
+++ b/src/anonymizer/engine/workflow_columns/detection/impl.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from collections.abc import Callable
+from typing import Any
+
+from data_designer.config.column_configs import GenerationStrategy
+from data_designer.engine.column_generators.generators.base import (
+    ColumnGeneratorCellByCell,
+    ColumnGeneratorWithModelRegistry,
+)
+
+from anonymizer.engine.detection.chunked_validation import (
+    ChunkedValidationParams,
+    chunked_validate_row,
+    chunked_validate_row_async,
+)
+from anonymizer.engine.detection.custom_columns import (
+    apply_validation_and_finalize,
+    apply_validation_to_seed_entities,
+    enrich_validation_decisions,
+    merge_and_build_candidates,
+    parse_detected_entities,
+    prepare_validation_inputs,
+)
+from anonymizer.engine.workflow_columns.detection.config import (
+    ChunkedValidationConfig,
+    DetectionTransformConfig,
+    DetectionTransformOperation,
+)
+
+_TRANSFORMS: dict[DetectionTransformOperation, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    DetectionTransformOperation.PARSE_DETECTED_ENTITIES: parse_detected_entities,
+    DetectionTransformOperation.PREPARE_VALIDATION_INPUTS: prepare_validation_inputs,
+    DetectionTransformOperation.ENRICH_VALIDATION_DECISIONS: enrich_validation_decisions,
+    DetectionTransformOperation.APPLY_VALIDATION_TO_SEED_ENTITIES: apply_validation_to_seed_entities,
+    DetectionTransformOperation.MERGE_AND_BUILD_CANDIDATES: merge_and_build_candidates,
+    DetectionTransformOperation.APPLY_VALIDATION_AND_FINALIZE: apply_validation_and_finalize,
+}
+
+
+_BRIDGE_TIMEOUT_FLOOR_S = 60.0
+
+
+def _compute_bridge_timeout(
+    request_timeout: float,
+    max_correction_steps: int,
+    max_conversation_restarts: int = 0,
+) -> float:
+    attempts = (1 + max_conversation_restarts) * (1 + max_correction_steps)
+    return max(_BRIDGE_TIMEOUT_FLOOR_S, attempts * request_timeout * 1.5)
+
+
+class _AsyncBridgedModelFacade:
+    def __init__(self, facade: Any) -> None:
+        self._facade = facade
+
+    def generate(self, *args: Any, **kwargs: Any) -> tuple[Any, list]:
+        from data_designer.engine.models.clients.errors import SyncClientUnavailableError
+
+        try:
+            return self._facade.generate(*args, **kwargs)
+        except SyncClientUnavailableError:
+            pass
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError("model.generate() cannot be bridged from the running event loop.")
+
+        from data_designer.engine.dataset_builders.utils.async_concurrency import ensure_async_engine_loop
+
+        timeout_override = kwargs.get("timeout")
+        request_timeout = float(timeout_override) if timeout_override is not None else self._facade.request_timeout
+        bridge_timeout = _compute_bridge_timeout(
+            request_timeout=request_timeout,
+            max_correction_steps=int(kwargs.get("max_correction_steps", 0) or 0),
+            max_conversation_restarts=int(kwargs.get("max_conversation_restarts", 0) or 0),
+        )
+        loop = ensure_async_engine_loop()
+        future = asyncio.run_coroutine_threadsafe(self._facade.agenerate(*args, **kwargs), loop)
+        try:
+            return future.result(timeout=bridge_timeout)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()
+            from data_designer.engine.models.errors import ModelTimeoutError
+
+            raise ModelTimeoutError(f"model.generate() bridge timed out after {bridge_timeout:.0f}s") from exc
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._facade, name)
+
+
+class DetectionTransformGenerator(ColumnGeneratorCellByCell[DetectionTransformConfig]):
+    def generate(self, data: dict[str, Any]) -> dict[str, Any]:
+        operation = DetectionTransformOperation(self.config.operation)
+        return _TRANSFORMS[operation](data)
+
+
+class ChunkedValidationGenerator(ColumnGeneratorWithModelRegistry[ChunkedValidationConfig]):
+    @staticmethod
+    def get_generation_strategy() -> GenerationStrategy:
+        return GenerationStrategy.CELL_BY_CELL
+
+    def _params(self, models: dict[str, Any]) -> ChunkedValidationParams:
+        return ChunkedValidationParams(
+            pool=list(self.config.pool),
+            max_entities_per_call=self.config.max_entities_per_call,
+            excerpt_window_chars=self.config.excerpt_window_chars,
+            max_parallel_chunks=self.config.max_parallel_chunks or _derive_max_parallel_chunks(models),
+            single_chunk_full_text=self.config.single_chunk_full_text,
+            prompt_template=self.config.prompt_template,
+            system_prompt=self.config.system_prompt,
+        )
+
+    def generate(self, data: dict[str, Any]) -> dict[str, Any]:
+        raw_models = {alias: self.get_model(alias) for alias in self.config.pool}
+        models = {alias: _AsyncBridgedModelFacade(model) for alias, model in raw_models.items()}
+        return chunked_validate_row(data, self._params(raw_models), models)
+
+    async def agenerate(self, data: dict[str, Any]) -> dict[str, Any]:
+        models = {alias: self.get_model(alias) for alias in self.config.pool}
+        return await chunked_validate_row_async(data, self._params(models), models)
+
+
+def _derive_max_parallel_chunks(models: dict[str, Any]) -> int:
+    return max(1, sum(max(1, int(getattr(model, "max_parallel_requests", 1) or 1)) for model in models.values()))

--- a/src/anonymizer/engine/workflow_columns/detection/plugins.py
+++ b/src/anonymizer/engine/workflow_columns/detection/plugins.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from data_designer.plugins import Plugin, PluginType
+
+detection_transform_plugin = Plugin(
+    config_qualified_name="anonymizer.engine.workflow_columns.detection.config.DetectionTransformConfig",
+    impl_qualified_name="anonymizer.engine.workflow_columns.detection.impl.DetectionTransformGenerator",
+    plugin_type=PluginType.COLUMN_GENERATOR,
+)
+
+chunked_validation_plugin = Plugin(
+    config_qualified_name="anonymizer.engine.workflow_columns.detection.config.ChunkedValidationConfig",
+    impl_qualified_name="anonymizer.engine.workflow_columns.detection.impl.ChunkedValidationGenerator",
+    plugin_type=PluginType.COLUMN_GENERATOR,
+)

--- a/tests/engine/test_chunked_validation.py
+++ b/tests/engine/test_chunked_validation.py
@@ -10,11 +10,14 @@ fake ``ModelFacade`` that records calls and returns preconfigured responses.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
+from types import SimpleNamespace
 from typing import Any, Callable
 
 import pytest
+from data_designer.engine.models.clients.errors import SyncClientUnavailableError
 
 from anonymizer.engine.constants import (
     COL_MERGED_TAGGED_TEXT,
@@ -32,6 +35,7 @@ from anonymizer.engine.detection.chunked_validation import (
     build_chunk_skeleton,
     chunk_candidates,
     chunked_validate_row,
+    chunked_validate_row_async,
     make_chunked_validation_generator,
     merge_chunk_decisions,
     order_candidates_by_position,
@@ -44,6 +48,8 @@ from anonymizer.engine.schemas import (
     ValidationCandidateSchema,
     ValidationCandidatesSchema,
 )
+from anonymizer.engine.workflow_columns.detection.config import ChunkedValidationConfig
+from anonymizer.engine.workflow_columns.detection.impl import ChunkedValidationGenerator
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -53,11 +59,8 @@ from anonymizer.engine.schemas import (
 class FakeFacade:
     """Test double for ``ModelFacade`` recording invocations and replaying canned responses.
 
-    Exposes a ``generate()`` method because ``_dispatch_chunk`` calls the
-    sync facade primitive directly; per-row chunk concurrency comes from
-    the ``ThreadPoolExecutor`` inside ``chunked_validate_row``. Under DD's
-    async engine the sync ``.generate()`` call is transparently bridged to
-    ``agenerate`` by the DD runtime.
+    Exposes both ``generate()`` and ``agenerate()`` so the sync custom-column
+    wrapper and async plugin path can share assertions.
 
     A canned response can be a ``dict`` (auto-wrapped in a ```json fence), a
     raw string, or a callable that receives the prompt and returns either.
@@ -70,13 +73,21 @@ class FakeFacade:
         response: dict | str | Callable[[str], dict | str] | None = None,
         *,
         raise_on_call: bool = False,
+        max_parallel_requests: int = 4,
     ) -> None:
         self.alias = alias
         self._response = response
         self._raise = raise_on_call
+        self.max_parallel_requests = max_parallel_requests
         self.calls: list[dict[str, Any]] = []
 
     def generate(self, *, prompt, parser, system_prompt=None, purpose=None, **kwargs):
+        return self._call(prompt=prompt, parser=parser, system_prompt=system_prompt, purpose=purpose, kwargs=kwargs)
+
+    async def agenerate(self, *, prompt, parser, system_prompt=None, purpose=None, **kwargs):
+        return self._call(prompt=prompt, parser=parser, system_prompt=system_prompt, purpose=purpose, kwargs=kwargs)
+
+    def _call(self, *, prompt, parser, system_prompt, purpose, kwargs):
         self.calls.append(
             {
                 "prompt": prompt,
@@ -92,6 +103,63 @@ class FakeFacade:
             response = response(prompt)
         raw = response if isinstance(response, str) else f"```json\n{json.dumps(response)}\n```"
         return parser(raw), []
+
+
+class AsyncTrackingFacade(FakeFacade):
+    """Async-only facade that tracks concurrent ``agenerate`` calls."""
+
+    def __init__(
+        self,
+        alias: str,
+        response: dict | str | Callable[[str], dict | str] | None = None,
+        *,
+        raise_on_call: bool = False,
+    ) -> None:
+        super().__init__(alias, response, raise_on_call=raise_on_call)
+        self.active_calls = 0
+        self.max_active_calls = 0
+
+    def generate(self, *, prompt, parser, system_prompt=None, purpose=None, **kwargs):
+        raise AssertionError("sync generate should not be used by async chunk validation")
+
+    async def agenerate(self, *, prompt, parser, system_prompt=None, purpose=None, **kwargs):
+        self.active_calls += 1
+        self.max_active_calls = max(self.max_active_calls, self.active_calls)
+        try:
+            await asyncio.sleep(0.01)
+            return self._call(prompt=prompt, parser=parser, system_prompt=system_prompt, purpose=purpose, kwargs=kwargs)
+        finally:
+            self.active_calls -= 1
+
+
+class SyncUnavailableFacade(FakeFacade):
+    def __init__(
+        self,
+        alias: str,
+        response: dict | str | Callable[[str], dict | str] | None = None,
+        *,
+        max_parallel_requests: int = 1,
+    ) -> None:
+        super().__init__(alias, response, max_parallel_requests=max_parallel_requests)
+        self.request_timeout = 1.0
+        self.sync_calls = 0
+        self.async_calls = 0
+
+    def generate(self, *, prompt, parser, system_prompt=None, purpose=None, **kwargs):
+        self.sync_calls += 1
+        raise SyncClientUnavailableError("sync client unavailable")
+
+    async def agenerate(self, *, prompt, parser, system_prompt=None, purpose=None, **kwargs):
+        self.async_calls += 1
+        return self._call(prompt=prompt, parser=parser, system_prompt=system_prompt, purpose=purpose, kwargs=kwargs)
+
+
+class FakeModelRegistry:
+    def __init__(self, models: dict[str, Any]) -> None:
+        self.models = models
+
+    def get_model(self, *, model_alias: str) -> Any:
+        return self.models[model_alias]
 
 
 def _entity_span(entity_id: str, value: str, label: str, start: int, end: int) -> EntitySpan:
@@ -581,6 +649,76 @@ class TestChunkedValidateRowPoolOfTwoRoundRobin:
         # 6 candidates / 2 per chunk = 3 chunks; round-robin → v0,v1,v0
         assert len(v0.calls) == 2
         assert len(v1.calls) == 1
+
+
+class TestChunkedValidateRowAsync:
+    def test_async_path_uses_agenerate_and_caps_parallel_chunks(self) -> None:
+        async def run() -> AsyncTrackingFacade:
+            text = "A B C D" + " " * 50
+            spans = [_entity_span(f"e{i}", chr(ord("A") + i), "first_name", i * 2, i * 2 + 1) for i in range(4)]
+            candidates = _candidates_schema(*[(f"e{i}", chr(ord("A") + i), "first_name") for i in range(4)])
+            row = _build_row(text=text, seed_entities=spans, candidates=candidates)
+            facade = AsyncTrackingFacade("v0", response={"decisions": []})
+            params = ChunkedValidationParams(
+                pool=["v0"],
+                max_entities_per_call=1,
+                excerpt_window_chars=50,
+                max_parallel_chunks=2,
+                prompt_template=_MINIMAL_TEMPLATE,
+            )
+
+            await chunked_validate_row_async(row, params, {"v0": facade})
+            return facade
+
+        facade = asyncio.run(run())
+        assert len(facade.calls) == 4
+        assert facade.max_active_calls == 2
+
+    def test_async_primary_failure_falls_over_to_secondary(self) -> None:
+        async def run() -> tuple[dict[str, Any], AsyncTrackingFacade, AsyncTrackingFacade]:
+            spans = [_entity_span("a", "Alice", "first_name", 0, 5)]
+            candidates = _candidates_schema(("a", "Alice", "first_name"))
+            row = _build_row(text="Alice", seed_entities=spans, candidates=candidates)
+            v0 = AsyncTrackingFacade("v0", raise_on_call=True)
+            v1 = AsyncTrackingFacade("v1", response={"decisions": [{"id": "a", "decision": "keep"}]})
+            params = ChunkedValidationParams(
+                pool=["v0", "v1"],
+                max_entities_per_call=5,
+                excerpt_window_chars=50,
+                prompt_template=_MINIMAL_TEMPLATE,
+            )
+
+            out = await chunked_validate_row_async(row, params, {"v0": v0, "v1": v1})
+            return out, v0, v1
+
+        out, v0, v1 = asyncio.run(run())
+        assert out[COL_VALIDATION_DECISIONS]["decisions"][0]["id"] == "a"
+        assert len(v0.calls) == 1
+        assert len(v1.calls) == 1
+
+
+class TestChunkedValidationGenerator:
+    def test_generate_bridges_sync_unavailable_to_agenerate(self) -> None:
+        spans = [_entity_span("a", "Alice", "first_name", 0, 5)]
+        candidates = _candidates_schema(("a", "Alice", "first_name"))
+        row = _build_row(text="Alice", seed_entities=spans, candidates=candidates)
+        facade = SyncUnavailableFacade("v0", response={"decisions": [{"id": "a", "decision": "keep"}]})
+        generator = ChunkedValidationGenerator(
+            ChunkedValidationConfig(
+                name=COL_VALIDATION_DECISIONS,
+                pool=["v0"],
+                max_entities_per_call=5,
+                excerpt_window_chars=50,
+                prompt_template=_MINIMAL_TEMPLATE,
+            ),
+            resource_provider=SimpleNamespace(model_registry=FakeModelRegistry({"v0": facade})),
+        )
+
+        out = generator.generate(row)
+
+        assert out[COL_VALIDATION_DECISIONS]["decisions"][0]["id"] == "a"
+        assert facade.sync_calls == 1
+        assert facade.async_calls == 1
 
 
 class TestChunkedValidateRowMultiChunkReassembly:

--- a/tests/engine/test_detection_workflow.py
+++ b/tests/engine/test_detection_workflow.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import Mock
 
 import pandas as pd
 import pytest
-from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
+from data_designer.config.column_configs import LLMStructuredColumnConfig
 from data_designer.config.models import ModelConfig
+from data_designer.plugins.plugin import PluginType
+from data_designer.plugins.registry import PluginRegistry
 
 from anonymizer.config.models import DetectionModelSelection
 from anonymizer.config.rewrite import PrivacyGoal
@@ -17,15 +20,17 @@ from anonymizer.engine.constants import (
     COL_ENTITIES_BY_VALUE,
     COL_FINAL_ENTITIES,
     COL_LATENT_ENTITIES,
+    COL_MERGED_ENTITIES,
     COL_SEED_ENTITIES,
+    COL_SEED_ENTITIES_JSON,
     COL_SEED_VALIDATION_CANDIDATES,
     COL_TAG_NOTATION,
     COL_TAGGED_TEXT,
     COL_TEXT,
+    COL_VALIDATED_ENTITIES,
     COL_VALIDATION_DECISIONS,
     DEFAULT_ENTITY_LABELS,
 )
-from anonymizer.engine.detection.chunked_validation import ChunkedValidationParams
 from anonymizer.engine.detection.detection_workflow import (
     EntityDetectionWorkflow,
     _format_label_examples,
@@ -41,6 +46,11 @@ from anonymizer.engine.ndd.model_loader import (
     resolve_model_aliases,
 )
 from anonymizer.engine.schemas import EntitiesSchema
+from anonymizer.engine.workflow_columns.detection.config import (
+    ChunkedValidationConfig,
+    DetectionTransformConfig,
+    DetectionTransformOperation,
+)
 
 
 @pytest.fixture
@@ -453,7 +463,7 @@ def test_default_entity_labels_preserves_novel_augmented_entities(
 
 
 # ---------------------------------------------------------------------------
-# Chunked validation wiring (Commit 2)
+# Workflow column wiring
 # ---------------------------------------------------------------------------
 
 
@@ -464,12 +474,90 @@ def _find_column(columns: list, name: str):
     raise AssertionError(f"Column {name!r} not found in workflow columns: {[getattr(c, 'name', c) for c in columns]}")
 
 
-def test_validation_column_is_custom_chunked_generator(
+def test_detection_workflow_plugins_are_discoverable() -> None:
+    PluginRegistry.reset()
+    try:
+        names = {
+            plugin.name
+            for plugin in PluginRegistry().get_plugins(PluginType.COLUMN_GENERATOR)
+            if plugin.name.startswith("anonymizer-")
+        }
+        assert names == {"anonymizer-detection-transform", "anonymizer-chunked-validation"}
+    finally:
+        PluginRegistry.reset()
+
+
+def test_detection_workflow_uses_plugin_transform_columns(
     stub_detector_model_configs: list[ModelConfig],
     stub_detection_model_selection: DetectionModelSelection,
 ) -> None:
-    """COL_VALIDATION_DECISIONS is now a CustomColumnConfig bound to the chunked generator,
-    not an LLMStructuredColumnConfig."""
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Alice"],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
+            }
+        ),
+        failed_records=[],
+    )
+    workflow = EntityDetectionWorkflow(adapter=adapter)
+    workflow.run(
+        pd.DataFrame({COL_TEXT: ["Alice"]}),
+        model_configs=stub_detector_model_configs,
+        selected_models=stub_detection_model_selection,
+        gliner_detection_threshold=0.5,
+        tag_latent_entities=False,
+    )
+    columns = adapter.run_workflow.call_args.kwargs["columns"]
+    expected_operations = {
+        COL_SEED_ENTITIES: DetectionTransformOperation.PARSE_DETECTED_ENTITIES,
+        COL_SEED_VALIDATION_CANDIDATES: DetectionTransformOperation.PREPARE_VALIDATION_INPUTS,
+        COL_VALIDATED_ENTITIES: DetectionTransformOperation.ENRICH_VALIDATION_DECISIONS,
+        COL_SEED_ENTITIES_JSON: DetectionTransformOperation.APPLY_VALIDATION_TO_SEED_ENTITIES,
+        COL_MERGED_ENTITIES: DetectionTransformOperation.MERGE_AND_BUILD_CANDIDATES,
+        COL_DETECTED_ENTITIES: DetectionTransformOperation.APPLY_VALIDATION_AND_FINALIZE,
+    }
+    for name, operation in expected_operations.items():
+        column = _find_column(columns, name)
+        assert isinstance(column, DetectionTransformConfig)
+        assert DetectionTransformOperation(column.operation) == operation
+    assert all(getattr(column, "column_type", None) != "custom" for column in columns)
+
+
+def test_detection_workflow_columns_are_json_serializable(
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> None:
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(
+        dataframe=pd.DataFrame(
+            {
+                COL_TEXT: ["Alice"],
+                COL_DETECTED_ENTITIES: [{"entities": [{"value": "Alice", "label": "first_name"}]}],
+            }
+        ),
+        failed_records=[],
+    )
+    workflow = EntityDetectionWorkflow(adapter=adapter)
+    workflow.run(
+        pd.DataFrame({COL_TEXT: ["Alice"]}),
+        model_configs=stub_detector_model_configs,
+        selected_models=stub_detection_model_selection,
+        gliner_detection_threshold=0.5,
+        tag_latent_entities=False,
+    )
+    payload = json.dumps(
+        [column.model_dump(mode="json") for column in adapter.run_workflow.call_args.kwargs["columns"]]
+    )
+    assert "generator_function" not in payload
+    assert "generator_params" not in payload
+
+
+def test_validation_column_is_chunked_validation_plugin(
+    stub_detector_model_configs: list[ModelConfig],
+    stub_detection_model_selection: DetectionModelSelection,
+) -> None:
     adapter = Mock()
     adapter.run_workflow.return_value = WorkflowRunResult(
         dataframe=pd.DataFrame(
@@ -490,20 +578,14 @@ def test_validation_column_is_custom_chunked_generator(
     )
     columns = adapter.run_workflow.call_args.kwargs["columns"]
     validation_col = _find_column(columns, COL_VALIDATION_DECISIONS)
-    assert isinstance(validation_col, CustomColumnConfig)
-    # Must NOT be the old structured-output LLM column.
+    assert isinstance(validation_col, ChunkedValidationConfig)
     assert not isinstance(validation_col, LLMStructuredColumnConfig)
     assert validation_col.drop is True
-    # generator_params must match the Detect config defaults that flow through.
-    assert isinstance(validation_col.generator_params, ChunkedValidationParams)
-    assert validation_col.generator_params.pool == stub_detection_model_selection.entity_validator
-    assert validation_col.generator_params.max_entities_per_call > 0
-    assert validation_col.generator_params.excerpt_window_chars > 0
-    # The decorated generator's metadata must expose the pool and the exact
-    # set of columns it reads, so DataDesigner resolves facades and DAG ordering.
-    metadata = validation_col.generator_function.custom_column_metadata
-    assert metadata["model_aliases"] == list(stub_detection_model_selection.entity_validator)
-    assert set(metadata["required_columns"]) == {
+    assert validation_col.pool == stub_detection_model_selection.entity_validator
+    assert validation_col.max_entities_per_call > 0
+    assert validation_col.excerpt_window_chars > 0
+    assert validation_col.get_model_aliases() == list(stub_detection_model_selection.entity_validator)
+    assert set(validation_col.required_columns) == {
         COL_TEXT,
         COL_SEED_ENTITIES,
         COL_SEED_VALIDATION_CANDIDATES,
@@ -511,12 +593,12 @@ def test_validation_column_is_custom_chunked_generator(
     }
 
 
-def test_validator_pool_kwargs_thread_through_to_generator_params(
+def test_validator_pool_kwargs_thread_through_to_plugin_config(
     stub_detector_model_configs: list[ModelConfig],
     stub_detection_model_selection: DetectionModelSelection,
 ) -> None:
     """Explicit ``validation_max_entities_per_call`` and ``validation_excerpt_window_chars``
-    propagate from ``run()`` all the way to ``ChunkedValidationParams``."""
+    propagate from ``run()`` to ``ChunkedValidationConfig``."""
     adapter = Mock()
     adapter.run_workflow.return_value = WorkflowRunResult(
         dataframe=pd.DataFrame(
@@ -538,12 +620,12 @@ def test_validator_pool_kwargs_thread_through_to_generator_params(
         tag_latent_entities=False,
     )
     columns = adapter.run_workflow.call_args.kwargs["columns"]
-    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
-    assert params.max_entities_per_call == 17
-    assert params.excerpt_window_chars == 42
+    config = _find_column(columns, COL_VALIDATION_DECISIONS)
+    assert config.max_entities_per_call == 17
+    assert config.excerpt_window_chars == 42
 
 
-def test_validation_single_chunk_full_text_threads_to_generator_params(
+def test_validation_single_chunk_full_text_threads_to_config(
     stub_detector_model_configs: list[ModelConfig],
     stub_detection_model_selection: DetectionModelSelection,
 ) -> None:
@@ -567,8 +649,8 @@ def test_validation_single_chunk_full_text_threads_to_generator_params(
         tag_latent_entities=False,
     )
     columns = adapter.run_workflow.call_args.kwargs["columns"]
-    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
-    assert params.single_chunk_full_text is False
+    config = _find_column(columns, COL_VALIDATION_DECISIONS)
+    assert config.single_chunk_full_text is False
 
 
 def test_build_detection_config_threads_validation_single_chunk_full_text(
@@ -587,8 +669,8 @@ def test_build_detection_config_threads_validation_single_chunk_full_text(
         validation_single_chunk_full_text=False,
     )
     columns = adapter.build_config.call_args.kwargs["columns"]
-    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
-    assert params.single_chunk_full_text is False
+    config = _find_column(columns, COL_VALIDATION_DECISIONS)
+    assert config.single_chunk_full_text is False
 
 
 def test_build_detection_builder_for_seed_threads_validation_single_chunk_full_text(
@@ -606,8 +688,8 @@ def test_build_detection_builder_for_seed_threads_validation_single_chunk_full_t
         validation_single_chunk_full_text=False,
     )
     columns = adapter.build_config_for_seed.call_args.kwargs["columns"]
-    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
-    assert params.single_chunk_full_text is False
+    config = _find_column(columns, COL_VALIDATION_DECISIONS)
+    assert config.single_chunk_full_text is False
 
 
 def test_build_detection_config_uses_default_validation_single_chunk_full_text(
@@ -625,8 +707,8 @@ def test_build_detection_config_uses_default_validation_single_chunk_full_text(
         gliner_detection_threshold=0.5,
     )
     columns = adapter.build_config.call_args.kwargs["columns"]
-    params = _find_column(columns, COL_VALIDATION_DECISIONS).generator_params
-    assert params.single_chunk_full_text is True
+    config = _find_column(columns, COL_VALIDATION_DECISIONS)
+    assert config.single_chunk_full_text is True
 
 
 def test_pool_size_greater_than_one_emits_warning(


### PR DESCRIPTION
## Summary

- Add an Anonymizer workflow-column plugin package with detection transform and chunked validation column types.
- Register both column plugins through `data_designer.plugins` entry points.
- Move the detection workflow off `CustomColumnConfig` for parse, validation prep, chunked validation, merge, and finalize steps.
- Add the staged migration plan under `plans/custom-column-plugins/`, including the note that native NER transport is a separate follow-up from pluginizing custom columns.
- Make the package-level `Anonymizer` export lazy so DataDesigner plugin discovery does not hit a circular import.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring

## Testing

- [ ] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

Targeted validation:

- `.venv/bin/ruff check --fix .`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check src/anonymizer/engine/detection src/anonymizer/engine/workflow_columns tests/engine/test_detection_workflow.py tests/engine/test_chunked_validation.py`
- `.venv/bin/pytest tests/engine/test_detection_postprocess.py tests/engine/test_chunked_validation.py tests/engine/test_detection_workflow.py`
- Plugin discovery smoke test: both `anonymizer-chunked-validation` and `anonymizer-detection-transform` load via DataDesigner registry.
- Real-provider local smoke/benchmark results posted in https://github.com/NVIDIA-NeMo/Anonymizer/pull/192#issuecomment-4730655852.

## Documentation

- [ ] If docs changed: `make docs-build` passes locally

Not run; this PR adds a migration plan under `plans/`, not rendered docs-site content.

## NER Transport Note

This PR does not remove the chat-completions-compatible NER path. The detector remains an `LLMTextColumnConfig`; avoiding the extra chat completions head would require a separate native detector workflow column or provider/client path.

## Related Issues

- DataDesigner native detector follow-up: [NVIDIA-NeMo/DataDesigner#758](https://github.com/NVIDIA-NeMo/DataDesigner/issues/758)
