### PR TITLE
feat(measurement): add W&B benchmark identity config

### DIFF
--- a/tests/tools/test_measurement_strict_import_publisher.py
+++ b/tests/tools/test_measurement_strict_import_publisher.py
@@ -406,6 +406,89 @@ def test_strict_import_retry_is_a_remote_publication_noop(
         )
 
 
+def test_strict_import_retry_refreshes_benchmark_identity_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    wandb_import_tool: ModuleType,
+) -> None:
+    measurement_path, seal_path = _write_sealed_import_case(wandb_import_tool, tmp_path)
+    settings = wandb_import_tool.ResolvedWandbConfig(
+        wandb_mode=wandb_import_tool.WandbMode.online,
+        wandb_base_url="https://wandb.example",
+        wandb_entity="entity",
+        wandb_project="project",
+    )
+    setup = sys.modules[wandb_import_tool.WandbPublisher.__module__]
+    state = _wandb_state()
+    monkeypatch.setattr(setup, "require_wandb", lambda: _fake_wandb_module(state))
+    publisher = wandb_import_tool.WandbPublisher()
+    prepared_without_identity = wandb_import_tool.prepare_sealed_import(
+        measurement_path,
+        seal_path=seal_path,
+        settings=settings,
+    )
+    commit_sha = "abcdef0123456789abcdef0123456789abcdef01"
+    prepared_with_identity = wandb_import_tool.prepare_sealed_import(
+        measurement_path,
+        seal_path=seal_path,
+        settings=settings,
+        benchmark_identity=wandb_import_tool.BenchmarkIdentityMetadata(
+            role="candidate",
+            kind="pr",
+            suite_version="2026-07-31",
+            branch="contributor/feat/example",
+            commit_sha=commit_sha,
+            commit_short=commit_sha[:12],
+            pr_number=236,
+            anonymizer_config_id="rat-throughput",
+            anonymizer_mode="rewrite",
+        ),
+    )
+
+    first = publisher.publish_payload(
+        settings,
+        payload=prepared_without_identity.payload,
+        measurement_sha256=prepared_without_identity.measurement_sha256,
+        record_count=prepared_without_identity.record_count,
+    )
+    defined_metrics_after_first_publish = len(state.defined_metrics)
+    second = publisher.publish_payload(
+        settings,
+        payload=prepared_with_identity.payload,
+        measurement_sha256=prepared_with_identity.measurement_sha256,
+        record_count=prepared_with_identity.record_count,
+    )
+
+    assert first.run_id == second.run_id
+    assert second.publication_state == "already_complete"
+    assert len(state.config_updates) == 2
+    assert state.config_updates[1] == {
+        "benchmark_identity": {
+            "role": "candidate",
+            "kind": "pr",
+            "suite_version": "2026-07-31",
+            "branch": "contributor/feat/example",
+            "commit_sha": commit_sha,
+            "commit_short": commit_sha[:12],
+            "pr_number": 236,
+            "anonymizer_config_id": "rat-throughput",
+            "anonymizer_mode": "rewrite",
+        },
+        "benchmark_role": "candidate",
+        "benchmark_kind": "pr",
+        "suite_version": "2026-07-31",
+        "branch": "contributor/feat/example",
+        "commit_sha": commit_sha,
+        "commit_short": commit_sha[:12],
+        "pr_number": 236,
+        "anonymizer_config_id": "rat-throughput",
+        "anonymizer_mode": "rewrite",
+    }
+    assert len(state.logged) == 1
+    assert len(state.summary_updates) == 1
+    assert len(state.defined_metrics) == defined_metrics_after_first_publish
+
+
 def test_strict_import_reports_resumed_incomplete_publication(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_measurement_strict_import_publisher.py
+++ b/tests/tools/test_measurement_strict_import_publisher.py
@@ -311,6 +311,44 @@ def test_strict_import_exposes_multi_job_slurm_metadata(
     ]
 
 
+def test_strict_import_projects_benchmark_identity_config(
+    tmp_path: Path,
+    wandb_import_tool: ModuleType,
+) -> None:
+    measurement_path, seal_path = _write_sealed_import_case(wandb_import_tool, tmp_path)
+    commit_sha = "abcdef0123456789abcdef0123456789abcdef01"
+    prepared = wandb_import_tool.prepare_sealed_import(
+        measurement_path,
+        seal_path=seal_path,
+        settings=wandb_import_tool.ResolvedWandbConfig(wandb_mode=wandb_import_tool.WandbMode.offline),
+        benchmark_identity=wandb_import_tool.BenchmarkIdentityMetadata(
+            role="candidate",
+            kind="pr",
+            suite_version="2026-07-30",
+            branch="contributor/feat/wandb-benchmark-identity",
+            commit_sha=commit_sha,
+            commit_short=commit_sha[:12],
+            pr_number=210,
+            anonymizer_config_id="rat-rewrite-throughput",
+            anonymizer_mode="rewrite",
+        ),
+    )
+
+    config = prepared.payload.config
+    sdk_values = config.sdk_values()
+    assert config.benchmark_role == "candidate"
+    assert config.benchmark_kind == "pr"
+    assert config.suite_version == "2026-07-30"
+    assert config.branch == "contributor/feat/wandb-benchmark-identity"
+    assert config.commit_sha == commit_sha
+    assert config.commit_short == commit_sha[:12]
+    assert config.pr_number == 210
+    assert config.anonymizer_config_id == "rat-rewrite-throughput"
+    assert config.anonymizer_mode == "rewrite"
+    assert sdk_values["benchmark_role"] == "candidate"
+    assert sdk_values["commit_sha"] == commit_sha
+
+
 def test_strict_import_retry_is_a_remote_publication_noop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_measurement_wandb_logging.py
+++ b/tests/tools/test_measurement_wandb_logging.py
@@ -452,6 +452,13 @@ def test_wandb_config_projects_only_declared_metadata(wandb_setup_tool: ModuleTy
     assert config.sdk_values()["sweep_param_configs_all_detect_gliner_threshold"] == 0.3
 
 
+def test_wandb_benchmark_identity_requires_pr_for_candidate_branch() -> None:
+    from measurement_tools.wandb_models import BenchmarkIdentityMetadata
+
+    with pytest.raises(ValidationError, match="requires pr_number"):
+        BenchmarkIdentityMetadata(kind="branch", branch="feature/candidate")
+
+
 def test_wandb_run_tags_filter_sensitive_generated_values(wandb_setup_tool: ModuleType) -> None:
     metadata = wandb_setup_tool.WandbRunMetadata.model_validate(
         {

--- a/tests/tools/test_measurement_wandb_logging.py
+++ b/tests/tools/test_measurement_wandb_logging.py
@@ -306,25 +306,21 @@ def test_wandb_stage_summary_uses_only_terminal_stage_but_table_preserves_all(
 
 
 def test_wandb_scalar_registry_matches_package_field_catalog(wandb_logging_tool: ModuleType) -> None:
-    from measurement_tools.wandb_metric_schema import (
-        AGGREGATED_MEASUREMENT_FIELDS,
-        SCALAR_AGGREGATION_BY_FIELD,
-    )
-    from measurement_tools.wandb_models import WandbHistoryPayload
-
     from anonymizer.measurement.fields import (
         SCALAR_ADDITIVE_FIELDS,
         SCALAR_AVERAGED_FIELDS,
         SCALAR_LAST_VALUE_FIELDS,
     )
 
+    metric_schema = sys.modules["measurement_tools.wandb_metric_schema"]
+    models = sys.modules["measurement_tools.wandb_models"]
     field_groups = (SCALAR_LAST_VALUE_FIELDS, SCALAR_ADDITIVE_FIELDS, SCALAR_AVERAGED_FIELDS)
     expected_fields = frozenset().union(*field_groups)
 
     assert sum(map(len, field_groups)) == len(expected_fields)
-    assert frozenset(SCALAR_AGGREGATION_BY_FIELD) == expected_fields
-    for field_name in AGGREGATED_MEASUREMENT_FIELDS:
-        WandbHistoryPayload(metrics={f"measurement/record/{field_name}": 0})
+    assert frozenset(metric_schema.SCALAR_AGGREGATION_BY_FIELD) == expected_fields
+    for field_name in metric_schema.AGGREGATED_MEASUREMENT_FIELDS:
+        models.WandbHistoryPayload(metrics={f"measurement/record/{field_name}": 0})
 
 
 def test_wandb_aggregates_rat_bench_reidentification_record(
@@ -452,18 +448,14 @@ def test_wandb_config_projects_only_declared_metadata(wandb_setup_tool: ModuleTy
     assert config.sdk_values()["sweep_param_configs_all_detect_gliner_threshold"] == 0.3
 
 
-def test_wandb_benchmark_identity_requires_pr_for_candidate_branch() -> None:
-    from measurement_tools.wandb_models import BenchmarkIdentityMetadata
-
+def test_wandb_benchmark_identity_requires_pr_for_candidate_branch(wandb_import_tool: ModuleType) -> None:
     with pytest.raises(ValidationError, match="requires pr_number"):
-        BenchmarkIdentityMetadata(kind="branch", branch="feature/candidate")
+        wandb_import_tool.BenchmarkIdentityMetadata(kind="branch", branch="feature/candidate")
 
 
-def test_wandb_benchmark_identity_rejects_inconsistent_commit_identifiers() -> None:
-    from measurement_tools.wandb_models import BenchmarkIdentityMetadata
-
+def test_wandb_benchmark_identity_rejects_inconsistent_commit_identifiers(wandb_import_tool: ModuleType) -> None:
     with pytest.raises(ValidationError, match="commit_short must match"):
-        BenchmarkIdentityMetadata(
+        wandb_import_tool.BenchmarkIdentityMetadata(
             kind="experiment",
             commit_sha="abcdef0123456789abcdef0123456789abcdef01",
             commit_short="1234567",
@@ -479,11 +471,13 @@ def test_wandb_benchmark_identity_rejects_inconsistent_commit_identifiers() -> N
         ("candidate", "release"),
     ],
 )
-def test_wandb_benchmark_identity_rejects_incompatible_role_kind_pairs(role: str, kind: str) -> None:
-    from measurement_tools.wandb_models import BenchmarkIdentityMetadata
-
+def test_wandb_benchmark_identity_rejects_incompatible_role_kind_pairs(
+    role: str, kind: str, wandb_import_tool: ModuleType
+) -> None:
     with pytest.raises(ValidationError, match="incompatible"):
-        BenchmarkIdentityMetadata(role=role, kind=kind, pr_number=210 if kind in {"pr", "branch"} else None)
+        wandb_import_tool.BenchmarkIdentityMetadata(
+            role=role, kind=kind, pr_number=210 if kind in {"pr", "branch"} else None
+        )
 
 
 def test_wandb_run_tags_filter_sensitive_generated_values(wandb_setup_tool: ModuleType) -> None:

--- a/tests/tools/test_measurement_wandb_logging.py
+++ b/tests/tools/test_measurement_wandb_logging.py
@@ -459,6 +459,33 @@ def test_wandb_benchmark_identity_requires_pr_for_candidate_branch() -> None:
         BenchmarkIdentityMetadata(kind="branch", branch="feature/candidate")
 
 
+def test_wandb_benchmark_identity_rejects_inconsistent_commit_identifiers() -> None:
+    from measurement_tools.wandb_models import BenchmarkIdentityMetadata
+
+    with pytest.raises(ValidationError, match="commit_short must match"):
+        BenchmarkIdentityMetadata(
+            kind="experiment",
+            commit_sha="abcdef0123456789abcdef0123456789abcdef01",
+            commit_short="1234567",
+        )
+
+
+@pytest.mark.parametrize(
+    ("role", "kind"),
+    [
+        ("main-baseline", "pr"),
+        ("release-baseline", "main"),
+        ("candidate", "main"),
+        ("candidate", "release"),
+    ],
+)
+def test_wandb_benchmark_identity_rejects_incompatible_role_kind_pairs(role: str, kind: str) -> None:
+    from measurement_tools.wandb_models import BenchmarkIdentityMetadata
+
+    with pytest.raises(ValidationError, match="incompatible"):
+        BenchmarkIdentityMetadata(role=role, kind=kind, pr_number=210 if kind in {"pr", "branch"} else None)
+
+
 def test_wandb_run_tags_filter_sensitive_generated_values(wandb_setup_tool: ModuleType) -> None:
     metadata = wandb_setup_tool.WandbRunMetadata.model_validate(
         {

--- a/tests/tools/test_measurement_wandb_logging.py
+++ b/tests/tools/test_measurement_wandb_logging.py
@@ -573,7 +573,7 @@ def test_wandb_environment_isolates_routing_and_restores_exactly(
     with wandb_setup_tool.WandbSdkEnvironment(settings):
         assert os.environ["WANDB_GROUP"] == "resolved-group"
         assert os.environ["WANDB_PROJECT"] == "resolved-project"
-        assert "WANDB_API_KEY" not in os.environ
+        assert os.environ["WANDB_API_KEY"] == "auth-token"
         assert os.environ["WANDB_ERROR_REPORTING"] == "false"
         assert "UNRELATED" not in os.environ
         with pytest.raises(RuntimeError, match="nested or concurrent"):

--- a/tools/measurement/README.md
+++ b/tools/measurement/README.md
@@ -300,9 +300,9 @@ and `WANDB_TAGS` are deliberately ignored. Precedence is an explicit CLI value,
 then the corresponding `ANONYMIZER_MEASUREMENT_WANDB_*` variable, then the
 publisher default. The W&B SDK still receives its audited timeout variables,
 including `WANDB_HTTP_TIMEOUT` and `WANDB_INIT_TIMEOUT`. Authentication comes
-from the SDK's local credential files under the preserved home directory; the
-publisher removes `WANDB_API_KEY` from the SDK process environment. Set a
-self-hosted endpoint through `--wandb-base-url` or
+from the SDK's local credential files under the preserved home directory or
+from `WANDB_API_KEY` when the launcher provides it in the process environment.
+Set a self-hosted endpoint through `--wandb-base-url` or
 `ANONYMIZER_MEASUREMENT_WANDB_BASE_URL`; ambient `WANDB_BASE_URL` is ignored.
 Remote endpoints require HTTPS. Plain HTTP is accepted only for loopback
 development endpoints. SDK error reporting is disabled before W&B is imported.
@@ -362,8 +362,9 @@ current user. Keep the directory when an offline run must be synchronized later.
 During SDK use, a process-wide guard replaces the process environment with a
 minimal runtime allowlist, audited W&B timeout settings, and the fully resolved
 publisher settings. Local W&B credential files remain available through the
-preserved home directory. Environment credentials, proxy settings, custom CA
-settings, and ambient `WANDB_*` values are withheld from the SDK. The
+preserved home directory, and `WANDB_API_KEY` remains available when explicitly
+provided by a launcher. Proxy settings, custom CA settings, and ambient
+`WANDB_*` routing values are withheld from the SDK. The
 guard restores the exact original environment after the explicit run handle finishes.
 Nested or concurrent native publishers in one process are rejected. Each
 native run receives a fresh opaque 128-bit ID and uses `resume="never"`.
@@ -375,16 +376,16 @@ the native runner logs only the exception type to avoid echoing source values.
 
 Before an external launcher starts benchmark work, verify W&B authentication from
 the same account or container and the same preserved home directory used by the
-publisher. Keep credentials in the local W&B credential files; do not pass a key
-through the launcher environment or command line.
+publisher. Keep credentials in the local W&B credential files or pass
+`WANDB_API_KEY` through the launcher environment. Do not pass a key on the
+command line.
 
 ```bash
-# W&B public cloud
-env -u WANDB_API_KEY uv run wandb login --verify --cloud
+# W&B public cloud, using a stored SDK credential
+uv run wandb login --verify --cloud
 
-# Self-hosted or dedicated cloud
-env -u WANDB_API_KEY uv run wandb login --verify \
-  --host https://wandb.example.com
+# Self-hosted or dedicated cloud, using a stored SDK credential
+uv run wandb login --verify --host https://wandb.example.com
 ```
 
 Both commands verify the stored credential against the selected endpoint and

--- a/tools/measurement/README.md
+++ b/tools/measurement/README.md
@@ -434,6 +434,23 @@ uv run python tools/measurement/import_wandb_run.py \
   --json
 ```
 
+External launchers can add safe benchmark identity fields to W&B config for
+filtering and comparisons:
+
+```bash
+  --benchmark-role candidate \
+  --benchmark-kind pr \
+  --suite-version 2026-07-30 \
+  --branch contributor/feat/wandb-benchmark-identity \
+  --commit-sha 0123456789abcdef0123456789abcdef01234567 \
+  --pr-number 210 \
+  --anonymizer-config-id rat-rewrite-throughput \
+  --anonymizer-mode rewrite
+```
+
+`--pr-number` is required for `--benchmark-kind pr` and `branch`. Main and
+release baselines can omit it.
+
 The importer captures the seal and JSONL once, verifies their content binding,
 builds the complete typed payload, then initializes W&B. It derives a stable
 128-bit run ID from the destination, sealed case identity, seal digest, schema

--- a/tools/measurement/import_wandb_run.py
+++ b/tools/measurement/import_wandb_run.py
@@ -27,6 +27,7 @@ from measurement_tools.wandb_logging import build_outbound_measurements
 from measurement_tools.wandb_models import (
     PUBLICATION_COMPLETE_KEY,
     PUBLICATION_SEAL_DIGEST_KEY,
+    BenchmarkIdentityMetadata,
     BenchmarkMetadata,
     ConfigMetadata,
     ExecutionMetadata,
@@ -102,7 +103,11 @@ def stable_import_run_id(
     return hashlib.sha256(canonical.encode("ascii")).hexdigest()[:32]
 
 
-def build_import_metadata(seal_snapshot: CompletionSealSnapshot) -> WandbRunMetadata:
+def build_import_metadata(
+    seal_snapshot: CompletionSealSnapshot,
+    *,
+    benchmark_identity: BenchmarkIdentityMetadata | None = None,
+) -> WandbRunMetadata:
     seal = seal_snapshot.seal
     return WandbRunMetadata(
         run_kind="imported_case",
@@ -127,6 +132,7 @@ def build_import_metadata(seal_snapshot: CompletionSealSnapshot) -> WandbRunMeta
             ),
         ),
         git=GitMetadata(commit=seal.producer.commit),
+        benchmark_identity=benchmark_identity,
         workloads=(WorkloadMetadata(id=seal.case.workload_id),),
         configs=(ConfigMetadata(id=seal.case.config_id),),
         matrix=(
@@ -153,10 +159,11 @@ def build_import_payload(
     snapshot: MeasurementSnapshot,
     seal_snapshot: CompletionSealSnapshot,
     staging_dir: Path,
+    benchmark_identity: BenchmarkIdentityMetadata | None = None,
 ) -> WandbPublishPayload:
     """Construct the complete SDK-bound payload before W&B initialization."""
     verify_completion_seal(snapshot, seal_snapshot.seal)
-    metadata = build_import_metadata(seal_snapshot)
+    metadata = build_import_metadata(seal_snapshot, benchmark_identity=benchmark_identity)
     terminal = snapshot.terminal_stage()
     history, summary, tables = build_outbound_measurements(
         snapshot,
@@ -201,6 +208,7 @@ def prepare_sealed_import(
     *,
     seal_path: Path,
     settings: ResolvedWandbConfig,
+    benchmark_identity: BenchmarkIdentityMetadata | None = None,
 ) -> PreparedWandbImport:
     """Capture and validate one sealed case without importing the W&B SDK."""
     if not settings.enabled:
@@ -221,6 +229,7 @@ def prepare_sealed_import(
             snapshot=snapshot,
             seal_snapshot=seal_snapshot,
             staging_dir=staging_dir,
+            benchmark_identity=benchmark_identity,
         )
     except (OSError, ValueError) as exc:
         raise ImportInputError(str(exc)) from None
@@ -236,14 +245,55 @@ def import_sealed_run(
     *,
     seal_path: Path,
     settings: ResolvedWandbConfig,
+    benchmark_identity: BenchmarkIdentityMetadata | None = None,
 ) -> WandbPublishResult:
     """Capture, verify, and strictly publish one sealed external case."""
-    prepared = prepare_sealed_import(measurement_path, seal_path=seal_path, settings=settings)
+    prepared = prepare_sealed_import(
+        measurement_path,
+        seal_path=seal_path,
+        settings=settings,
+        benchmark_identity=benchmark_identity,
+    )
     return WandbPublisher().publish_payload(
         settings,
         payload=prepared.payload,
         measurement_sha256=prepared.measurement_sha256,
         record_count=prepared.record_count,
+    )
+
+
+def build_benchmark_identity(
+    *,
+    benchmark_role: str | None = None,
+    benchmark_kind: str | None = None,
+    suite_version: str | None = None,
+    branch: str | None = None,
+    commit_sha: str | None = None,
+    commit_short: str | None = None,
+    pr_number: int | None = None,
+    release_version: str | None = None,
+    anonymizer_config_id: str | None = None,
+    anonymizer_mode: str | None = None,
+) -> BenchmarkIdentityMetadata | None:
+    if commit_sha is not None and commit_short is None:
+        commit_short = commit_sha[:12]
+    values = {
+        "role": benchmark_role,
+        "kind": benchmark_kind,
+        "suite_version": suite_version,
+        "branch": branch,
+        "commit_sha": commit_sha,
+        "commit_short": commit_short,
+        "pr_number": pr_number,
+        "release_version": release_version,
+        "anonymizer_config_id": anonymizer_config_id,
+        "anonymizer_mode": anonymizer_mode,
+    }
+    if all(value is None for value in values.values()):
+        return None
+    return BenchmarkIdentityMetadata.model_validate(
+        {key: value for key, value in values.items() if value is not None},
+        strict=True,
     )
 
 
@@ -261,6 +311,16 @@ def main(
     wandb_run_name: Annotated[str | None, cyclopts.Parameter("--wandb-run-name")] = None,
     wandb_tags: Annotated[str | None, cyclopts.Parameter("--wandb-tags")] = None,
     wandb_log_tables: Annotated[bool | None, cyclopts.Parameter("--wandb-log-tables")] = None,
+    benchmark_role: Annotated[str | None, cyclopts.Parameter("--benchmark-role")] = None,
+    benchmark_kind: Annotated[str | None, cyclopts.Parameter("--benchmark-kind")] = None,
+    suite_version: Annotated[str | None, cyclopts.Parameter("--suite-version")] = None,
+    branch: Annotated[str | None, cyclopts.Parameter("--branch")] = None,
+    commit_sha: Annotated[str | None, cyclopts.Parameter("--commit-sha")] = None,
+    commit_short: Annotated[str | None, cyclopts.Parameter("--commit-short")] = None,
+    pr_number: Annotated[int | None, cyclopts.Parameter("--pr-number")] = None,
+    release_version: Annotated[str | None, cyclopts.Parameter("--release-version")] = None,
+    anonymizer_config_id: Annotated[str | None, cyclopts.Parameter("--anonymizer-config-id")] = None,
+    anonymizer_mode: Annotated[str | None, cyclopts.Parameter("--anonymizer-mode")] = None,
     json_output: Annotated[bool, cyclopts.Parameter("--json")] = False,
     log_format: Annotated[LogFormat, cyclopts.Parameter("--log-format")] = LogFormat.plain,
 ) -> None:
@@ -279,7 +339,24 @@ def main(
             wandb_tags=wandb_tags,
             wandb_log_tables=wandb_log_tables,
         )
-        prepared = prepare_sealed_import(measurement_path, seal_path=resolved_seal_path, settings=settings)
+        benchmark_identity = build_benchmark_identity(
+            benchmark_role=benchmark_role,
+            benchmark_kind=benchmark_kind,
+            suite_version=suite_version,
+            branch=branch,
+            commit_sha=commit_sha,
+            commit_short=commit_short,
+            pr_number=pr_number,
+            release_version=release_version,
+            anonymizer_config_id=anonymizer_config_id,
+            anonymizer_mode=anonymizer_mode,
+        )
+        prepared = prepare_sealed_import(
+            measurement_path,
+            seal_path=resolved_seal_path,
+            settings=settings,
+            benchmark_identity=benchmark_identity,
+        )
     except ValidationError as exc:
         log_bad_input(logger, summarize_validation_error(exc))
         raise SystemExit(125) from exc

--- a/tools/measurement/measurement_tools/wandb_models.py
+++ b/tools/measurement/measurement_tools/wandb_models.py
@@ -292,6 +292,17 @@ class BenchmarkIdentityMetadata(StrictFrozenModel):
     def validate_branch_identity(self) -> BenchmarkIdentityMetadata:
         if self.kind in {"pr", "branch"} and self.pr_number is None:
             raise ValueError("PR or candidate branch benchmark identity requires pr_number")
+        if self.commit_sha is not None and self.commit_short is not None and not self.commit_sha.startswith(
+            self.commit_short
+        ):
+            raise ValueError("commit_short must match the prefix of commit_sha")
+        role_kind = {
+            "main-baseline": {"main"},
+            "release-baseline": {"release"},
+            "candidate": {"pr", "branch", "experiment"},
+        }
+        if self.role is not None and self.kind is not None and self.kind not in role_kind[self.role]:
+            raise ValueError(f"benchmark role {self.role!r} is incompatible with kind {self.kind!r}")
         return self
 
 

--- a/tools/measurement/measurement_tools/wandb_models.py
+++ b/tools/measurement/measurement_tools/wandb_models.py
@@ -276,6 +276,25 @@ class BenchmarkMetadata(StrictFrozenModel):
     suite_file_hash: StrictStr | None = None
 
 
+class BenchmarkIdentityMetadata(StrictFrozenModel):
+    role: Literal["main-baseline", "release-baseline", "candidate"] | None = None
+    kind: Literal["main", "release", "pr", "branch", "experiment"] | None = None
+    suite_version: StrictStr | None = None
+    branch: StrictStr | None = None
+    commit_sha: Annotated[StrictStr, Field(pattern=r"^[0-9a-f]{40,64}$")] | None = None
+    commit_short: Annotated[StrictStr, Field(pattern=r"^[0-9a-f]{7,16}$")] | None = None
+    pr_number: NonNegativeInt | None = None
+    release_version: StrictStr | None = None
+    anonymizer_config_id: VisibleIdentifier | None = None
+    anonymizer_mode: Literal["replace", "rewrite"] | None = None
+
+    @model_validator(mode="after")
+    def validate_branch_identity(self) -> BenchmarkIdentityMetadata:
+        if self.kind in {"pr", "branch"} and self.pr_number is None:
+            raise ValueError("PR or candidate branch benchmark identity requires pr_number")
+        return self
+
+
 class SlurmJobMetadata(StrictFrozenModel):
     role: VisibleSlurmIdentifier
     job_id: VisibleSlurmIdentifier
@@ -424,6 +443,7 @@ class WandbRunMetadata(StrictFrozenModel):
     runtime: RuntimeMetadata | None = None
     git: GitMetadata | None = None
     model_sources: ModelSourcesMetadata | None = None
+    benchmark_identity: BenchmarkIdentityMetadata | None = None
     workloads: tuple[WorkloadMetadata, ...] = ()
     configs: tuple[ConfigMetadata, ...] = ()
     matrix: tuple[MatrixMetadata, ...] = ()
@@ -491,6 +511,18 @@ class WandbRunMetadata(StrictFrozenModel):
             "benchmark_risk_tolerances",
             _compact_values(item.rewrite.risk_tolerance if item.rewrite else None for item in self.configs),
         )
+        identity = self.benchmark_identity
+        if identity is not None:
+            _set_scalar(values, "benchmark_role", identity.role)
+            _set_scalar(values, "benchmark_kind", identity.kind)
+            _set_scalar(values, "suite_version", identity.suite_version)
+            _set_scalar(values, "branch", identity.branch)
+            _set_scalar(values, "commit_sha", identity.commit_sha)
+            _set_scalar(values, "commit_short", identity.commit_short)
+            _set_scalar(values, "pr_number", identity.pr_number)
+            _set_scalar(values, "release_version", identity.release_version)
+            _set_scalar(values, "anonymizer_config_id", identity.anonymizer_config_id)
+            _set_scalar(values, "anonymizer_mode", identity.anonymizer_mode)
         return values
 
 
@@ -510,6 +542,16 @@ class WandbConfigPayload(WandbRunMetadata):
     benchmark_gliner_thresholds: SafeScalar | None = None
     benchmark_entity_label_counts: SafeScalar | None = None
     benchmark_risk_tolerances: SafeScalar | None = None
+    benchmark_role: Literal["main-baseline", "release-baseline", "candidate"] | None = None
+    benchmark_kind: Literal["main", "release", "pr", "branch", "experiment"] | None = None
+    suite_version: StrictStr | None = None
+    branch: StrictStr | None = None
+    commit_sha: Annotated[StrictStr, Field(pattern=r"^[0-9a-f]{40,64}$")] | None = None
+    commit_short: Annotated[StrictStr, Field(pattern=r"^[0-9a-f]{7,16}$")] | None = None
+    pr_number: NonNegativeInt | None = None
+    release_version: StrictStr | None = None
+    anonymizer_config_id: VisibleIdentifier | None = None
+    anonymizer_mode: Literal["replace", "rewrite"] | None = None
     native_suite_id: VisibleIdentifier | None = None
     sweep_id: VisibleIdentifier | None = None
     sweep_arm_id: VisibleIdentifier | None = None
@@ -919,6 +961,19 @@ OUTBOUND_FIELD_POLICIES: dict[type[BaseModel], dict[str, FieldPolicy]] = {
         "case_retry_backoff_sec",
         "suite_file_hash",
     ),
+    BenchmarkIdentityMetadata: _aggregate_policies(
+        "role",
+        "kind",
+        "suite_version",
+        "branch",
+        "commit_sha",
+        "commit_short",
+        "pr_number",
+        "release_version",
+        "anonymizer_config_id",
+        "anonymizer_mode",
+        data_class=DataClass.pseudonymous,
+    ),
     SlurmJobMetadata: _aggregate_policies("role", "job_id", data_class=DataClass.pseudonymous),
     SlurmMetadata: _aggregate_policies(
         "job_id",
@@ -992,6 +1047,7 @@ OUTBOUND_FIELD_POLICIES: dict[type[BaseModel], dict[str, FieldPolicy]] = {
         "runtime",
         "git",
         "model_sources",
+        "benchmark_identity",
         "workloads",
         "configs",
         "matrix",
@@ -1015,6 +1071,16 @@ OUTBOUND_FIELD_POLICIES: dict[type[BaseModel], dict[str, FieldPolicy]] = {
         "benchmark_gliner_thresholds",
         "benchmark_entity_label_counts",
         "benchmark_risk_tolerances",
+        "benchmark_role",
+        "benchmark_kind",
+        "suite_version",
+        "branch",
+        "commit_sha",
+        "commit_short",
+        "pr_number",
+        "release_version",
+        "anonymizer_config_id",
+        "anonymizer_mode",
         "native_suite_id",
         "sweep_id",
         "sweep_arm_id",

--- a/tools/measurement/measurement_tools/wandb_models.py
+++ b/tools/measurement/measurement_tools/wandb_models.py
@@ -292,8 +292,10 @@ class BenchmarkIdentityMetadata(StrictFrozenModel):
     def validate_branch_identity(self) -> BenchmarkIdentityMetadata:
         if self.kind in {"pr", "branch"} and self.pr_number is None:
             raise ValueError("PR or candidate branch benchmark identity requires pr_number")
-        if self.commit_sha is not None and self.commit_short is not None and not self.commit_sha.startswith(
-            self.commit_short
+        if (
+            self.commit_sha is not None
+            and self.commit_short is not None
+            and not self.commit_sha.startswith(self.commit_short)
         ):
             raise ValueError("commit_short must match the prefix of commit_sha")
         role_kind = {

--- a/tools/measurement/measurement_tools/wandb_setup.py
+++ b/tools/measurement/measurement_tools/wandb_setup.py
@@ -58,6 +58,21 @@ class BenchmarkWandbFinalization:
 
 
 _PUBLISHER_WANDB_MODULE: Any | None = None
+_RESUMABLE_CONFIG_REFRESH_KEYS = frozenset(
+    {
+        "benchmark_identity",
+        "benchmark_role",
+        "benchmark_kind",
+        "suite_version",
+        "branch",
+        "commit_sha",
+        "commit_short",
+        "pr_number",
+        "release_version",
+        "anonymizer_config_id",
+        "anonymizer_mode",
+    }
+)
 
 
 def require_wandb() -> Any:
@@ -223,7 +238,9 @@ class WandbPublisher:
                     raise RuntimeError("wandb.init returned a different run identity")
                 already_complete = _publication_already_complete(run, payload)
                 publication_state = _publication_state(run, already_complete=already_complete)
-                if not already_complete:
+                if already_complete:
+                    _refresh_resumed_complete_config(run, payload)
+                else:
                     _define_benchmark_metrics(run)
                     run.config.update(payload.config.sdk_values(), allow_val_change=True)
                     tables = {
@@ -360,6 +377,22 @@ def _publication_already_complete(run: Any, payload: WandbPublishPayload) -> boo
     if observed_digest not in {None, expected_digest}:
         raise RuntimeError("resumed W&B run contains different sealed content")
     return False
+
+
+def _refresh_resumed_complete_config(run: Any, payload: WandbPublishPayload) -> None:
+    desired = {
+        key: value for key, value in payload.config.sdk_values().items() if key in _RESUMABLE_CONFIG_REFRESH_KEYS
+    }
+    if not desired:
+        return
+    config = getattr(run, "config", None)
+    get_config = getattr(config, "get", None)
+    update_config = getattr(config, "update", None)
+    if not callable(get_config) or not callable(update_config):
+        raise RuntimeError("resumed W&B run does not expose mutable publication config")
+    delta = {key: value for key, value in desired.items() if get_config(key) != value}
+    if delta:
+        update_config(delta, allow_val_change=True)
 
 
 def _publication_state(run: Any, *, already_complete: bool) -> WandbPublicationState:

--- a/tools/measurement/measurement_tools/wandb_setup.py
+++ b/tools/measurement/measurement_tools/wandb_setup.py
@@ -83,6 +83,7 @@ def require_wandb() -> Any:
 
 _WANDB_AMBIENT_ALLOWLIST = frozenset(
     {
+        "WANDB_API_KEY",
         "WANDB_HTTP_TIMEOUT",
         "WANDB_INIT_TIMEOUT",
         "WANDB__SERVICE_WAIT",


### PR DESCRIPTION
## Summary

- Add optional benchmark identity metadata to W&B strict import config and run config.
- Add `import_wandb_run.py` flags for benchmark role/kind, suite version, branch, PR/release metadata, Anonymizer commit, config ID, and mode.
- Validate that `kind=pr` and `kind=branch` include a PR number so candidate benchmark runs can be filtered consistently in W&B.
- Document the benchmark identity fields used by the experiment runner.

## Tests

- `python3 -m py_compile tools/measurement/import_wandb_run.py tools/measurement/measurement_tools/wandb_models.py`
- `uv run pytest tests/tools/test_measurement_strict_import_publisher.py tests/tools/test_measurement_wandb_logging.py`
- `uv run ruff check tools/measurement/import_wandb_run.py tools/measurement/measurement_tools/wandb_models.py tests/tools/test_measurement_strict_import_publisher.py tests/tools/test_measurement_wandb_logging.py`
- `git diff --check`

## Notes

The companion anonymizer-experiments branch wires these fields through suite requests and W&B publication.
