### PR TITLE
docs: add third-party software license notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@
 ```bash
 pip install nemo-anonymizer
 ```
-Or install from source: 
+
+> [!NOTE]
+> This project will download and install additional third-party open source
+> software projects. Review the license terms of these open source projects
+> before use.
+
+Or install from source:
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Anonymizer.git
 cd Anonymizer
@@ -51,7 +57,7 @@ DATA_URL="https://raw.githubusercontent.com/NVIDIA-NeMo/Anonymizer/refs/heads/ma
 uv run anonymizer preview --source $DATA_URL --text-column biography --replace redact --num_records 3
 
 # Full run with output file
-uv run anonymizer run --source $DATA_URL --text-column biography --replace redact --output result.csv 
+uv run anonymizer run --source $DATA_URL --text-column biography --replace redact --output result.csv
 
 # Validate config without running
 uv run anonymizer validate --source $DATA_URL --text-column biography --replace hash


### PR DESCRIPTION
## Summary

- add a third-party open source software license notice after the README installation command
- match the wording and placement used by NeMo Data Designer
- remove two trailing spaces automatically flagged by the repository pre-commit hook

## Validation

- `make docs-build`
- repository pre-commit and commit-message hooks
- `git diff --check origin/main...HEAD`

## Contributor checks

- No issue required: this is a small maintainer-owned README parity and legal-notice clarification.
- No plan required: the change is documentation-only and does not affect code, APIs, pipeline behavior, or repository policy.
- Public API impact: none; `skills/anonymizer/SKILL.md` does not require an update.
- PII fixture impact: none.
- Secrets impact: none.
