### PR TITLE
ci: add NVSkills CI request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Related Issue

No linked issue required: maintainer-owned NVSkills CI integration.

## Plan Document

No plan required: this ports the landed Safe Synthesizer requester workflow unchanged apart from the repository SPDX header.

## Summary

- Add the repository-side requester for `/nvskills-ci` PR comments.
- Dispatch the shared `NVIDIA/skills` workflow for evaluation requests and signature-bot pushes.
- Keep permissions read-only and pass only the dedicated dispatch secret.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI, release, or contributor workflow update

## Contributor Checklist

- [x] PR title follows Conventional Commits
- [x] Maintainer-owned no-issue reason is documented above
- [x] No-plan reason is documented above
- [x] Public API impact checked; no skill update needed
- [x] No real PII added
- [x] No credentials or secret values added

## Validation

- `uv run --frozen pre-commit run check-yaml --files .github/workflows/request-nvskills-ci.yml`
- `uv run --frozen pre-commit run --files .github/workflows/request-nvskills-ci.yml`
- Compared with NVIDIA-NeMo/Safe-Synthesizer#602; only the SPDX header differs.

## Documentation and Artifacts

- [x] Documentation updates are not needed.

## Administrator Follow-up

Configure the `NVSKILLS_CI_DISPATCH_TOKEN` Actions secret before using `/nvskills-ci`.
