### PR TITLE
fix: make rewrite replacement telemetry Parquet-safe

### DIFF
--- a/src/anonymizer/engine/rewrite/combined_rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/combined_rewrite_workflow.py
@@ -53,7 +53,10 @@ from anonymizer.engine.rewrite.evaluate import EvaluateWorkflow
 from anonymizer.engine.rewrite.parsers import normalize_payload
 from anonymizer.engine.rewrite.qa_generation import QAGenerationWorkflow
 from anonymizer.engine.rewrite.repair import RepairWorkflow
-from anonymizer.engine.rewrite.rewrite_generation import RewriteGenerationWorkflow
+from anonymizer.engine.rewrite.rewrite_generation import (
+    RewriteGenerationWorkflow,
+    restore_empty_skipped_span_label_counts,
+)
 from anonymizer.engine.rewrite.rewrite_workflow import (
     RewriteResult,
     RewriteWorkflow,
@@ -520,6 +523,7 @@ class CombinedRewriteWorkflow(RewriteWorkflow):
                 workflow_name="rewrite-combined",
                 preview_num_records=preview_num_records,
             )
+            restore_empty_skipped_span_label_counts(run_result.dataframe)
             entity_rows = _join_new_columns(entity_rows, run_result.dataframe)
             entity_rows = entity_rows.drop(columns=graph.internal_columns, errors="ignore")
             _apply_passthrough_defaults(passthrough_rows)

--- a/src/anonymizer/engine/rewrite/rewrite_generation.py
+++ b/src/anonymizer/engine/rewrite/rewrite_generation.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
+import pandas as pd
 from data_designer.config import custom_column_generator
 from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
 from data_designer.config.column_types import ColumnConfigT
@@ -211,7 +213,20 @@ def _prepare_rewrite_tagged_text(row: dict[str, Any]) -> dict[str, Any]:
     baseline, application = apply_replacements_to_spans(
         str(row.get(COL_TEXT, "")), target_entities, replacements, allow_value_fallback=False
     )
-    row[COL_REPLACEMENT_APPLICATION] = application.to_metrics()
+    metrics: dict[str, Any] = application.to_metrics()
+    # DataDesigner checkpoints side-effect columns to Parquet as part of this same
+    # adapter call, potentially across multiple row-group/batch files whose schemas
+    # are inferred independently. A nested dict column that is sometimes `{}` and
+    # sometimes non-empty gets inferred as incompatible Arrow types across those
+    # files (an all-empty batch infers as `null`, a populated one as a `struct`),
+    # and reunifying them fails. Serialize to a JSON string instead -- always the
+    # same Arrow type regardless of content -- and let
+    # ``restore_empty_skipped_span_label_counts`` decode it back to a dict once the
+    # dataframe is back in our hands (see the analogous drop-before-run_workflow
+    # pattern in replace_runner.py / entity_coverage_judge.py, which isn't available
+    # here since this column is produced *during* the DataDesigner run).
+    metrics["skipped_span_label_counts"] = json.dumps(metrics["skipped_span_label_counts"], sort_keys=True)
+    row[COL_REPLACEMENT_APPLICATION] = metrics
     admitted_pairs = {(entity.value, entity.label) for entity in target_entities.entities}
     row[COL_REWRITE_REPLACEMENT_READY] = (
         replace_pairs <= admitted_pairs and application.applied_span_count == application.targeted_span_count
@@ -229,6 +244,27 @@ def _prepare_rewrite_tagged_text(row: dict[str, Any]) -> dict[str, Any]:
         notation=str(row.get(COL_TAG_NOTATION, "bracket")),
     )
     return row
