### PR TITLE
fix: coerce low combined_risk_level to medium instead of rejecting

### DIFF
--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -150,8 +150,9 @@ class EntityDispositionSchema(BaseModel):
             self.combined_risk_level == CombinedRiskLevel.low
             and self.protection_method_suggestion != ProtectionMethod.leave_as_is
         ):
-            # LLM occasionally returns an inconsistent combination; coerce rather than reject.
-            self.protection_method_suggestion = ProtectionMethod.leave_as_is
+            # Trust the protection intent over the risk label; promote risk to medium
+            # rather than suppressing the protection.
+            self.combined_risk_level = CombinedRiskLevel.medium
         if (
             self.combined_risk_level == CombinedRiskLevel.high
             and self.protection_method_suggestion == ProtectionMethod.leave_as_is

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -38,9 +38,12 @@ Supporting enums: Domain, EntitySource, EntityCategory, SensitivityLevel,
 
 from __future__ import annotations
 
+import logging
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
+
+logger = logging.getLogger("anonymizer.schemas.rewrite")
 
 # ---------------------------------------------------------------------------
 # Domain
@@ -150,6 +153,13 @@ class EntityDispositionSchema(BaseModel):
             self.combined_risk_level == CombinedRiskLevel.low
             and self.protection_method_suggestion != ProtectionMethod.leave_as_is
         ):
+            logger.warning(
+                "Entity %d (%r): combined_risk_level='low' conflicts with "
+                "protection_method_suggestion=%r; promoting risk to 'medium'.",
+                self.id,
+                self.entity_value,
+                self.protection_method_suggestion,
+            )
             # Trust the protection intent over the risk label; promote risk to medium
             # rather than suppressing the protection.
             self.combined_risk_level = CombinedRiskLevel.medium

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -150,10 +150,8 @@ class EntityDispositionSchema(BaseModel):
             self.combined_risk_level == CombinedRiskLevel.low
             and self.protection_method_suggestion != ProtectionMethod.leave_as_is
         ):
-            raise ValueError(
-                f"Entity {self.id}: combined_risk_level='low' requires protection_method_suggestion='leave_as_is', "
-                f"got '{self.protection_method_suggestion}'"
-            )
+            # LLM occasionally returns an inconsistent combination; coerce rather than reject.
+            self.protection_method_suggestion = ProtectionMethod.leave_as_is
         if (
             self.combined_risk_level == CombinedRiskLevel.high
             and self.protection_method_suggestion == ProtectionMethod.leave_as_is

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -154,10 +154,10 @@ class EntityDispositionSchema(BaseModel):
             and self.protection_method_suggestion != ProtectionMethod.leave_as_is
         ):
             logger.warning(
-                "Entity %d (%r): combined_risk_level='low' conflicts with "
+                "Entity %d (label=%r): combined_risk_level='low' conflicts with "
                 "protection_method_suggestion=%r; promoting risk to 'medium'.",
                 self.id,
-                self.entity_value,
+                self.entity_label,
                 self.protection_method_suggestion,
             )
             # Trust the protection intent over the risk label; promote risk to medium

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -162,7 +162,7 @@ class EntityDispositionSchema(BaseModel):
             )
             # Trust the protection intent over the risk label; promote risk to medium
             # rather than suppressing the protection.
-            self.combined_risk_level = CombinedRiskLevel.medium.value  # type: ignore[assignment]
+            self.combined_risk_level = CombinedRiskLevel.medium.value  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         if (
             self.combined_risk_level == CombinedRiskLevel.high
             and self.protection_method_suggestion == ProtectionMethod.leave_as_is

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -162,7 +162,7 @@ class EntityDispositionSchema(BaseModel):
             )
             # Trust the protection intent over the risk label; promote risk to medium
             # rather than suppressing the protection.
-            self.combined_risk_level = CombinedRiskLevel.medium.value
+            self.combined_risk_level = CombinedRiskLevel.medium.value  # type: ignore[assignment]
         if (
             self.combined_risk_level == CombinedRiskLevel.high
             and self.protection_method_suggestion == ProtectionMethod.leave_as_is

--- a/src/anonymizer/engine/schemas/rewrite.py
+++ b/src/anonymizer/engine/schemas/rewrite.py
@@ -162,7 +162,7 @@ class EntityDispositionSchema(BaseModel):
             )
             # Trust the protection intent over the risk label; promote risk to medium
             # rather than suppressing the protection.
