### PR TITLE
fix: prevent evaluation seed serialization failures

### DIFF
--- a/src/anonymizer/engine/evaluation/entity_coverage_judge.py
+++ b/src/anonymizer/engine/evaluation/entity_coverage_judge.py
@@ -19,6 +19,7 @@ from anonymizer.engine.constants import (
     COL_ENTITY_COVERAGE_JUDGE,
     COL_ENTITY_COVERAGE_N_CANDIDATES,
     COL_MISSED_ENTITIES,
+    COL_REPLACEMENT_APPLICATION,
     COL_TEXT,
     DEFAULT_ENTITY_LABELS,
     _jinja,
@@ -528,8 +529,13 @@ class EntityCoverageWorkflow(_BaseJudgeWorkflow):
             had_record_ids = RECORD_ID_COLUMN in dataframe.columns
             adapter = cast(NddAdapter, self._adapter)
             prepared = adapter._attach_record_ids(dataframe)
+            # Keep replacement application telemetry in the final trace, but do
+            # not serialize it into the judge's temporary Parquet seed. Its
+            # all-empty nested skipped-label mapping is not representable as a
+            # Parquet struct, and entity coverage does not consume this column.
+            workflow_input = prepared.drop(columns=[COL_REPLACEMENT_APPLICATION], errors="ignore")
             result = self.evaluate(
-                prepared,
+                workflow_input,
                 model_configs=model_configs,
                 selected_models=selected_models,
                 preview_num_records=preview_num_records,

--- a/src/anonymizer/engine/replace/replace_runner.py
+++ b/src/anonymizer/engine/replace/replace_runner.py
@@ -20,6 +20,7 @@ from anonymizer.config.replace_strategies import (
 )
 from anonymizer.engine.constants import (
     COL_ENTITIES_BY_VALUE,
+    COL_REPLACEMENT_APPLICATION,
     COL_REPLACEMENT_MAP,
 )
 from anonymizer.engine.evaluation.detection_judge import DetectionJudgeWorkflow
@@ -217,8 +218,14 @@ class ReplacementWorkflow:
         prepared = adapter._attach_record_ids(prepared)
 
         try:
+            # Replacement application telemetry can contain an all-empty nested
+            # ``skipped_span_label_counts`` mapping. PyArrow cannot represent that
+            # as a Parquet struct with no child fields, and the judges do not read
+            # this diagnostic column. Keep it on ``prepared`` for the returned
+            # trace, but omit it from DataDesigner's temporary seed dataframe.
+            workflow_input = prepared.drop(columns=[COL_REPLACEMENT_APPLICATION], errors="ignore")
             run_result = adapter.run_workflow(
-                prepared,
+                workflow_input,
                 model_configs=model_configs,
                 columns=[judge.column_config(selected_models) for judge in active],
                 workflow_name="replace-judges",

--- a/tests/engine/test_entity_coverage_judge.py
+++ b/tests/engine/test_entity_coverage_judge.py
@@ -15,6 +15,7 @@ from anonymizer.engine.constants import (
     COL_ENTITY_COVERAGE_JUDGE,
     COL_ENTITY_COVERAGE_N_CANDIDATES,
     COL_MISSED_ENTITIES,
+    COL_REPLACEMENT_APPLICATION,
     COL_TEXT,
 )
 from anonymizer.engine.evaluation.entity_coverage_judge import (
@@ -396,12 +397,46 @@ def test_run_non_critical_preserves_successful_rows_when_adapter_drops_one() -> 
     )
 
     result, failed_records = workflow.run_non_critical(
-        pd.DataFrame({"input_value": ["scored", "dropped"]}),
+        pd.DataFrame(
+            {
+                "input_value": ["scored", "dropped"],
+                COL_REPLACEMENT_APPLICATION: [
+                    {
+                        "targeted_span_count": 1,
+                        "applied_span_count": 1,
+                        "skipped_span_count": 0,
+                        "skipped_span_label_counts": {},
+                    },
+                    {
+                        "targeted_span_count": 2,
+                        "applied_span_count": 2,
+                        "skipped_span_count": 0,
+                        "skipped_span_label_counts": {},
+                    },
+                ],
+            }
+        ),
         model_configs=[],
         selected_models=_stub_evaluate_selection(),
     )
 
+    evaluation_input = workflow.evaluate.call_args.args[0]
+    assert COL_REPLACEMENT_APPLICATION not in evaluation_input.columns
     assert result["input_value"].tolist() == ["scored", "dropped"]
+    assert result[COL_REPLACEMENT_APPLICATION].tolist() == [
+        {
+            "targeted_span_count": 1,
+            "applied_span_count": 1,
+            "skipped_span_count": 0,
+            "skipped_span_label_counts": {},
+        },
+        {
+            "targeted_span_count": 2,
+            "applied_span_count": 2,
+            "skipped_span_count": 0,
+            "skipped_span_label_counts": {},
+        },
+    ]
     assert result.loc[0, COL_ENTITY_COVERAGE] == 1.0
     assert result.loc[1, COL_ENTITY_COVERAGE] is None
     assert result[COL_MISSED_ENTITIES].tolist() == [[], []]

--- a/tests/engine/test_replace_runner.py
+++ b/tests/engine/test_replace_runner.py
@@ -207,6 +207,14 @@ def test_evaluate_uses_merged_dd_workflow_for_judges(
                     ]
                 }
             ],
+            COL_REPLACEMENT_APPLICATION: [
+                {
+                    "targeted_span_count": 2,
+                    "applied_span_count": 2,
+                    "skipped_span_count": 0,
+                    "skipped_span_label_counts": {},
+                }
+            ],
         }
     )
 
