### PR TITLE
feat: expose Data Designer run config

### DIFF
--- a/src/anonymizer/__init__.py
+++ b/src/anonymizer/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 __version__ = version("nemo-anonymizer")
 
 from data_designer.config.models import ModelProvider as ModelProvider
+from data_designer.config.run_config import RunConfig as RunConfig
 
 from anonymizer.config.anonymizer_config import (
     AnonymizerConfig,
@@ -64,6 +65,7 @@ __all__ = [
     "Redact",
     "Rewrite",
     "RiskTolerance",
+    "RunConfig",
     "Substitute",
     "configure_logging",
 ]

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from data_designer.config.models import ModelProvider
+from data_designer.config.run_config import RunConfig
 from data_designer.config.utils.io_helpers import load_config_file
 from data_designer.interface.data_designer import DataDesigner
 
@@ -109,6 +110,7 @@ class Anonymizer:
         model_providers: list[ModelProvider] | str | Path | None = None,
         artifact_path: str | Path | None = None,
         data_designer: DataDesigner | None = None,
+        data_designer_run_config: RunConfig | None = None,
         detection_workflow: EntityDetectionWorkflow | None = None,
         replace_runner: ReplacementWorkflow | None = None,
         rewrite_runner: RewriteWorkflow | None = None,
@@ -125,6 +127,10 @@ class Anonymizer:
             artifact_path: Directory for intermediate artifacts. Defaults to
                 ``.anonymizer-artifacts``.
             data_designer: Pre-configured DataDesigner instance (advanced usage).
+            data_designer_run_config: Optional DataDesigner run configuration
+                applied to the Anonymizer-managed or caller-supplied DataDesigner
+                instance. Use this for DataDesigner execution knobs such as
+                ``buffer_size`` and ``max_in_flight_tasks``.
             detection_workflow: Custom detection workflow (advanced/testing).
             replace_runner: Custom replacement workflow (advanced/testing).
             rewrite_runner: Custom rewrite workflow (advanced/testing).
@@ -164,6 +170,8 @@ class Anonymizer:
                 model_providers=self._resolved_providers,
             )
             reapply_log_levels()
