### PR TITLE
test(detection): add regression coverage for numeric validator values

### DIFF
--- a/tests/engine/test_chunked_validation.py
+++ b/tests/engine/test_chunked_validation.py
@@ -459,6 +459,45 @@ class TestChunkedValidateRowPoolOfOne:
         decisions = out[COL_VALIDATION_DECISIONS]["decisions"]
         assert {d["id"]: d["decision"] for d in decisions} == {"a": "keep", "b": "drop"}
 
+    def test_numeric_value_echo_does_not_fail_response_parsing(self) -> None:
+        text = "Reference 42."
+        spans = [_entity_span("id1", "42", "account_number", 10, 12)]
+        candidates = _candidates_schema(("id1", "42", "account_number"))
+        row = _build_row(text=text, seed_entities=spans, candidates=candidates)
+        facade = FakeFacade(
+            "v0",
+            response={
+                "decisions": [
+                    {
+                        "id": "id1",
+                        "value": 42,
+                        "decision": "keep",
+                        "proposed_label": "",
+                        "reason": "numeric identifier",
+                    }
+                ]
+            },
+        )
+        params = ChunkedValidationParams(
+            pool=["v0"],
+            max_entities_per_call=10,
+            excerpt_window_chars=100,
+            prompt_template=_MINIMAL_TEMPLATE,
+        )
+
+        out = chunked_validate_row(row, params, {"v0": facade})
+
+        assert out[COL_VALIDATION_DECISIONS]["decisions"] == [
+            {
+                "id": "id1",
+                "value": "42",
+                "label": "account_number",
+                "decision": "keep",
+                "proposed_label": "",
+                "reason": "numeric identifier",
+            }
+        ]
+
     def test_single_chunk_sends_single_chunk_tagged_text_not_windowed_excerpt(self) -> None:
         """Single-chunk rows must receive the fully tagged document, not a windowed excerpt.
 

--- a/tests/engine/test_detection_custom_columns.py
+++ b/tests/engine/test_detection_custom_columns.py
@@ -120,6 +120,39 @@ def test_enrich_validation_decisions_adds_value_from_candidates() -> None:
     assert decisions[1]["value"] == "name"
 
 
+def test_enrich_validation_decisions_ignores_numeric_value_echo() -> None:
+    row = {
+        COL_VALIDATION_DECISIONS: {
+            "decisions": [
+                {
+                    "id": "id1",
+                    "value": 42,
+                    "decision": "keep",
+                    "proposed_label": "",
+                    "reason": "numeric identifier",
+                }
+            ]
+        },
+        COL_SEED_VALIDATION_CANDIDATES: {
+            "candidates": [
+                {
+                    "id": "id1",
+                    "value": "42",
+                    "label": "account_number",
+                    "context_before": "",
+                    "context_after": "",
+                }
+            ]
+        },
+    }
+
+    result = enrich_validation_decisions(row)
+
+    decisions = result[COL_VALIDATED_ENTITIES]["decisions"]
+    assert len(decisions) == 1
+    assert decisions[0]["value"] == "42"
+
+
 def test_enrich_validation_decisions_filters_unknown_ids() -> None:
     row = {
         COL_VALIDATION_DECISIONS: {"decisions": [{"id": "unknown_id", "decision": "keep", "proposed_label": ""}]},


### PR DESCRIPTION
## Related Issue
Fixes #129 and is related to #126.

## Summary
[Issue #129](https://github.com/NVIDIA-NeMo/Anonymizer/issues/129) reported that the previous validator schema required echoed entity values to be strings. When an LLM returned numeric 42 instead of "42", DataDesigner failed to parse the response. No keep/drop/reclass decision was produced, and the entire record—not only the entity—was dropped from the workflow output.
[PR #126](https://github.com/NVIDIA-NeMo/Anonymizer/pull/126) resolved this by parsing validator responses with RawValidationDecisionsSchema, which only consumes the candidate ID and decision fields. `merge_chunk_decisions()` and `enrich_validation_decisions()` then restore the authoritative string value and label from the GLiNER-derived candidate lookup.

This behavior had no regression coverage. This PR adds tests confirming that a numeric validator echo does not cause parser failure or record loss and that the trusted candidate value "42" is restored.
## Testing
Parser-path regression for numeric validator values.
Candidate-enrichment regression for restoring string values.
46 relevant tests pass; Ruff passes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI, release, or contributor workflow update

## Contributor Checklist
- [ ] PR title follows Conventional Commits, for example `fix: handle empty entity list`
- [ ] Related issue is linked, or a maintainer-owned no-issue reason is documented above
- [ ] For non-trivial changes, a plan document is linked above, or the no-plan reason is documented above
- [ ] Public API impact checked; `skills/anonymizer/SKILL.md` updated if needed
- [ ] No real PII added to tests, docs, notebooks, fixtures, or artifacts
- [ ] No API keys, service tokens, private keys, credentials, or real endpoint secrets added

## Validation
<!-- Choose from the relevant commands below and list what you actually ran. If a relevant check was skipped, explain why. -->
<!-- Common options: make check, make test, make coverage, make test-e2e, make docs-build, make convert-notebooks -->
- Commands run:
- Skipped checks or known failures:

## Documentation and Artifacts
- [ ] Docs updated, or not needed
- [ ] If docs changed: `make docs-build` passes locally
- [ ] If tutorial sources changed: notebooks regenerated with `make convert-notebooks`
- [ ] If e2e, benchmark, or model-provider behavior changed: relevant validation is listed above
