### PR TITLE
docs: fix gen_ref_pages.py test-module substring filter

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -23,7 +23,7 @@ for path in sorted(package.rglob("*.py")):
         continue
     if parts[-1] == "__init__":
         continue
-    if "test" in parts[-1]:
+    if parts[-1].startswith("test_"):
         continue
     if len(parts) > 1 and parts[1] in {"engine", "utils"}:
         continue


### PR DESCRIPTION
Fixes #233

The test-module filter in `docs/gen_ref_pages.py` used `"test" in parts[-1]`, which silently omits any module whose base name contains the substring `test` (for example `testing.py`, `contest.py`, `attestation.py`) instead of only excluding actual test modules.

This change updates the filter to match the conventional Python test-module prefix `test_`, so only real test modules are excluded from the generated reference docs.

- [x] Linked issue
- [x] Conventional PR title
- [x] Minimal, single-file bug fix
- [ ] Maintainer applies `triaged` label before merge (per CONTRIBUTING.md)
