### PR TITLE
docs: clarify rewrite notebook guidance

### DIFF
--- a/docs/notebook_source/01_your_first_anonymization.py
+++ b/docs/notebook_source/01_your_first_anonymization.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # ---
 # jupyter:
 #   jupytext:

--- a/docs/notebook_source/02_inspecting_detected_entities.py
+++ b/docs/notebook_source/02_inspecting_detected_entities.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # ---
 # jupyter:
 #   jupytext:

--- a/docs/notebook_source/03_choosing_a_replacement_strategy.py
+++ b/docs/notebook_source/03_choosing_a_replacement_strategy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # ---
 # jupyter:
 #   jupytext:

--- a/docs/notebook_source/04_rewriting_biographies.py
+++ b/docs/notebook_source/04_rewriting_biographies.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # ---
 # jupyter:
 #   jupytext:
@@ -18,8 +21,8 @@
 # -->
 # # 🕵️ Rewriting Biographies
 #
-# Instead of replacing entities with tokens, rewrite mode generates a
-# privacy-safe transformation of the entire text. The `run()` / `preview()` pipeline:
+# Instead of replacing individual entities, rewrite mode transforms the entire
+# text and measures any sensitive information that remains. The `run()` / `preview()` pipeline:
 #
 # 1. Detects entities (same as replace mode, plus latent entity detection)
 # 2. Classifies the domain and assigns sensitivity dispositions
@@ -154,7 +157,7 @@ result.trace_dataframe.columns.tolist()
 # %% [markdown]
 # ## 🚩 Filter by review flag
 #
-# - Records where automated metrics exceed thresholds are flagged for manual review.
+# - Records that cross the configured leakage or utility thresholds are flagged for manual review.
 # - `needs_human_review` is threshold-based, so a record can have small nonzero
 #   leakage without being flagged.
 # - Use this to prioritize human attention on the records that need it most.
@@ -173,7 +176,7 @@ flagged.head()
 # Call `evaluate()` to run LLM-as-judge scoring on the rewrite result — detection validity and three quality rubrics (privacy, quality, style).
 # Evaluation makes additional LLM calls per record. For larger datasets, evaluate
 # a preview first; this tutorial evaluates all 25 rows to demonstrate the complete workflow.
-# This holistic judge is independent of pipeline leakage scoring, so their assessments may differ.
+# The holistic privacy rubric and pipeline leakage metric are independent, so they may disagree.
 # See [Evaluation](../../concepts/evaluation/#rewrite-evaluation) for details.
 
 # %%

--- a/docs/notebook_source/05_rewriting_legal_documents.py
+++ b/docs/notebook_source/05_rewriting_legal_documents.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # ---
 # jupyter:
 #   jupytext:
