### PR TITLE
fix: increase latent entity rationale maxLength from 150 to 250

### DIFF
--- a/src/anonymizer/engine/schemas/detection.py
+++ b/src/anonymizer/engine/schemas/detection.py
@@ -157,7 +157,7 @@ class LatentEntitySchema(BaseModel):
     )
     rationale: str = Field(
         min_length=20,
-        max_length=150,
+        max_length=250,
         description="One sentence explaining the inference without adding new facts",
     )
 


### PR DESCRIPTION
## Summary
- Increases `LatentEntitySchema.rationale` `max_length` from 150 to 250 characters

## Motivation
Validation errors on longer LLM-generated rationale strings were causing record loss. The model regularly produces rationales in the 150–200 char range that were being silently dropped.