@@ -218,6 +226,7 @@ def test_evaluate_uses_merged_dd_workflow_for_judges(
     }
 
     def fake_run_workflow(df: pd.DataFrame, *, columns, **_: object) -> WorkflowRunResult:
+        assert COL_REPLACEMENT_APPLICATION not in df.columns
         out = df.copy()
         for column in columns:
             out[column.name] = [judge_defaults[column.name]] * len(out)
@@ -258,6 +267,12 @@ def test_evaluate_uses_merged_dd_workflow_for_judges(
     # Entity coverage is a float (1.0 = full coverage); replace judges use bool True.
     assert COL_ENTITY_COVERAGE in result.dataframe.columns
     assert result.dataframe[COL_ENTITY_COVERAGE].iloc[0] == 1.0
+    assert result.dataframe[COL_REPLACEMENT_APPLICATION].iloc[0] == {
+        "targeted_span_count": 2,
+        "applied_span_count": 2,
+        "skipped_span_count": 0,
+        "skipped_span_label_counts": {},
+    }
     for col in (
         COL_TYPE_FIDELITY_VALID,
         COL_RELATIONAL_CONSISTENCY_VALID,


### PR DESCRIPTION
## Related Issue
Fixes #246

## Summary
Prevent evaluation workflows from serializing _replacement_application into temporary Parquet judge inputs.
Preserve replacement-application diagnostics in final traces.
Cover Replace and Rewrite Entity Coverage paths with regression tests.
## Issue
PR #246 introduced `_replacement_application`, whose `skipped_span_label_counts` is normally {} when all replacements succeed. When every evaluated row contains this empty mapping, PyArrow cannot infer a valid Parquet struct. Judge execution therefore never starts, and evaluation scores appear as unavailable.

## Solution
Exclude the unused diagnostic column from judge workflow inputs, run evaluation normally, and merge scores back into the complete trace.

Implemented the fix for both Replace and Rewrite evaluation:
- Excludes `_replacement_application` only from temporary DataDesigner judge inputs.
- Preserves it in the final trace dataframe.
- Adds regression tests for all-empty `skipped_span_label_counts`

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI, release, or contributor workflow update

## Contributor Checklist
- [ ] PR title follows Conventional Commits, for example `fix: handle empty entity list`
- [ ] Related issue is linked, or a maintainer-owned no-issue reason is documented above
- [ ] For non-trivial changes, a plan document is linked above, or the no-plan reason is documented above
- [ ] Public API impact checked; `skills/anonymizer/SKILL.md` updated if needed
- [ ] No real PII added to tests, docs, notebooks, fixtures, or artifacts
- [ ] No API keys, service tokens, private keys, credentials, or real endpoint secrets added

## Validation
<!-- Choose from the relevant commands below and list what you actually ran. If a relevant check was skipped, explain why. -->
<!-- Common options: make check, make test, make coverage, make test-e2e, make docs-build, make convert-notebooks -->
- Commands run:
- Skipped checks or known failures:

## Documentation and Artifacts
- [ ] Docs updated, or not needed
- [ ] If docs changed: `make docs-build` passes locally
- [ ] If tutorial sources changed: notebooks regenerated with `make convert-notebooks`
- [ ] If e2e, benchmark, or model-provider behavior changed: relevant validation is listed above