+
+
+def restore_empty_skipped_span_label_counts(dataframe: pd.DataFrame) -> None:
+    """Undo the Parquet-safe JSON-string encoding written by ``_prepare_rewrite_tagged_text``.
+
+    Mutates ``dataframe`` in place so ``skipped_span_label_counts`` is always a dict
+    (empty or not) in the trace returned to callers, matching ``ReplacementApplication``'s
+    documented contract.
+    """
+    if COL_REPLACEMENT_APPLICATION not in dataframe.columns:
+        return
+
+    def _restore(value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        counts = value.get("skipped_span_label_counts")
+        if not isinstance(counts, str):
+            return value
+        return {**value, "skipped_span_label_counts": json.loads(counts)}
+
+    dataframe[COL_REPLACEMENT_APPLICATION] = dataframe[COL_REPLACEMENT_APPLICATION].map(_restore)
 
 
 def _replace_pairs(disposition_block: object) -> set[tuple[str, str]]:

--- a/src/anonymizer/engine/rewrite/rewrite_workflow.py
+++ b/src/anonymizer/engine/rewrite/rewrite_workflow.py
@@ -40,7 +40,10 @@ from anonymizer.engine.rewrite.final_judge import FinalJudgeWorkflow
 from anonymizer.engine.rewrite.parsers import normalize_payload
 from anonymizer.engine.rewrite.qa_generation import QAGenerationWorkflow
 from anonymizer.engine.rewrite.repair import RepairWorkflow
-from anonymizer.engine.rewrite.rewrite_generation import RewriteGenerationWorkflow
+from anonymizer.engine.rewrite.rewrite_generation import (
+    RewriteGenerationWorkflow,
+    restore_empty_skipped_span_label_counts,
+)
 from anonymizer.engine.rewrite.sensitivity_disposition import SensitivityDispositionWorkflow
 from anonymizer.engine.rewrite.workflow_utils import derive_seed_columns, select_seed_cols
 from anonymizer.engine.row_partitioning import merge_and_reorder, split_rows
@@ -323,6 +326,7 @@ class RewriteWorkflow:
                 workflow_name="rewrite-pipeline",
                 preview_num_records=preview_num_records,
             )
+            restore_empty_skipped_span_label_counts(pipeline_result.dataframe)
             entity_rows = _join_new_columns(entity_rows, pipeline_result.dataframe)
             all_failed.extend(pipeline_result.failed_records)
 

