### PR TITLE
fix: evaluate rewrite_judge not checked

### DIFF
--- a/src/anonymizer/engine/ndd/model_loader.py
+++ b/src/anonymizer/engine/ndd/model_loader.py
@@ -260,13 +260,16 @@ def validate_model_alias_references(
     check_substitute: bool = False,
     check_rewrite: bool = False,
     check_evaluate: bool = False,
+    check_rewrite_judge: bool = False,
 ) -> None:
     """Validate that active workflow model aliases exist in the model pool.
 
-    ``check_evaluate`` validates the evaluation roles. ``detection_validity_judge``
-    is always checked when evaluation is on; the three ``replace_*_judge`` roles
-    are additionally checked when ``check_substitute`` is also True (those only
-    fire on the Substitute replace strategy).
+    ``check_evaluate`` validates the shared evaluation roles (``detection_validity_judge``
+    is always checked when on; the three ``replace_*_judge`` roles are additionally
+    checked when ``check_substitute`` is also True). ``check_rewrite_judge`` validates
+    ``evaluate.rewrite_judge`` and must be set independently when evaluating a rewrite
+    result — it is separate from ``check_rewrite`` so that full rewrite pipeline roles
+    are not required just to call ``evaluate()`` on an existing rewrite result.
     """
     known_aliases = {model_config.alias for model_config in model_configs}
     detection_roles = selected_models.detection.model_dump()
@@ -284,6 +287,8 @@ def validate_model_alias_references(
     if check_evaluate:
         evaluate_roles = selected_models.evaluate.model_dump()
         _collect_role(roles_to_check, "evaluate.detection_validity_judge", evaluate_roles["detection_validity_judge"])
+        if check_rewrite_judge:
+            _collect_role(roles_to_check, "evaluate.rewrite_judge", evaluate_roles["rewrite_judge"])
         if check_substitute:
             for role in (
                 "replace_type_fidelity_judge",
@@ -291,8 +296,6 @@ def validate_model_alias_references(
                 "replace_attribute_fidelity_judge",
             ):
                 _collect_role(roles_to_check, f"evaluate.{role}", evaluate_roles[role])
-        if check_rewrite:
-            _collect_role(roles_to_check, "evaluate.rewrite_judge", evaluate_roles["rewrite_judge"])
 
     unknown = {path: alias for path, alias in roles_to_check.items() if alias not in known_aliases}
     if unknown:

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -383,6 +383,7 @@ class Anonymizer:
                     self._selected_models,
                     check_rewrite=False,
                     check_evaluate=True,
+                    check_rewrite_judge=True,
                 )
             except ValueError as exc:
                 raise InvalidConfigError(str(exc)) from exc

--- a/tests/engine/test_model_loader.py
+++ b/tests/engine/test_model_loader.py
@@ -462,6 +462,47 @@ def test_validate_model_alias_references_skips_rewrite_alias_when_not_enabled(
     )
 
 
+def test_validate_model_alias_references_raises_on_unknown_rewrite_judge_when_check_rewrite_judge_enabled(
+    stub_known_model_configs: list[ModelConfig],
+    stub_slim_model_selection: ModelSelection,
+) -> None:
+    selected_models = stub_slim_model_selection.model_copy(
+        update={
+            "evaluate": stub_slim_model_selection.evaluate.model_copy(
+                update={"rewrite_judge": "bad-rewrite-judge-alias"}
+            )
+        }
+    )
+
+    with pytest.raises(ValueError, match="bad-rewrite-judge-alias"):
+        validate_model_alias_references(
+            stub_known_model_configs,
+            selected_models,
+            check_evaluate=True,
+            check_rewrite_judge=True,
+        )
+
+
+def test_validate_model_alias_references_skips_rewrite_judge_without_check_rewrite_judge(
+    stub_known_model_configs: list[ModelConfig],
+    stub_slim_model_selection: ModelSelection,
+) -> None:
+    selected_models = stub_slim_model_selection.model_copy(
+        update={
+            "evaluate": stub_slim_model_selection.evaluate.model_copy(
+                update={"rewrite_judge": "bad-rewrite-judge-alias"}
+            )
+        }
+    )
+
+    # check_evaluate=True but check_rewrite_judge not set — rewrite_judge must be skipped
+    validate_model_alias_references(
+        stub_known_model_configs,
+        selected_models,
+        check_evaluate=True,
+    )
+
+
 class TestEntityValidatorNormalization:
     """``DetectionModelSelection.entity_validator`` accepts scalar or list input.
 

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -887,6 +887,35 @@ def test_evaluate_rewrite_raises_without_rewrite_config() -> None:
         anonymizer.evaluate(bare_result)  # type: ignore[arg-type]
 
 
+def test_evaluate_rewrite_raises_on_bad_rewrite_judge_alias(
+    stub_input: AnonymizerInput,
+    stub_known_model_configs: list[ModelConfig],
+    stub_slim_model_selection: ModelSelection,
+) -> None:
+    """evaluate() on a rewrite result must raise InvalidConfigError for an unknown rewrite_judge alias.
+
+    This is the integration-level counterpart to the unit tests on
+    validate_model_alias_references — it guards the path from Anonymizer.evaluate()
+    through to the validator so that a misconfigured evaluate.rewrite_judge is caught
+    before any LLM call is made.
+    """
+    config = AnonymizerConfig(rewrite=Rewrite())
+    anonymizer, _, _, _ = _make_anonymizer()
+    anonymizer._model_configs = stub_known_model_configs
+    anonymizer._selected_models = stub_slim_model_selection.model_copy(
+        update={
+            "evaluate": stub_slim_model_selection.evaluate.model_copy(
+                update={"rewrite_judge": "bad-rewrite-judge-alias"}
+            )
+        }
+    )
+
+    run_result = anonymizer.run(config=config, data=stub_input)
+
+    with pytest.raises(InvalidConfigError, match="bad-rewrite-judge-alias"):
+        anonymizer.evaluate(run_result)
+
+
 def test_evaluate_rewrite_calls_validate_with_check_rewrite_false(stub_input: AnonymizerInput) -> None:
     """evaluate() on a rewrite result must NOT validate rewrite pipeline model aliases.
 


### PR DESCRIPTION
## Summary

- **Bug:** `evaluate.rewrite_judge` alias was never validated — `run()` skips `check_evaluate` entirely, and `evaluate()` passes `check_rewrite=False` but `rewrite_judge` was nested under `if check_rewrite`, so neither path caught a misconfigured alias at preflight
- **Fix:** Added `check_rewrite_judge: bool = False` to `validate_model_alias_references`; gates `evaluate.rewrite_judge` validation independently of `check_rewrite`, so full rewrite pipeline roles are not required just to call `evaluate()`
- **Call site:** Rewrite `evaluate()` path in `anonymizer.py` now passes `check_rewrite_judge=True` alongside `check_rewrite=False, check_evaluate=True`
- **Tests:** Two new tests in `test_model_loader.py` — bad alias raises with `check_rewrite_judge=True`; skipped without it

Follow-up to #186.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [ ] `make check` passes locally (format + lint + typecheck + lock-check)
- [ ] Added/updated tests for changes

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

## Related Issues
<!-- Closes #123 -->