-            self.combined_risk_level = CombinedRiskLevel.medium
+            self.combined_risk_level = CombinedRiskLevel.medium.value
         if (
             self.combined_risk_level == CombinedRiskLevel.high
             and self.protection_method_suggestion == ProtectionMethod.leave_as_is

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -244,11 +244,11 @@ def mixed_disposition() -> SensitivityDispositionSchema:
 # EntityDispositionSchema — protection consistency
 
 
-def test_entity_disposition_invalid_low_risk_but_not_leave_as_is() -> None:
-    with pytest.raises(ValidationError, match="combined_risk_level='low'"):
-        EntityDispositionSchema.model_validate(
-            _make_entity(combined_risk_level="low", protection_method_suggestion="replace")
-        )
+def test_entity_disposition_low_risk_non_leave_as_is_is_coerced() -> None:
+    entity = EntityDispositionSchema.model_validate(
+        _make_entity(combined_risk_level="low", protection_method_suggestion="replace")
+    )
+    assert entity.protection_method_suggestion == "leave_as_is"
 
 
 def test_entity_disposition_invalid_high_risk_but_leave_as_is() -> None:

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -244,12 +244,13 @@ def mixed_disposition() -> SensitivityDispositionSchema:
 # EntityDispositionSchema — protection consistency
 
 
-def test_entity_disposition_low_risk_non_leave_as_is_promotes_risk_to_medium() -> None:
+@pytest.mark.parametrize("method", ["replace", "generalize", "remove", "suppress_inference"])
+def test_entity_disposition_low_risk_non_leave_as_is_promotes_risk_to_medium(method: str) -> None:
     entity = EntityDispositionSchema.model_validate(
-        _make_entity(combined_risk_level="low", protection_method_suggestion="replace")
+        _make_entity(combined_risk_level="low", protection_method_suggestion=method)
     )
     assert entity.combined_risk_level == "medium"
-    assert entity.protection_method_suggestion == "replace"
+    assert entity.protection_method_suggestion == method
 
 
 def test_entity_disposition_invalid_high_risk_but_leave_as_is() -> None:

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -244,11 +244,12 @@ def mixed_disposition() -> SensitivityDispositionSchema:
 # EntityDispositionSchema — protection consistency
 
 
-def test_entity_disposition_low_risk_non_leave_as_is_is_coerced() -> None:
+def test_entity_disposition_low_risk_non_leave_as_is_promotes_risk_to_medium() -> None:
     entity = EntityDispositionSchema.model_validate(
         _make_entity(combined_risk_level="low", protection_method_suggestion="replace")
     )
-    assert entity.protection_method_suggestion == "leave_as_is"
+    assert entity.combined_risk_level == "medium"
+    assert entity.protection_method_suggestion == "replace"
 
 
 def test_entity_disposition_invalid_high_risk_but_leave_as_is() -> None:

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -254,7 +254,7 @@ def test_entity_disposition_low_risk_non_leave_as_is_promotes_risk_to_medium(met
     # Coerced and non-coerced paths must produce the same serialization type (plain string, not enum).
     dumped = entity.model_dump()
     assert dumped["combined_risk_level"] == "medium"
-    assert isinstance(dumped["combined_risk_level"], str)
+    assert type(dumped["combined_risk_level"]) is str
 
 
 def test_entity_disposition_invalid_high_risk_but_leave_as_is() -> None:

--- a/tests/engine/test_schemas.py
+++ b/tests/engine/test_schemas.py
@@ -251,6 +251,10 @@ def test_entity_disposition_low_risk_non_leave_as_is_promotes_risk_to_medium(met
     )
     assert entity.combined_risk_level == "medium"
     assert entity.protection_method_suggestion == method
+    # Coerced and non-coerced paths must produce the same serialization type (plain string, not enum).
+    dumped = entity.model_dump()
+    assert dumped["combined_risk_level"] == "medium"
+    assert isinstance(dumped["combined_risk_level"], str)
 
 
 def test_entity_disposition_invalid_high_risk_but_leave_as_is() -> None:


### PR DESCRIPTION
## Summary
 - The LLM occasionally outputs combined_risk_level='low' with a non-leave_as_is
  protection_method_suggestion (e.g. suppress_inference, generalize)
  - Previously EntityDispositionSchema._validate_protection_consistency raised a ValidationError, which
  caused the entire record to be skipped (UPDATE - sometimes the record isn't skipped, but the entity silently gets dropped from the sensitivity disposition)
  - Now combined_risk_level is promoted to medium — preserving the model's intent to protect the entity
  rather than suppressing it. This is more appropriate for weaker models that apply protection methods
  without fully accounting for contextual risk
  - Updated the corresponding test from asserting a ValidationError to asserting that
  combined_risk_level is promoted and the original protection_method_suggestion is retained

UPDATE - the sensitivity disposition prompt is overloaded and doesn't do as well on gpt-oss-120b. We will do another PR to fix that, but above is a quick fix for now