--- a/tests/engine/test_combined_rewrite_workflow.py
+++ b/tests/engine/test_combined_rewrite_workflow.py
@@ -27,6 +27,7 @@ from anonymizer.engine.constants import (
     COL_NEEDS_HUMAN_REVIEW,
     COL_NEEDS_REPAIR,
     COL_REPAIR_ITERATIONS,
+    COL_REPLACEMENT_APPLICATION,
     COL_REWRITTEN_TEXT,
     COL_REWRITTEN_TEXT_INITIAL,
     COL_REWRITTEN_TEXT_NEXT,
@@ -300,6 +301,55 @@ def test_run_executes_one_data_designer_workflow(
     assert stage_records[0]["input_row_count"] == 1
     assert stage_records[0]["output_row_count"] == 1
     assert stage_records[0]["failed_record_count"] == 0
+
+
+def test_run_restores_skipped_span_label_counts_json_string_to_dict(
+    stub_model_configs: list[ModelConfig],
+    stub_rewrite_model_selection: RewriteModelSelection,
+    stub_replace_model_selection: ReplaceModelSelection,
+) -> None:
+    """CombinedRewriteWorkflow reuses RewriteGenerationWorkflow's columns, which encode
+    ``skipped_span_label_counts`` as a JSON string for Parquet schema stability. The
+    combined-graph path must restore it to a dict in the final trace, same as the
+    legacy RewriteWorkflow path, or measurement parsing silently drops real counts to {}.
+    """
+    dataframe = pd.DataFrame(
+        {
+            COL_TEXT: ["Alice works at Acme"],
+            COL_ENTITIES_BY_VALUE: [{"entities_by_value": [{"value": "Alice", "labels": ["first_name"]}]}],
+        }
+    )
+    output = dataframe.copy()
+    output[COL_REWRITTEN_TEXT] = "Maria works at a company"
+    output[COL_UTILITY_SCORE] = 0.9
+    output[COL_LEAKAGE_MASS] = 0.1
+    output[COL_WEIGHTED_LEAKAGE_RATE] = 0.05
+    output[COL_ANY_HIGH_LEAKED] = False
+    output[COL_NEEDS_REPAIR] = False
+    output[COL_REPAIR_ITERATIONS] = 1
+    output[COL_NEEDS_HUMAN_REVIEW] = False
+    output[COL_REPLACEMENT_APPLICATION] = [
+        {
+            "targeted_span_count": 2,
+            "applied_span_count": 1,
+            "skipped_span_count": 1,
+            "skipped_span_label_counts": '{"first_name": 1}',
+        }
+    ]
+    adapter = Mock()
+    adapter.run_workflow.return_value = WorkflowRunResult(dataframe=output, failed_records=[])
+
+    result = CombinedRewriteWorkflow(adapter=adapter).run(
+        dataframe,
+        model_configs=stub_model_configs,
+        selected_models=stub_rewrite_model_selection,
+        replace_model_selection=stub_replace_model_selection,
+        privacy_goal=_PRIVACY_GOAL,
+        evaluation=EvaluationCriteria(max_repair_iterations=2),
+    )
+
+    counts = result.dataframe[COL_REPLACEMENT_APPLICATION].iloc[0]["skipped_span_label_counts"]
+    assert counts == {"first_name": 1}
 
 
 def test_run_reports_combined_failure_and_drops_only_failed_entity_row(

--- a/tests/engine/test_rewrite_generation.py
+++ b/tests/engine/test_rewrite_generation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 from data_designer.config.column_configs import CustomColumnConfig, LLMStructuredColumnConfig
 from data_designer.engine.column_generators.generators.custom import CustomColumnGenerator
@@ -35,6 +36,7 @@ from anonymizer.engine.rewrite.rewrite_generation import (
     _format_rewrite_disposition_block,
     _get_rewrite_prompt,
     _prepare_rewrite_tagged_text,
+    restore_empty_skipped_span_label_counts,
 )
 from anonymizer.engine.schemas import EntityReplacementMapSchema, RewriteOutputSchema
 
@@ -265,7 +267,7 @@ def test_prepare_rewrite_tagged_text_fails_closed_for_partial_map() -> None:
     assert result[COL_REWRITE_REPLACEMENT_READY] is False
     assert result[COL_REPLACEMENT_APPLICATION]["targeted_span_count"] == 2
     assert result[COL_REPLACEMENT_APPLICATION]["applied_span_count"] == 1
-    assert result[COL_REPLACEMENT_APPLICATION]["skipped_span_label_counts"] == {"first_name": 1}
+    assert result[COL_REPLACEMENT_APPLICATION]["skipped_span_label_counts"] == '{"first_name": 1}'
 
 
 def test_prepare_rewrite_tagged_text_preserves_side_effects_through_data_designer() -> None:
@@ -340,6 +342,177 @@ def test_rewrite_replacement_fails_closed_for_absent_or_malformed_map(replacemen
 
     assert result[COL_REWRITE_REPLACEMENT_READY] is False
     assert result[COL_REWRITE_BASELINE_TEXT] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Parquet-safe skipped_span_label_counts round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_rewrite_tagged_text_serializes_zero_skipped_spans_as_json_string() -> None:
+    """When nothing is skipped, the diagnostic dict must not reach DataDesigner as a bare `{}`.
+
+    A dict column that is `{}` on some rows and non-empty on others gets inferred
+    as incompatible Arrow types (`null` vs. `struct`) across independently-checkpointed
+    Parquet batches, so `_prepare_rewrite_tagged_text` always encodes it as a JSON
+    string -- a stable Arrow type regardless of content.
+    """
+    row = {
+        COL_TEXT: "Alice",
+        COL_FINAL_ENTITIES: {
+            "entities": [{"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5}]
+        },
+        COL_REPLACEMENT_MAP: {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maria"}]},
+        COL_REWRITE_DISPOSITION_BLOCK: [
+            {"entity_value": "Alice", "entity_label": "first_name", "protection_method_suggestion": "replace"},
+        ],
+        COL_TAG_NOTATION: "bracket",
+        COL_TAGGED_TEXT: "[[Alice|first_name]]",
+    }
+    result = _prepare_rewrite_tagged_text(row)
+    assert result[COL_REPLACEMENT_APPLICATION]["skipped_span_count"] == 0
+    assert result[COL_REPLACEMENT_APPLICATION]["skipped_span_label_counts"] == "{}"
+
+
+def test_prepare_rewrite_tagged_text_no_targeted_spans_serializes_as_json_string() -> None:
+    """Rows with zero targeted spans hit the early-return path in apply_replacements_to_spans."""
+    row = {
+        COL_TEXT: "Nothing sensitive here",
+        COL_FINAL_ENTITIES: {"entities": []},
+        COL_REPLACEMENT_MAP: {"replacements": []},
+        COL_REWRITE_DISPOSITION_BLOCK: [],
+        COL_TAG_NOTATION: "bracket",
+        COL_TAGGED_TEXT: "Nothing sensitive here",
+    }
+    result = _prepare_rewrite_tagged_text(row)
+    assert result[COL_REPLACEMENT_APPLICATION]["targeted_span_count"] == 0
+    assert result[COL_REPLACEMENT_APPLICATION]["skipped_span_label_counts"] == "{}"
+
+
+def test_prepare_rewrite_tagged_text_serializes_non_empty_skipped_label_counts_as_json_string() -> None:
+    row = {
+        COL_TEXT: "Alice met Bob",
+        COL_FINAL_ENTITIES: {
+            "entities": [
+                {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+                {"value": "Bob", "label": "first_name", "start_position": 10, "end_position": 13},
+            ]
+        },
+        COL_REPLACEMENT_MAP: {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maria"}]},
+        COL_REWRITE_DISPOSITION_BLOCK: [
+            {"entity_value": "Alice", "entity_label": "first_name", "protection_method_suggestion": "replace"},
+            {"entity_value": "Bob", "entity_label": "first_name", "protection_method_suggestion": "replace"},
+        ],
+        COL_TAG_NOTATION: "bracket",
+        COL_TAGGED_TEXT: "[[Alice|first_name]] met [[Bob|first_name]]",
+    }
+    result = _prepare_rewrite_tagged_text(row)
+    assert result[COL_REPLACEMENT_APPLICATION]["skipped_span_label_counts"] == '{"first_name": 1}'
+
+
+def test_restore_empty_skipped_span_label_counts_mixed_empty_and_non_empty() -> None:
+    df = pd.DataFrame(
+        {
+            COL_REPLACEMENT_APPLICATION: [
+                {
+                    "targeted_span_count": 1,
+                    "applied_span_count": 1,
+                    "skipped_span_count": 0,
+                    "skipped_span_label_counts": "{}",
+                },
+                {
+                    "targeted_span_count": 2,
+                    "applied_span_count": 1,
+                    "skipped_span_count": 1,
+                    "skipped_span_label_counts": '{"first_name": 1}',
+                },
+            ]
+        }
+    )
+    restore_empty_skipped_span_label_counts(df)
+    assert df[COL_REPLACEMENT_APPLICATION].iloc[0]["skipped_span_label_counts"] == {}
+    assert df[COL_REPLACEMENT_APPLICATION].iloc[1]["skipped_span_label_counts"] == {"first_name": 1}
+
+
+def test_restore_empty_skipped_span_label_counts_restores_final_trace_contract() -> None:
+    """The public `ReplacementApplication.to_metrics()` contract always returns a dict."""
+    df = pd.DataFrame(
+        {
+            COL_REPLACEMENT_APPLICATION: [
+                {
+                    "targeted_span_count": 0,
+                    "applied_span_count": 0,
+                    "skipped_span_count": 0,
+                    "skipped_span_label_counts": "{}",
+                },
+            ]
+        }
+    )
+    restore_empty_skipped_span_label_counts(df)
+    counts = df[COL_REPLACEMENT_APPLICATION].iloc[0]["skipped_span_label_counts"]
+    assert counts == {}
+    assert isinstance(counts, dict)
+
+
+def test_restore_empty_skipped_span_label_counts_noop_when_column_absent() -> None:
+    df = pd.DataFrame({"other_column": [1, 2, 3]})
+    restore_empty_skipped_span_label_counts(df)
+    assert list(df.columns) == ["other_column"]
+
+
+def test_skipped_span_label_counts_survives_multi_file_parquet_dataset(tmp_path) -> None:
+    """Regression for schema drift across independently-checkpointed Parquet batches.
+
+    Before JSON-string encoding, writing an all-empty batch and a non-empty batch to
+    separate Parquet files (as DataDesigner's checkpointing does) produced incompatible
+    inferred types (`null` vs. `struct<...>`), and reading them back as one dataset
+    raised ``ArrowNotImplementedError: Unsupported cast from struct<...> to null``.
+    """
+    pyarrow = pytest.importorskip("pyarrow")
+    pyarrow_dataset = pytest.importorskip("pyarrow.dataset")
+    pyarrow_parquet = pytest.importorskip("pyarrow.parquet")
+
+    empty_row = _prepare_rewrite_tagged_text(
+        {
+            COL_TEXT: "Nothing sensitive here",
+            COL_FINAL_ENTITIES: {"entities": []},
+            COL_REPLACEMENT_MAP: {"replacements": []},
+            COL_REWRITE_DISPOSITION_BLOCK: [],
+            COL_TAG_NOTATION: "bracket",
+            COL_TAGGED_TEXT: "Nothing sensitive here",
+        }
+    )
+    non_empty_row = _prepare_rewrite_tagged_text(
+        {
+            COL_TEXT: "Alice met Bob",
+            COL_FINAL_ENTITIES: {
+                "entities": [
+                    {"value": "Alice", "label": "first_name", "start_position": 0, "end_position": 5},
+                    {"value": "Bob", "label": "first_name", "start_position": 10, "end_position": 13},
+                ]
+            },
+            COL_REPLACEMENT_MAP: {"replacements": [{"original": "Alice", "label": "first_name", "synthetic": "Maria"}]},
+            COL_REWRITE_DISPOSITION_BLOCK: [
+                {"entity_value": "Alice", "entity_label": "first_name", "protection_method_suggestion": "replace"},
+                {"entity_value": "Bob", "entity_label": "first_name", "protection_method_suggestion": "replace"},
+            ],
+            COL_TAG_NOTATION: "bracket",
+            COL_TAGGED_TEXT: "[[Alice|first_name]] met [[Bob|first_name]]",
+        }
+    )
+
+    empty_batch_df = pd.DataFrame({COL_REPLACEMENT_APPLICATION: [empty_row[COL_REPLACEMENT_APPLICATION]]})
+    non_empty_batch_df = pd.DataFrame({COL_REPLACEMENT_APPLICATION: [non_empty_row[COL_REPLACEMENT_APPLICATION]]})
+
+    pyarrow_parquet.write_table(pyarrow.Table.from_pandas(empty_batch_df), tmp_path / "batch-0.parquet")
+    pyarrow_parquet.write_table(pyarrow.Table.from_pandas(non_empty_batch_df), tmp_path / "batch-1.parquet")
+
+    dataset = pyarrow_dataset.dataset(tmp_path, format="parquet")
+    combined = dataset.to_table().to_pandas()
+
+    restore_empty_skipped_span_label_counts(combined)
+    assert combined[COL_REPLACEMENT_APPLICATION].iloc[0]["skipped_span_label_counts"] == {}
+    assert combined[COL_REPLACEMENT_APPLICATION].iloc[1]["skipped_span_label_counts"] == {"first_name": 1}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue
Fixes #246 and follow-up on #255

## Summary
Fix Rewrite mode `anonymizer.run()` failing while DataDesigner checkpoints replacement telemetry to Parquet.

## Problem
`_replacement_application.skipped_span_label_counts` is a dynamic dictionary. Empty and populated dictionaries can produce incompatible Parquet schemas across checkpoint files, causing `ArrowNotImplementedError` and preventing the rewrite dataset from loading.

This is a follow-up to [PR #255](https://github.com/NVIDIA-NeMo/Anonymizer/pull/255), which addressed the same telemetry issue in evaluation inputs but not the main Rewrite workflow.

## Solution
Encode `skipped_span_label_counts` as a stable JSON string during DataDesigner execution.
Decode it back to a dictionary after the workflow completes.
Preserve the existing final trace contract and non-empty diagnostic counts.
Add regression coverage for empty, populated, mixed, and multi-file Parquet cases.

## Validation
129 focused tests passed.
Ruff and type checks passed.


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI, release, or contributor workflow update

## Contributor Checklist
- [ ] PR title follows Conventional Commits, for example `fix: handle empty entity list`
- [ ] Related issue is linked, or a maintainer-owned no-issue reason is documented above
- [ ] For non-trivial changes, a plan document is linked above, or the no-plan reason is documented above
- [ ] Public API impact checked; `skills/anonymizer/SKILL.md` updated if needed
- [ ] No real PII added to tests, docs, notebooks, fixtures, or artifacts
- [ ] No API keys, service tokens, private keys, credentials, or real endpoint secrets added

## Validation
<!-- Choose from the relevant commands below and list what you actually ran. If a relevant check was skipped, explain why. -->
<!-- Common options: make check, make test, make coverage, make test-e2e, make docs-build, make convert-notebooks -->
- Commands run:
- Skipped checks or known failures:

## Documentation and Artifacts
- [ ] Docs updated, or not needed
- [ ] If docs changed: `make docs-build` passes locally
- [ ] If tutorial sources changed: notebooks regenerated with `make convert-notebooks`
- [ ] If e2e, benchmark, or model-provider behavior changed: relevant validation is listed above
