### PR TITLE
fix: restore NVSkills workflow startup

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -6,11 +6,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -20,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Related Issue

No linked issue required: maintainer-owned CI workflow repair.

## Plan Document

No plan required: this ports the landed DataDesigner NVSkills workflow startup fix.

## Summary

- Trigger the NVSkills requester on pull request lifecycle events.
- Route pull request events through the shared reusable workflow.
- Grant the reusable workflow the required `statuses: read` permission.
- Preserve the existing issue-comment and trusted signature-push paths.

The shared `NVIDIA/skills` workflow now enforces pull request status access. Without this caller contract, Anonymizer's `Request NVSkills CI` runs fail during workflow startup before creating any jobs.

Representative failure: https://github.com/NVIDIA-NeMo/Anonymizer/actions/runs/31420302346

Reference fix: https://github.com/NVIDIA-NeMo/DataDesigner/pull/848

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI, release, or contributor workflow update

## Contributor Checklist

- [x] PR title follows Conventional Commits
- [x] Related issue is linked, or a maintainer-owned no-issue reason is documented above
- [x] For non-trivial changes, a plan document is linked above, or the no-plan reason is documented above
- [x] Public API impact checked; no skill update needed
- [x] No real PII added to tests, docs, notebooks, fixtures, or artifacts
- [x] No API keys, service tokens, private keys, credentials, or real endpoint secrets added

## Validation

- Commands run:
  - `.venv/bin/ruff check --fix .`
  - `.venv/bin/ruff format .`
  - `.venv/bin/pre-commit run check-yaml --files .github/workflows/request-nvskills-ci.yml`
  - `.venv/bin/pre-commit run --files .github/workflows/request-nvskills-ci.yml`
- Skipped checks or known failures:
  - Full unit and end-to-end suites were not run because this is a workflow-only wiring change.

## Documentation and Artifacts

- [x] Docs updated, or not needed
- [ ] If docs changed: `make docs-build` passes locally
- [ ] If tutorial sources changed: notebooks regenerated with `make convert-notebooks`
- [ ] If e2e, benchmark, or model-provider behavior changed: relevant validation is listed above