+        if data_designer_run_config is not None:
+            self._data_designer.set_run_config(data_designer_run_config)
         self._adapter = NddAdapter(data_designer=self._data_designer)
         self._detection_workflow = detection_workflow or EntityDetectionWorkflow(adapter=self._adapter)
         self._replace_runner = replace_runner or ReplacementWorkflow(

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from data_designer.config.models import ModelProvider
+from data_designer.config.run_config import RunConfig
 from data_designer.config.utils.io_helpers import load_config_file
 from data_designer.interface.data_designer import DataDesigner
 
@@ -86,7 +87,6 @@ from anonymizer.telemetry import (
 if TYPE_CHECKING:
     import pandas as pd
     from data_designer.config.config_builder import DataDesignerConfigBuilder
-    from data_designer.config.run_config import RunConfig
 
 logger = logging.getLogger("anonymizer")
 

--- a/src/anonymizer/interface/anonymizer.py
+++ b/src/anonymizer/interface/anonymizer.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from data_designer.config.models import ModelProvider
-from data_designer.config.run_config import RunConfig
 from data_designer.config.utils.io_helpers import load_config_file
 from data_designer.interface.data_designer import DataDesigner
 
@@ -87,6 +86,7 @@ from anonymizer.telemetry import (
 if TYPE_CHECKING:
     import pandas as pd
     from data_designer.config.config_builder import DataDesignerConfigBuilder
+    from data_designer.config.run_config import RunConfig
 
 logger = logging.getLogger("anonymizer")
 

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -10,8 +10,8 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 from data_designer.config.models import ModelConfig
-from data_designer.config.run_config import RunConfig
 
+from anonymizer import RunConfig
 from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Rewrite
 from anonymizer.config.models import ModelSelection, ReplaceModelSelection
 from anonymizer.config.replace_strategies import Redact, Substitute

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 from data_designer.config.models import ModelConfig
+from data_designer.config.run_config import RunConfig
 
 from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput, Rewrite
 from anonymizer.config.models import ModelSelection, ReplaceModelSelection
@@ -167,6 +168,37 @@ def test_anonymizer_custom_model_providers_override_bundled_defaults() -> None:
         )
     passed_providers = mock_data_designer.call_args.kwargs["model_providers"]
     assert passed_providers is custom_providers
+
+
+def test_anonymizer_applies_data_designer_run_config_to_managed_instance() -> None:
+    run_config = RunConfig(buffer_size=20, max_in_flight_tasks=64)
+
+    with patch("anonymizer.interface.anonymizer.DataDesigner") as mock_data_designer:
+        Anonymizer(
+            data_designer_run_config=run_config,
+            detection_workflow=Mock(),
+            replace_runner=Mock(),
+            rewrite_runner=Mock(),
+        )
+
+    mock_data_designer.return_value.set_run_config.assert_called_once_with(run_config)
+
+
+def test_anonymizer_applies_data_designer_run_config_to_supplied_instance() -> None:
+    from data_designer.interface.data_designer import DataDesigner
+
+    data_designer = Mock(spec=DataDesigner)
+    run_config = RunConfig(buffer_size=20, max_in_flight_tasks=64)
+
+    Anonymizer(
+        data_designer=data_designer,
+        data_designer_run_config=run_config,
+        detection_workflow=Mock(),
+        replace_runner=Mock(),
+        rewrite_runner=Mock(),
+    )
+
+    data_designer.set_run_config.assert_called_once_with(run_config)
 
 
 def test_anonymizer_rejects_missing_provider_as_invalid_config_error() -> None:

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import get_type_hints
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -200,12 +199,6 @@ def test_anonymizer_applies_data_designer_run_config_to_supplied_instance() -> N
     )
 
     data_designer.set_run_config.assert_called_once_with(run_config)
-
-
-def test_anonymizer_init_type_hints_resolve_run_config() -> None:
-    hints = get_type_hints(Anonymizer.__init__)
-
-    assert hints["data_designer_run_config"] == RunConfig | None
 
 
 def test_anonymizer_rejects_missing_provider_as_invalid_config_error() -> None:

--- a/tests/interface/test_anonymizer_interface.py
+++ b/tests/interface/test_anonymizer_interface.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import get_type_hints
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -199,6 +200,12 @@ def test_anonymizer_applies_data_designer_run_config_to_supplied_instance() -> N
     )
 
     data_designer.set_run_config.assert_called_once_with(run_config)
+
+
+def test_anonymizer_init_type_hints_resolve_run_config() -> None:
+    hints = get_type_hints(Anonymizer.__init__)
+
+    assert hints["data_designer_run_config"] == RunConfig | None
 
 
 def test_anonymizer_rejects_missing_provider_as_invalid_config_error() -> None:


### PR DESCRIPTION
## Summary
Adds an optional `data_designer_run_config` parameter to `Anonymizer(...)` so callers can configure Data Designer runtime controls such as `buffer_size` and `max_in_flight_tasks` while still using Anonymizer's normal model config/provider loading path.

The name is intentionally explicit: it sits next to the existing advanced `data_designer` constructor parameter and avoids overloading `run_config`, which could be confused with `AnonymizerConfig` or `anonymizer.run(config=...)`.

This keeps execution/backpressure tuning on the runtime constructor instead of putting it on `AnonymizerConfig`, which remains focused on anonymization behavior. The PR also re-exports `RunConfig` from `anonymizer` so examples can use the public Anonymizer import path.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `make test` passes locally
- [x] `make check` passes locally (format + lint + typecheck + lock-check)
- [x] Added/updated tests for changes

Targeted validation run:
- `uv run pytest tests/interface/test_anonymizer_interface.py -q`
- `uv run ruff check src/anonymizer/interface/anonymizer.py tests/interface/test_anonymizer_interface.py`

## Documentation
- [ ] If docs changed: `make docs-build` passes locally

No docs changed. This small API hook is intended to support self-hosted Data Designer runtime/backpressure configuration without bypassing Anonymizer's provider setup.

## Related Issues
<!-- Closes #123 -->