### PR TITLE
fix(measurement): allow rewrite W&B records and project dirs

### DIFF
--- a/docs/development/observability.md
+++ b/docs/development/observability.md
@@ -133,8 +133,10 @@ information in these values.
 
 The runner stages W&B files under `<benchmark-output>/.wandb-private` with
 owner-only permissions. Descriptor-relative traversal rejects symlinks and
-untrusted writable directories. Offline runs retain this directory for later
-sync.
+untrusted writable directories. Root-owned, group-writable project directories
+are trusted shared-storage ancestors, but the final benchmark output and W&B
+staging directories must be owned by the current user. Offline runs retain this
+directory for later sync.
 
 The main goal is benchmark data in W&B. Workspaces, reports, project views, and
 panels are presentation layers. They can be edited in W&B, regenerated with the
@@ -171,9 +173,11 @@ provenance, and producer commit. Seal creation and import share the same
 completed-run invariant and require every record's reserved case tags to match
 the seal identity. `write_completion_seal.py` owns the producer contract;
 `import_wandb_run.py` captures and verifies the sealed JSONL before a strict W&B
-publication. Identical completed imports reuse a destination-scoped run ID with
-`resume="allow"` and become no-ops. Changed sealed content receives a different
-run ID.
+publication. Root-owned, group-writable project directories are trusted
+shared-storage ancestors for seal writes, but the final case directory must be
+owned by the current user. Identical completed imports reuse a
+destination-scoped run ID with `resume="allow"` and become no-ops. Changed
+sealed content receives a different run ID.
 
 ## Local and Slurm Benchmark Execution
 

--- a/tests/tools/test_measurement_ingress_completion.py
+++ b/tests/tools/test_measurement_ingress_completion.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -46,7 +47,7 @@ def _rewrite_run_payload(*, include_replace_key: bool) -> dict[str, Any]:
         "input_has_data_summary": False,
         "detect": {"entity_label_source": "default", "entity_label_count": 2},
         "rewrite": {
-            "risk_tolerance": "medium",
+            "risk_tolerance": "low",
             "max_repair_iterations": 2,
             "strict_entity_protection": True,
         },
@@ -116,6 +117,33 @@ def test_wandb_snapshot_accepts_rewrite_run_without_replace_metadata(
     assert snapshot.records[0].record_type == "run"
     assert snapshot.records[0].mode == "rewrite"
     assert snapshot.records[0].replace is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "missing_key"),
