### PR TITLE
bugfix: remove stale evaluation kwarg from _run_final_judge

### DIFF
--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -327,7 +327,6 @@ class RewriteWorkflow:
                 model_configs=model_configs,
                 selected_models=selected_models,
                 privacy_goal=privacy_goal,
-                evaluation=evaluation,
                 preview_num_records=preview_num_records,
             )
             all_failed.extend(judge_failed)
@@ -454,14 +453,12 @@ class RewriteWorkflow:
         model_configs: list[ModelConfig],
         selected_models: RewriteModelSelection,
         privacy_goal: PrivacyGoal,
-        evaluation: EvaluationCriteria,
         preview_num_records: int | None,
     ) -> tuple[pd.DataFrame, list[FailedRecord]]:
         try:
             judge_columns = self._judge_wf.columns(
                 selected_models=selected_models,
                 privacy_goal=privacy_goal,
-                evaluation=evaluation,
             )
             judge_seed = select_seed_cols(df, derive_seed_columns(judge_columns, df))
             judge_result = self._adapter.run_workflow(


### PR DESCRIPTION
## Summary
- PR #173 refactored `FinalJudgeWorkflow.columns()` to remove the `evaluation` parameter, but `rewrite_workflow.py` was not updated — it still passed `evaluation=evaluation` in the call site and in `_run_final_judge`'s signature
- This caused a `TypeError: FinalJudgeWorkflow.columns() got an unexpected keyword argument 'evaluation'` at runtime whenever the final judge step ran

## Test plan
- [ ] Run the rewrite pipeline end-to-end and confirm the final judge step completes without `TypeError`
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)