@@ -178,9 +181,10 @@ result.dataframe[["text_rewritten", "utility_score", "leakage_mass", "needs_huma
 # %% [markdown]
 # ## 🚩 Filter by review flag
 #
-# - Records where automated metrics exceed thresholds are flagged for manual review.
-# - The repair loop stops after `max_repair_iterations`; records that still need
-#   repair remain flagged for human review but are not pipeline failures.
+# - Records that cross the configured leakage or utility thresholds are flagged for manual review.
+# - The repair loop stops after `max_repair_iterations`. Afterward,
+#   `needs_human_review` is computed separately from the final leakage, utility,
+#   and high-sensitivity-leak metrics.
 # - Use this to prioritize human attention on the records that need it most.
 # - See [Working with flagged records](../../concepts/rewrite/#working-with-flagged-records)
 #   for guidance on diagnosing and resolving flagged records.
@@ -197,7 +201,7 @@ flagged.head()
 # Call `evaluate()` to run LLM-as-judge scoring on the rewrite result — detection validity and three quality rubrics (privacy, quality, style).
 # Evaluation makes additional LLM calls per record. For larger datasets, evaluate
 # a preview first; this tutorial evaluates all 25 rows to demonstrate the complete workflow.
-# This holistic judge is independent of pipeline leakage scoring, so their assessments may differ.
+# The holistic privacy rubric and pipeline leakage metric are independent, so they may disagree.
 # See [Evaluation](../../concepts/evaluation/#rewrite-evaluation) for details.
 
 # %%

--- a/docs/notebooks/04_rewriting_biographies.ipynb
+++ b/docs/notebooks/04_rewriting_biographies.ipynb
@@ -11,8 +11,8 @@
         "-->\n",
         "# 🕵️ Rewriting Biographies\n",
         "\n",
-        "Instead of replacing entities with tokens, rewrite mode generates a\n",
-        "privacy-safe transformation of the entire text. The `run()` / `preview()` pipeline:\n",
+        "Instead of replacing individual entities, rewrite mode transforms the entire\n",
+        "text and measures any sensitive information that remains. The `run()` / `preview()` pipeline:\n",
         "\n",
         "1. Detects entities (same as replace mode, plus latent entity detection)\n",
         "2. Classifies the domain and assigns sensitivity dispositions\n",
@@ -800,7 +800,7 @@
       "source": [
         "## 🚩 Filter by review flag\n",
         "\n",
-        "- Records where automated metrics exceed thresholds are flagged for manual review.\n",
+        "- Records that cross the configured leakage or utility thresholds are flagged for manual review.\n",
         "- `needs_human_review` is threshold-based, so a record can have small nonzero\n",
         "  leakage without being flagged.\n",
         "- Use this to prioritize human attention on the records that need it most.\n",
@@ -891,7 +891,7 @@
         "Call `evaluate()` to run LLM-as-judge scoring on the rewrite result — detection validity and three quality rubrics (privacy, quality, style).\n",
         "Evaluation makes additional LLM calls per record. For larger datasets, evaluate\n",
         "a preview first; this tutorial evaluates all 25 rows to demonstrate the complete workflow.\n",
-        "This holistic judge is independent of pipeline leakage scoring, so their assessments may differ.\n",
+        "The holistic privacy rubric and pipeline leakage metric are independent, so they may disagree.\n",
         "See [Evaluation](../../concepts/evaluation/#rewrite-evaluation) for details."
       ]
     },

--- a/docs/notebooks/05_rewriting_legal_documents.ipynb
+++ b/docs/notebooks/05_rewriting_legal_documents.ipynb
@@ -960,9 +960,10 @@
       "source": [
         "## 🚩 Filter by review flag\n",
         "\n",
-        "- Records where automated metrics exceed thresholds are flagged for manual review.\n",
-        "- The repair loop stops after `max_repair_iterations`; records that still need\n",
-        "  repair remain flagged for human review but are not pipeline failures.\n",
+        "- Records that cross the configured leakage or utility thresholds are flagged for manual review.\n",
+        "- The repair loop stops after `max_repair_iterations`. Afterward,\n",
+        "  `needs_human_review` is computed separately from the final leakage, utility,\n",
+        "  and high-sensitivity-leak metrics.\n",
         "- Use this to prioritize human attention on the records that need it most.\n",
         "- See [Working with flagged records](../../concepts/rewrite/#working-with-flagged-records)\n",
         "  for guidance on diagnosing and resolving flagged records."
@@ -1136,7 +1137,7 @@
         "Call `evaluate()` to run LLM-as-judge scoring on the rewrite result — detection validity and three quality rubrics (privacy, quality, style).\n",
         "Evaluation makes additional LLM calls per record. For larger datasets, evaluate\n",
         "a preview first; this tutorial evaluates all 25 rows to demonstrate the complete workflow.\n",
-        "This holistic judge is independent of pipeline leakage scoring, so their assessments may differ.\n",
+        "The holistic privacy rubric and pipeline leakage metric are independent, so they may disagree.\n",
         "See [Evaluation](../../concepts/evaluation/#rewrite-evaluation) for details."
       ]
     },


### PR DESCRIPTION
Follow-up to #218.

## Summary

- Restore file-level SPDX headers in all five Python notebook sources while retaining the hidden notebook notices.
- Describe repair and human-review decisions as separate threshold checks.
- Calibrate rewrite privacy language and clarify the leakage-metric comparison.
- Synchronize the affected notebook input cells without changing execution outputs.

## Validation

- `tools/codestyle/format.sh --check`
- `tools/codestyle/ruff_check.sh`
- `tools/codestyle/copyright_fixer.py --check .`
- `mkdocs build --strict`
- Notebook schema validation for all five tutorials
- Source/notebook input-cell synchronization check