+    [
+        ("replace", "replace"),
+        ("rewrite", "rewrite"),
+    ],
+)
+def test_wandb_snapshot_requires_active_mode_metadata(
+    tmp_path: Path,
+    wandb_ingress_tool: ModuleType,
+    mode: str,
+    missing_key: str,
+) -> None:
+    path = tmp_path / "measurements.jsonl"
+    run = _rewrite_run_payload(include_replace_key=False)
+    run["mode"] = mode
+    run["strategy"] = "Substitute" if mode == "replace" else "Rewrite"
+    run.pop(missing_key, None)
+    if mode == "replace":
+        run.pop("rewrite", None)
+    records = [run, _terminal_stage_payload()]
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema violation at run"):
+        wandb_ingress_tool.read_measurement_snapshot(path, expected_statuses={"run-a": "completed"})
 
 
 def test_wandb_snapshot_uses_one_descriptor_and_enforces_limits(
@@ -441,6 +469,42 @@ def test_wandb_snapshot_requires_exactly_one_terminal_stage(tmp_path: Path, wand
 
     with pytest.raises(ValueError, match="exactly one terminal stage"):
         wandb_ingress_tool.read_measurement_snapshot(path, expected_statuses={"run-a": "completed"})
+
+
+def test_completion_seal_allows_root_owned_group_writable_intermediate_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    wandb_completion_tool: ModuleType,
+) -> None:
+    descriptor_paths: dict[int, str] = {}
+
+    def fake_open(path: Any, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        descriptor = 100 + len(descriptor_paths)
+        descriptor_paths[descriptor] = str(path)
+        return descriptor
+
+    def fake_close(descriptor: int) -> None:
+        pass
+
+    def fake_fstat(descriptor: int) -> Any:
+        name = descriptor_paths[descriptor]
+        directory_mode = stat.S_IFDIR | 0o755
+        uid = 0
+        if name == "shared-project":
+            directory_mode = stat.S_IFDIR | 0o2770
+        if name == "case":
+            uid = wandb_completion_tool.os.geteuid()
+        return SimpleNamespace(st_mode=directory_mode, st_uid=uid)
+
+    monkeypatch.setattr(wandb_completion_tool.os, "open", fake_open)
+    monkeypatch.setattr(wandb_completion_tool.os, "close", fake_close)
+    monkeypatch.setattr(wandb_completion_tool.os, "fstat", fake_fstat)
+
+    descriptor = wandb_completion_tool._open_owned_directory_no_follow(
+        Path("/shared/projects/shared-project/users/test-user/case")
+    )
+
+    assert descriptor_paths[descriptor] == "case"
+    assert any(path == "shared-project" for path in descriptor_paths.values())
 
 
 def test_completion_seal_round_trip_and_digest_verification(

--- a/tests/tools/test_measurement_ingress_completion.py
+++ b/tests/tools/test_measurement_ingress_completion.py
@@ -23,6 +23,59 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WRITE_COMPLETION_SEAL_PATH = REPO_ROOT / "tools/measurement/write_completion_seal.py"
 
 
+def _rewrite_run_payload(*, include_replace_key: bool) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "record_type": "run",
+        "run_id": "run-a",
+        "run_tags": {
+            "case_id": "run-a",
+            "workload_id": "rat-diff1",
+            "config_id": "rewrite",
+            "repetition": 0,
+        },
+        "timestamp_unix_sec": 1.0,
+        "mode": "rewrite",
+        "strategy": "Rewrite",
+        "input_row_count": 1,
+        "preview_num_records": None,
+        "source_hash": "a" * 64,
+        "input_source": {"kind": "local_file", "scheme": None, "suffix": ".csv"},
+        "input_text_column": "text",
+        "input_has_id_column": False,
+        "input_has_data_summary": False,
+        "detect": {"entity_label_source": "default", "entity_label_count": 2},
+        "rewrite": {
+            "risk_tolerance": "medium",
+            "max_repair_iterations": 2,
+            "strict_entity_protection": True,
+        },
+        "models": [],
+        "runtime": {},
+    }
+    if include_replace_key:
+        payload["replace"] = None
+    return payload
+
+
+def _terminal_stage_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "record_type": "stage",
+        "run_id": "run-a",
+        "run_tags": {
+            "case_id": "run-a",
+            "workload_id": "rat-diff1",
+            "config_id": "rewrite",
+            "repetition": 0,
+        },
+        "timestamp_unix_sec": 2.0,
+        "stage": "Anonymizer._run_internal",
+        "status": "completed",
+        "elapsed_sec": 0.5,
+    }
+
+
 def test_wandb_publisher_validates_before_import(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -42,6 +95,27 @@ def test_wandb_publisher_validates_before_import(
                 cases=[],
             ),
         )
+
+
+@pytest.mark.parametrize("include_replace_key", [True, False])
+def test_wandb_snapshot_accepts_rewrite_run_without_replace_metadata(
+    tmp_path: Path,
+    wandb_ingress_tool: ModuleType,
+    include_replace_key: bool,
+) -> None:
+    path = tmp_path / "measurements.jsonl"
+    records = [
+        _rewrite_run_payload(include_replace_key=include_replace_key),
+        _terminal_stage_payload(),
+    ]
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+    snapshot = wandb_ingress_tool.read_measurement_snapshot(path, expected_statuses={"run-a": "completed"})
+
+    assert len(snapshot.records) == 2
+    assert snapshot.records[0].record_type == "run"
+    assert snapshot.records[0].mode == "rewrite"
+    assert snapshot.records[0].replace is None
 
 
 def test_wandb_snapshot_uses_one_descriptor_and_enforces_limits(

--- a/tests/tools/test_measurement_wandb_logging.py
+++ b/tests/tools/test_measurement_wandb_logging.py
@@ -504,6 +504,42 @@ def test_wandb_environment_isolates_routing_and_restores_exactly(
     assert dict(os.environ) == before
 
 
+def test_wandb_output_allows_root_owned_group_writable_intermediate_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    wandb_setup_tool: ModuleType,
+) -> None:
+    descriptor_paths: dict[int, str] = {}
+
+    def fake_open(path: Any, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        descriptor = 100 + len(descriptor_paths)
+        descriptor_paths[descriptor] = str(path)
+        return descriptor
+
+    def fake_close(descriptor: int) -> None:
+        pass
+
+    def fake_fstat(descriptor: int) -> Any:
+        name = descriptor_paths[descriptor]
+        directory_mode = wandb_setup_tool.stat.S_IFDIR | 0o755
+        uid = 0
+        if name == "shared-project":
+            directory_mode = wandb_setup_tool.stat.S_IFDIR | 0o2770
+        if name == "wandb-output":
+            uid = wandb_setup_tool.os.geteuid()
+        return SimpleNamespace(st_mode=directory_mode, st_uid=uid)
+
+    monkeypatch.setattr(wandb_setup_tool.os, "open", fake_open)
+    monkeypatch.setattr(wandb_setup_tool.os, "close", fake_close)
+    monkeypatch.setattr(wandb_setup_tool.os, "fstat", fake_fstat)
+
+    descriptor = wandb_setup_tool._open_directory_no_follow(
+        Path("/shared/projects/shared-project/users/test-user/wandb-output")
+    )
+
+    assert descriptor_paths[descriptor] == "wandb-output"
+    assert any(path == "shared-project" for path in descriptor_paths.values())
+
+
 def test_wandb_environment_uses_namespaced_base_url(
     monkeypatch: pytest.MonkeyPatch,
     wandb_setup_tool: ModuleType,

--- a/tools/measurement/README.md
+++ b/tools/measurement/README.md
@@ -354,8 +354,10 @@ sensitive information.
 W&B writes local run state under `<benchmark-output>/.wandb-private`. The runner
 creates this directory with owner-only permissions before calling the W&B SDK.
 The runner rejects symlinks, untrusted writable parent directories, and output
-directories owned by another user. Keep the directory when an offline run must
-be synchronized later.
+directories owned by another user. Root-owned, group-writable project
+directories are trusted shared-storage ancestors, but the final benchmark output
+directory and `.wandb-private` staging directory must still be owned by the
+current user. Keep the directory when an offline run must be synchronized later.
 
 During SDK use, a process-wide guard replaces the process environment with a
 minimal runtime allowlist, audited W&B timeout settings, and the fully resolved
@@ -399,8 +401,11 @@ carry the same `case_id`, `workload_id`, `config_id`, and `repetition` tags, and
 the run ID must equal the case ID. The seal binds the measurement SHA-256
 digest, byte and record counts, expected run ID, case identity, Slurm
 provenance, and producer commit. The writer pins each parent directory without
-following symlinks and rejects untrusted writable directories. The companion
-workflow in `anonymizer-experiments` calls the seal writer after its case report:
+following symlinks and rejects untrusted writable directories. Root-owned,
+group-writable project directories are trusted shared-storage ancestors, but the
+final case directory that receives `completion-seal.json` must still be owned by
+the current user. The companion workflow in `anonymizer-experiments` calls the
+seal writer after its case report:
 
 ```bash
 uv run python tools/measurement/write_completion_seal.py \

--- a/tools/measurement/measurement_tools/wandb_completion.py
+++ b/tools/measurement/measurement_tools/wandb_completion.py
@@ -256,8 +256,13 @@ def _open_owned_directory_no_follow(path: Path) -> int:
                 raise ValueError("completion seal path must contain only directories")
             if final and metadata.st_uid != os.geteuid():
                 raise ValueError("completion seal directory must be owned by the current user")
-            writable_by_others = metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-            if writable_by_others and not metadata.st_mode & stat.S_ISVTX:
+            sticky = metadata.st_mode & stat.S_ISVTX
+            world_writable = metadata.st_mode & stat.S_IWOTH
+            group_writable = metadata.st_mode & stat.S_IWGRP
+            root_owned = metadata.st_uid == 0
+            if world_writable and not sticky:
+                raise ValueError("completion seal path contains an untrusted writable directory")
+            if group_writable and not sticky and not root_owned:
                 raise ValueError("completion seal path contains an untrusted writable directory")
         return descriptor
     except (OSError, ValueError) as exc:

--- a/tools/measurement/measurement_tools/wandb_ingress.py
+++ b/tools/measurement/measurement_tools/wandb_ingress.py
@@ -20,6 +20,7 @@ from pydantic import (
     StrictStr,
     TypeAdapter,
     ValidationError,
+    model_validator,
 )
 
 from measurement_tools.validation import (
@@ -58,10 +59,18 @@ class RunMeasurement(_MeasurementEnvelope):
     input_has_id_column: StrictBool
     input_has_data_summary: StrictBool
     detect: dict[StrictStr, JsonValue]
-    replace: dict[StrictStr, JsonValue]
-    rewrite: dict[StrictStr, JsonValue]
+    replace: dict[StrictStr, JsonValue] | None = None
+    rewrite: dict[StrictStr, JsonValue] | None = None
     models: list[dict[StrictStr, JsonValue]]
     runtime: dict[StrictStr, JsonValue]
+
+    @model_validator(mode="after")
+    def validate_active_mode_metadata(self) -> RunMeasurement:
+        if self.mode == "replace" and self.replace is None:
+            raise ValueError("replace metadata is required for replace mode")
+        if self.mode == "rewrite" and self.rewrite is None:
+            raise ValueError("rewrite metadata is required for rewrite mode")
+        return self
 
 
 class StageMeasurement(_MeasurementEnvelope):

--- a/tools/measurement/measurement_tools/wandb_setup.py
+++ b/tools/measurement/measurement_tools/wandb_setup.py
@@ -468,8 +468,13 @@ def _validate_directory_metadata(metadata: os.stat_result, *, final: bool) -> No
         raise ValueError("W&B output path must contain only directories")
     if final and metadata.st_uid != os.geteuid():
         raise ValueError("W&B output directory must be owned by the current user")
-    writable_by_others = metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-    if writable_by_others and not metadata.st_mode & stat.S_ISVTX:
+    sticky = metadata.st_mode & stat.S_ISVTX
+    world_writable = metadata.st_mode & stat.S_IWOTH
+    group_writable = metadata.st_mode & stat.S_IWGRP
+    root_owned = metadata.st_uid == 0
+    if world_writable and not sticky:
+        raise ValueError("W&B output path contains an untrusted writable directory")
+    if group_writable and not sticky and not root_owned:
         raise ValueError("W&B output path contains an untrusted writable directory")
 
 


### PR DESCRIPTION
## Related Issue
Fixes #220.

## Plan Document
No plan required: narrow bug fix for W&B measurement schema/path validation.

## Summary
- Allows W&B measurement ingress to accept rewrite-mode run records when replacement metadata is `null` or omitted.
- Keeps active-mode validation strict: replace runs still require replace metadata, and rewrite runs still require rewrite metadata.
- Allows measurement completion seals and W&B output directory validation to pass through root-owned, group-writable project-directory ancestors while still rejecting unsafe world-writable or non-root-owned writable ancestors.
- Adds regression coverage for rewrite run metadata, active-mode metadata rejection, completion-seal path validation, and W&B output path validation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI, release, or contributor workflow update

## Contributor Checklist
- [x] PR title follows Conventional Commits, for example `fix: handle empty entity list`
- [x] Related issue is linked, or a maintainer-owned no-issue reason is documented above
- [x] For non-trivial changes, a plan document is linked above, or the no-plan reason is documented above
- [x] Public API impact checked; `skills/anonymizer/SKILL.md` updated if needed
- [x] No real PII added to tests, docs, notebooks, fixtures, or artifacts
- [x] No API keys, service tokens, private keys, credentials, or real endpoint secrets added

## Validation
- Commands run:
  - `uv run pytest tests/tools/test_measurement_ingress_completion.py -k "rewrite or active_mode or root_owned"`
  - `uv run pytest tests/tools/test_measurement_wandb_logging.py -k "root_owned or isolates_routing"`
  - `TMPDIR=/tmp uv run pytest tests/tools/test_measurement_ingress_completion.py tests/tools/test_measurement_wandb_logging.py`
  - `make check`
- Skipped checks or known failures:
  - `make format` was not run separately because `make check` includes the read-only `format-check`, which passed with `179 files already formatted`.
  - `make check` completed successfully; its advisory `typecheck` step reported existing diagnostics and is ignored by the Makefile.

## Documentation and Artifacts
- [x] Docs updated, or not needed
- [ ] If docs changed: `make docs-build` passes locally
- [ ] If tutorial sources changed: notebooks regenerated with `make convert-notebooks`
- [x] If e2e, benchmark, or model-provider behavior changed: relevant validation is listed above